### PR TITLE
fix: fixes issue #68 skimage module not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ textual = "^3.0.0"
 pytest = "^8.3.5"
 pydantic = "^2.11.2"
 pyserial = "^3.5"
+scikit-image = "^0.25.2"
 
 [tool.poetry.group.dev.dependencies]
 tox = "~4.24.1"


### PR DESCRIPTION
Fixes #68 Issue skimage module not found By Updating the dependencies in pyproject.toml