### PR TITLE
fix: scale element bboxes to screenshot pixel space before annotation

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -74,6 +74,9 @@ def _save_annotated_for_result(
         return
     if screenshot_np is None:
         return
+    # Element bbox is in the driver's window coordinate space; scale it to the
+    # screenshot's pixel space before drawing (no-op when the two already match).
+    bbox = utils.scale_bboxes_for_screenshot([bbox], element_source, screenshot_np)[0]
     framed = utils.annotate(screenshot_np.copy(), [bbox])
     utils.save_screenshot(
         framed,

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -122,6 +122,10 @@ class LocatorStrategy(ABC):
                 ]
             if frame is not None:
                 if bboxes:
+                    # Element bboxes are in the driver's window coordinate space;
+                    # scale them to the screenshot's pixel space before drawing
+                    # (no-op when the two resolutions already match).
+                    bboxes = utils.scale_bboxes_for_screenshot(bboxes, self.element_source, frame)
                     annotated_frame = utils.annotate(frame.copy(), bboxes)
                     return True, timestamp, annotated_frame
                 return True, timestamp, frame.copy()

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -695,6 +695,107 @@ def bbox_from_webelement_like(obj: Any) -> Optional[Tuple[Tuple[int, int], Tuple
     return None
 
 
+def _window_size_from_source(element_source: Any) -> Optional[Tuple[int, int]]:
+    """
+    Best-effort fetch of the driver's reported window size from an element source.
+
+    The window size defines the coordinate space that element bounding boxes are
+    expressed in. On some platforms this differs from the screenshot's resolution
+    (see scale_bboxes_for_screenshot), so callers need it to convert between the two.
+
+    Duck-typed and defensive: returns None when the source has no driver, the driver
+    does not expose ``get_window_size``, or the call fails, so callers can fall back
+    to unscaled annotation rather than raising. The element source exposes its driver
+    via ``.driver``, which may itself wrap the underlying WebDriver one level in.
+
+    :param element_source: An element source instance (may be any object).
+    :return: (width, height), or None if undeterminable.
+    """
+    try:
+        driver = getattr(element_source, "driver", None)
+        for candidate in (driver, getattr(driver, "driver", None)):
+            get_window_size = getattr(candidate, "get_window_size", None)
+            if callable(get_window_size):
+                size = get_window_size()
+                width = int(size["width"])
+                height = int(size["height"])
+                if width > 0 and height > 0:
+                    return width, height
+                return None
+    except Exception:
+        return None
+    return None
+
+
+def _scale_bbox(
+    bbox: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+    window_size: Tuple[int, int],
+    screenshot: np.ndarray,
+) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
+    """
+    Scale a single bbox from window-coordinate space into the screenshot's
+    pixel space.
+
+    A bbox is reported in the driver's window coordinate space, while the
+    screenshot may be captured at a different resolution. Multiply each corner by
+    the per-axis scale (screenshot size / window size) to map it onto the image.
+    When the window size equals the screenshot size the scale is 1.0 and this is a
+    no-op (``int(x * 1.0) == x``). Returns the bbox unchanged on any failure.
+    """
+    if bbox is None:
+        return bbox
+    try:
+        (x1, y1), (x2, y2) = bbox
+        win_w, win_h = window_size
+        sh_h, sh_w = screenshot.shape[:2]
+        if win_w <= 0 or win_h <= 0:
+            return bbox
+        scale_x = sh_w / win_w
+        scale_y = sh_h / win_h
+        return (
+            (int(x1 * scale_x), int(y1 * scale_y)),
+            (int(x2 * scale_x), int(y2 * scale_y)),
+        )
+    except (TypeError, ValueError, AttributeError):
+        return bbox
+
+
+def scale_bboxes_for_screenshot(
+    bboxes: List[Optional[Tuple[Tuple[int, int], Tuple[int, int]]]],
+    element_source: Any,
+    screenshot: Optional[np.ndarray],
+) -> List[Optional[Tuple[Tuple[int, int], Tuple[int, int]]]]:
+    """
+    Scale element bounding boxes into the screenshot's pixel space before
+    annotation, using the element source's driver window size.
+
+    Bounding boxes obtained from a driver's element handles are expressed in the
+    driver's window coordinate space. When that space differs in resolution from
+    the captured screenshot, drawing the raw coordinates places the boxes at the
+    wrong position and size; scaling each box by (screenshot size / window size)
+    maps them correctly. When the two sizes match, the scale is 1.0 and the boxes
+    are left unchanged.
+
+    Best-effort and non-failing: if the window size can't be determined (e.g. the
+    source has no driver, or the driver errors) or no screenshot is available, the
+    bboxes are returned unchanged so annotation falls back to drawing them as-is.
+    Window size is fetched once for the whole list. Do not use this for OCR /
+    image-detection bboxes — those are already computed in the screenshot's pixel
+    space and need no conversion.
+
+    :param bboxes: List of ((x1,y1),(x2,y2)) bboxes (or None entries) in window space.
+    :param element_source: The element source whose driver defines the window space.
+    :param screenshot: The captured frame the bboxes will be drawn onto.
+    :return: bboxes scaled to the screenshot's pixel space, or unchanged on any failure.
+    """
+    if screenshot is None or not bboxes:
+        return bboxes
+    window_size = _window_size_from_source(element_source)
+    if window_size is None:
+        return bboxes
+    return [_scale_bbox(b, window_size, screenshot) for b in bboxes]
+
+
 def bboxes_from_webelements(
     locate_fn: Callable[[str], Any],
     elements: List[str],

--- a/optics_framework/helper/version.py
+++ b/optics_framework/helper/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.8.6"
+VERSION = "1.8.7-beta.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "optics-framework"
-version = "1.8.6"
+version = "1.8.7-beta.1"
 description = "A flexible and modular test automation framework that can be used to automate any mobile application."
 authors = ["Lalitanand Dandge <lalit@mozark.ai>"]
 license = "Apache-2.0"

--- a/tests/units/common/test_bbox_scaling.py
+++ b/tests/units/common/test_bbox_scaling.py
@@ -1,0 +1,87 @@
+"""Unit tests for bbox -> screenshot pixel-space scaling.
+
+Regression coverage for annotation boxes drawn in the wrong position/size when
+the driver's window coordinate space differs in resolution from the captured
+screenshot. See utils.scale_bboxes_for_screenshot / _window_size_from_source /
+_scale_bbox.
+"""
+import numpy as np
+
+from optics_framework.common import utils
+
+
+class _FakeWebDriver:
+    def __init__(self, width, height, raises=False):
+        self._size = {"width": width, "height": height}
+        self._raises = raises
+
+    def get_window_size(self):
+        if self._raises:
+            raise RuntimeError("driver boom")
+        return self._size
+
+
+class _WrappedSource:
+    """Element source whose .driver wraps the real WebDriver one level in (.driver.driver)."""
+
+    def __init__(self, wd):
+        self.driver = type("Wrapper", (), {"driver": wd})()
+
+
+class _DirectSource:
+    def __init__(self, wd):
+        self.driver = wd
+
+
+def _pixel_screenshot(width=1080, height=2340):
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+class TestScaleBboxesForScreenshot:
+    BBOX = ((20, 96), (355, 140))
+
+    def test_window_smaller_than_screenshot_scales_up(self):
+        # Window 375x812, screenshot 1080x2340 -> ~2.88x per axis.
+        src = _DirectSource(_FakeWebDriver(375, 812))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [((57, 276), (1022, 403))]
+
+    def test_unwraps_nested_driver(self):
+        src = _WrappedSource(_FakeWebDriver(375, 812))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [((57, 276), (1022, 403))]
+
+    def test_window_equals_screenshot_is_noop(self):
+        # window size == screenshot size -> scale 1.0, bboxes untouched.
+        src = _DirectSource(_FakeWebDriver(1080, 2340))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [self.BBOX]
+
+    def test_source_without_window_size_falls_back_unchanged(self):
+        src = type("NoWindowSource", (), {"driver": object()})()
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [self.BBOX]
+
+    def test_missing_screenshot_falls_back_unchanged(self):
+        src = _DirectSource(_FakeWebDriver(375, 812))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, None)
+        assert result == [self.BBOX]
+
+    def test_driver_error_falls_back_unchanged(self):
+        src = _DirectSource(_FakeWebDriver(375, 812, raises=True))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [self.BBOX]
+
+    def test_zero_window_size_falls_back_unchanged(self):
+        src = _DirectSource(_FakeWebDriver(0, 0))
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [self.BBOX]
+
+    def test_none_bbox_entries_preserved(self):
+        src = _DirectSource(_FakeWebDriver(375, 812))
+        result = utils.scale_bboxes_for_screenshot([None, self.BBOX], src, _pixel_screenshot())
+        assert result == [None, ((57, 276), (1022, 403))]
+
+    def test_empty_list_returns_empty(self):
+        src = _DirectSource(_FakeWebDriver(375, 812))
+        assert utils.scale_bboxes_for_screenshot([], src, _pixel_screenshot()) == []


### PR DESCRIPTION
Element bounding boxes are reported in the driver's window coordinate space, but annotation screenshots are captured in physical pixels. When the two resolutions differ (e.g. Retina/high-DPI devices), drawing the raw box coordinates places highlights at the wrong position and size. Scale each box by (screenshot size / window size) before annotating; no-op when the sizes match, and falls back to unscaled drawing when the window size can't be determined.

Applied at both annotation sites (assertion evidence and self-healing press). OCR / image-detection boxes are unaffected (already in pixel space).