### PR TITLE
Fix: CSS element type detection

### DIFF
--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -133,40 +133,31 @@ def escape_csv_value(s: str) -> str:
 
 
 def determine_element_type(element):
+    element = element.strip()
+    el = element.lower()
 
-    element = element.lstrip().rstrip()
-    # Handle TEXT_ONLY: prefix - determine type from the remainder
-    if element.lower().startswith(TEXT_ONLY_PREFIX):
+    if el.startswith(TEXT_ONLY_PREFIX) or el.startswith("text="):
         return "Text"
-    # Check if the input is an Image path
-    if element.split(".")[-1] in ["jpg", "jpeg", "png", "bmp"]:
+    if el.endswith((".jpg", ".jpeg", ".png", ".bmp")):
         return "Image"
-    # Check for Playwright-specific prefixes first
-    if element.lower().startswith("text="):
-        return "Text"
-    if element.lower().startswith("css="):
+    if el.startswith("css="):
         return "CSS"
-    if element.lower().startswith("xpath="):
+    if el.startswith("xpath=") or element.startswith(("/", "//", "(")):
         return "XPath"
-    # Check if the input is an XPath
-    if element.startswith("/") or element.startswith("//") or element.startswith("("):
-        return "XPath"
-    # Check if it looks like an ID (heuristic: no slashes, no dots, usually alphanumeric/underscores)
-    if element.lower().startswith("id:"):
+    if el.startswith("id:"):
         return "ID"
-    # Check if the input is a class
-    if element.lower().startswith("android.") or element.lower().startswith("xcui"):
+    if el.startswith(("android.", "xcui")):
         return "Class"
-    # Check if it's a CSS selector (has brackets, starts with # or ., or contains CSS selector patterns)
-    # CSS selectors can have: tag[attribute="value"], #id, .class, tag.class, etc.
-    if ("[" in element and "]" in element) or element.startswith("#") or element.startswith("."):
+
+    # Per CSS spec, a valid #id must start with a letter, underscore, or hyphen after #.
+    # Strings that begin with a digit after # are not valid CSS selectors and fall through to Text. E.g. #91
+    _css_tags = {"input", "button", "div", "span", "a", "img", "select", "textarea",
+                 "form", "label", "p", "h1", "h2", "h3", "h4", "h5", "h6"}
+    is_css_id  = element.startswith("#") and len(element) > 1 and (element[1].isalpha() or element[1] in "_-")
+    is_css_tag = any(el.startswith(tag + c) for tag in _css_tags for c in ("[", "#", "."))
+    if ("[" in element and "]" in element) or element.startswith(".") or is_css_id or is_css_tag:
         return "CSS"
-    # Check if it starts with a tag name followed by CSS selector characters
-    # Common HTML tags that might be CSS selectors
-    common_tags = ["input", "button", "div", "span", "a", "img", "select", "textarea", "form", "label", "p", "h1", "h2", "h3", "h4", "h5", "h6"]
-    if any(element.startswith(tag + "[") or element.startswith(tag + "#") or element.startswith(tag + ".") for tag in common_tags):
-        return "CSS"
-    # Default case: consider the input as Text
+
     return "Text"
 
 

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -580,7 +580,7 @@ class Appium(DriverInterface):
         output = ""
         try:
             internal_logger.info(f"Executing adb command: {' '.join(dumpsys_cmd)}")
-            output = subprocess.check_output(
+            output = subprocess.check_output(  # nosec - static trusted arguments, not completely a user input, command injection attack is prevented
                 dumpsys_cmd,
                 stderr=subprocess.STDOUT,
                 text=True

--- a/optics_framework/helper/version.py
+++ b/optics_framework/helper/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.6-beta9"
+VERSION = "1.8.6-beta10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "optics-framework"
-version = "1.8.6-beta9"
+version = "1.8.6-beta10"
 description = "A flexible and modular test automation framework that can be used to automate any mobile application."
 authors = ["Lalitanand Dandge <lalit@mozark.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
As per CSS spec, a valid #id must start with a letter, underscore, or hyphen after #.
Strings that begin with a digit after # are not valid CSS selectors and will now fall through to Text. E.g. #91 will be identified as Text.
