### PR TITLE
feat(live): fast base64 screenshot path for the NL LLM agent

### DIFF
--- a/optics_framework/common/elementsource_interface.py
+++ b/optics_framework/common/elementsource_interface.py
@@ -24,6 +24,21 @@ class ElementSourceInterface(ABC):
         """
         pass
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the current screen as already-encoded image bytes (e.g. PNG/JPEG).
+
+        Optional fast-path companion to :meth:`capture`. A backend that can return the
+        device's native encoded screenshot should override this; callers then skip the
+        decode-to-numpy and re-encode round-trip. Otherwise they fall back to encoding
+        :meth:`capture`'s frame.
+
+        :raises NotImplementedError: if this element source has no native encoded path.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support capture_screenshot_bytes"
+        )
+
     @abstractmethod
     def locate(self, element: Any, index: int | None = None) -> tuple:
         """

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -735,6 +735,28 @@ class StrategyManager:
         internal_logger.debug("No screenshot captured.")
         raise OpticsError(Code.E0303, message="No screenshot captured using available strategies.")
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """Return the current screen as encoded image bytes (PNG/JPEG).
+
+        Prefers an element source that overrides
+        :meth:`ElementSourceInterface.capture_screenshot_bytes` (native encoded path,
+        skipping the numpy decode/re-encode round-trip); otherwise encodes the numpy
+        frame from :meth:`capture_screenshot`.
+        """
+        for strategy in self.screenshot_strategies:
+            source = strategy.element_source
+            try:
+                data = source.capture_screenshot_bytes()
+            except NotImplementedError:
+                continue
+            except Exception as e:
+                internal_logger.debug(
+                    "Native screenshot bytes via %s failed: %s", source.__class__.__name__, e)
+                continue
+            if data:
+                return data
+        return utils.encode_numpy_to_png_bytes(self.capture_screenshot())
+
     def capture_screenshot_stream(self, timeout: int = 30):
         """Capture a screenshot stream using the available strategies."""
         execution_logger.debug("Starting screenshot stream with available strategies.")

--- a/optics_framework/engines/elementsources/appium_screenshot.py
+++ b/optics_framework/engines/elementsources/appium_screenshot.py
@@ -47,6 +47,27 @@ class AppiumScreenshot(ElementSourceInterface):
         """
         return self.capture_screenshot_as_numpy()
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the device screen as native PNG bytes via Appium's base64 endpoint.
+
+        Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
+        :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
+        bytes. The retry absorbs the truncated-response ("Incorrect padding") base64
+        failures occasionally seen against busy remote hubs.
+        """
+        driver = self._require_driver()
+        last_exc: Optional[Exception] = None
+        for attempt in range(2):
+            try:
+                return base64.b64decode(driver.get_screenshot_as_base64())
+            except Exception as e:
+                last_exc = e
+                internal_logger.warning(
+                    "Appium native screenshot bytes attempt %d/2 failed: %s", attempt + 1, e
+                )
+        raise RuntimeError(f"Error capturing Appium screenshot bytes: {last_exc}")
+
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None):
         internal_logger.exception("AppiumScreenshot does not support getting interactive elements.")
         raise NotImplementedError(

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -975,12 +975,16 @@ class LiveController:
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:
-        """Capture the current screen as raw PNG bytes (for the LLM); no file side-effect."""
+        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect.
+
+        Delegates to ``StrategyManager.capture_screenshot_bytes()`` so the native
+        fast path (when a backend supports it) and the numpy fallback are chosen
+        driver-agnostically.
+        """
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
-        image = self._action_keyword.strategy_manager.capture_screenshot()
         try:
-            return utils.encode_numpy_to_png_bytes(image)
+            return self._action_keyword.strategy_manager.capture_screenshot_bytes()
         except ValueError as exc:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Failed to encode screenshot") from exc
 

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -182,3 +182,83 @@ class TestStrategyManagerAssertPresenceTextOnly:
             assert "Submit" in seen_elements
             assert "Login" in seen_elements
             assert "TEXT_ONLY:Login" not in seen_elements
+
+
+# --- capture_screenshot_bytes (native fast path + numpy fallback) ---
+
+
+def _sm_with_source(source):
+    """StrategyManager wrapping a single element source (screenshot path only)."""
+    return StrategyManager(
+        element_source=InstanceFallback([source]),
+        text_detection=None,
+        image_detection=None,
+    )
+
+
+class TestCaptureScreenshotBytes:
+    """StrategyManager.capture_screenshot_bytes() prefers the native path, else encodes numpy."""
+
+    def test_prefers_native_bytes(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.return_value = b"\x89PNG-native"
+        sm = _sm_with_source(source)
+        assert sm.capture_screenshot_bytes() == b"\x89PNG-native"
+        source.capture.assert_not_called()  # native path => no numpy capture/encode
+
+    def test_falls_back_to_numpy_encode(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.side_effect = NotImplementedError
+        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)  # white, not black
+        sm = _sm_with_source(source)
+        data = sm.capture_screenshot_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # real PNG magic from cv2.imencode
+
+    def test_skips_failing_native_then_falls_back(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.side_effect = RuntimeError("hub timeout")
+        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)
+        sm = _sm_with_source(source)
+        assert sm.capture_screenshot_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class _FakeWD:
+    """Stub webdriver (no ``.driver`` attr, so _require_driver returns it as-is)."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def get_screenshot_as_base64(self):
+        self.calls += 1
+        item = self._results.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class TestAppiumScreenshotBytes:
+    """AppiumScreenshot.capture_screenshot_bytes() decodes base64 with a single retry."""
+
+    def test_returns_decoded_base64(self):
+        import base64
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNG\r\n\x1a\nDATA"
+        drv = _FakeWD([base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 1
+
+    def test_retries_then_succeeds(self):
+        import base64
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNGok"
+        drv = _FakeWD(["not-valid-base64!!!", base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 2
+
+    def test_raises_after_exhausted_retries(self):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        drv = _FakeWD([ValueError("boom"), ValueError("boom")])
+        with pytest.raises(RuntimeError):
+            AppiumScreenshot(driver=drv).capture_screenshot_bytes()
+        assert drv.calls == 2


### PR DESCRIPTION
Add screenshot_png_bytes_fast(): grab the device frame via get_screenshot_as_base64() and return the PNG bytes verbatim, skipping the numpy decode -> black-screen check -> PNG re-encode round-trip that screenshot_png_bytes() performs. Wired as the natural-language agent's screenshot provider; falls back to the numpy pipeline for non-Appium sessions or on error, with a single retry to absorb truncated-response failures.