### PR TITLE
feat(live): refactor AI self-heal to use keyword-based ReAct loop and improve locator logging

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -1,14 +1,18 @@
 from functools import wraps
 import collections
+import inspect
+import shlex
 import time
 import json
-from typing import Callable, Optional, Any, Tuple
+from typing import Callable, Optional, Any, Tuple, List, Dict
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import StrategyManager
 from optics_framework.common.base_factory import InstanceFallback
 from optics_framework.common import utils
-from optics_framework.common.ai_self_heal import AISelfHealHandler, HealContext
+from optics_framework.common.ai_self_heal import (
+    AISelfHealHandler, HealContext, HealKeywordSpec, KeywordExecResult,
+)
 from optics_framework.common.error import OpticsError, Code
 from .verifier import Verifier
 
@@ -101,7 +105,19 @@ def _try_results_until_success(
 ):
     last_exception = None
     result_count = 0
-    for result in results:
+    locate_error: Optional[OpticsError] = None
+
+    try:
+        results_list = list(results)
+    except OpticsError as e:
+        # The locate generator raises when no strategy yields a result; treat that
+        # as "no results" so self-heal below gets a chance, but keep the original
+        # error as the cause instead of losing it.
+        internal_logger.debug(f"Locate generator raised for '{element}' in '{func_name}': {e}")
+        results_list = []
+        locate_error = e
+
+    for result in results_list:
         result_count += 1
         _save_annotated_for_result(result, screenshot_np, execution_dir, func_name)
         try:
@@ -118,7 +134,11 @@ def _try_results_until_success(
     if result_count == 0:
         if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
             return None
-        raise OpticsError(Code.E0201, message=f"No valid strategies found for '{element}' in '{func_name}'")
+        raise OpticsError(
+            Code.E0201,
+            message=f"No valid strategies found for '{element}' in '{func_name}'",
+            cause=locate_error,
+        ) from locate_error
     if last_exception:
         if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
             return None
@@ -223,6 +243,17 @@ class ActionKeyword:
         self._ai_healer: Optional[AISelfHealHandler] = None
         # Breadcrumbs of recently-succeeded keywords, fed to the LLM as context on heal.
         self._recent_steps: "collections.deque[Tuple[str, list]]" = collections.deque(maxlen=10)
+        # The focused subset of keywords the self-healer is allowed to call, bound here
+        # (rather than looked up by name via getattr) so a rename shows up as a static
+        # attribute error instead of a silent "Unknown keyword" at runtime.
+        self._heal_dispatch: Dict[str, Callable] = {
+            "press_element": self.press_element,
+            "enter_text": self.enter_text,
+            "scroll": self.scroll,
+            "swipe_by_percentage": self.swipe_by_percentage,
+            "press_keycode": self.press_keycode,
+            "press_by_percentage": self.press_by_percentage,
+        }
 
     def _record_successful_step(self, func_name: str, element: Any, args: tuple) -> None:
         self._recent_steps.append((func_name, [str(element), *map(str, args)]))
@@ -254,7 +285,11 @@ class ActionKeyword:
             ),
         )
         if self._ai_healer is None:
-            self._ai_healer = AISelfHealHandler(self._llm, self.driver)
+            self._ai_healer = AISelfHealHandler(
+                self._llm,
+                keyword_executor=self._heal_execute,
+                keyword_catalog=self._heal_catalog,
+            )
         internal_logger.info("AI self-heal: attempting recovery for '%s' on '%s'", func_name, element)
         result = self._ai_healer.heal(ctx, providers.screenshot, providers.pagesource)
         self._log_heal_outcome(result, func_name, element, args)
@@ -273,9 +308,78 @@ class ActionKeyword:
                 "AI self-heal: could not recover '%s': %s", func_name, result.message
             )
             return
-        action = result.action.action if result.action else "?"
-        internal_logger.info("AI self-heal: recovered '%s' via '%s'", func_name, action)
+        action = result.action
+        kw = action.keyword if action else "?"
+        internal_logger.info("AI self-heal: recovered '%s' via keyword '%s'", func_name, kw)
         self._record_successful_step(func_name, element, args)
+
+    # -- Self-heal keyword executor and catalog --------------------------------
+
+    def _heal_execute(self, line: str) -> KeywordExecResult:
+        """Keyword executor for self-heal: parse and run one keyword, returning a KeywordExecResult.
+
+        Calls the ActionKeyword methods directly but avoids re-triggering self-heal by
+        passing ``located=`` for self-healing-decorated methods or calling non-decorated ones.
+        """
+        try:
+            tokens = shlex.split(line, posix=True)
+        except ValueError as exc:
+            return KeywordExecResult(ok=False, message=f"Parse error: {exc}")
+        if not tokens:
+            return KeywordExecResult(ok=False, message="Empty keyword line")
+
+        keyword_name = tokens[0]
+        params = tokens[1:]
+
+        method = self._heal_dispatch.get(keyword_name)
+        if method is None:
+            return KeywordExecResult(ok=False, message=f"Unknown keyword: {keyword_name}")
+
+        try:
+            # Non-self-healing methods: call directly with params.
+            # Self-healing methods (press_element, enter_text): they will go through
+            # `with_self_healing` decorator, but self-heal is already running, so
+            # we need to temporarily disable it to avoid recursion.
+            original_enabled = self.ai_self_heal_enabled
+            self.ai_self_heal_enabled = False
+            try:
+                method(*params)
+            finally:
+                self.ai_self_heal_enabled = original_enabled
+            return KeywordExecResult(ok=True)
+        except OpticsError as exc:
+            return KeywordExecResult(ok=False, message=str(exc.message))
+        except Exception as exc:  # noqa: BLE001 - never crash the heal loop
+            return KeywordExecResult(ok=False, message=str(exc))
+
+    def _heal_catalog(self) -> List[HealKeywordSpec]:
+        """Return the keyword catalog for the self-healer (focused subset with signatures)."""
+        return [
+            HealKeywordSpec(name=name, signature=self._heal_keyword_signature(name, method))
+            for name, method in self._heal_dispatch.items()
+        ]
+
+    @staticmethod
+    def _heal_keyword_signature(name: str, method: Callable) -> str:
+        """Build a ghost-text signature like ``press_element <element> [repeat] [offset_x]``."""
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            return name
+        parts: List[str] = [name]
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            # Skip internal keyword-only params (located, event_name, aoi_*)
+            if param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if pname in ("event_name", "aoi_x", "aoi_y", "aoi_width", "aoi_height"):
+                continue
+            if param.default is inspect.Parameter.empty:
+                parts.append(f"<{pname}>")
+            else:
+                parts.append(f"[{pname}]")
+        return " ".join(parts)
 
     def _capture_screenshot_safe(self) -> Any:
         """Capture a screenshot, returning None on failure (e.g. secure/protected pages)."""

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -2,16 +2,20 @@
 
 When the normal element-location ladder (XPath -> on-screen text -> OCR -> image) exhausts
 for a locate-based keyword, :class:`AISelfHealHandler` asks an :class:`LLMInterface` to look at
-the current screen (screenshot + condensed page source) plus the keyword's intent and recent
-context, and to take ONE corrective device action at a time (tap / type / swipe / scroll) until
-the keyword's goal is achieved or a small step budget is hit.
+the current screen (screenshot + condensed page source) plus the keyword's intent and the
+available keyword catalog, and to emit ONE keyword call at a time (e.g. ``press_element "Meesho"``,
+``scroll "down"``) until the keyword's goal is achieved or a small step budget is hit.
 
-The handler runs *independently* of :class:`StrategyManager`: it drives the device directly via
-the :class:`DriverInterface` primitives, so the LLM must FINISH THE JOB itself (it cannot defer
-back to the normal locators). It is decoupled from any controller — it depends only on an ``llm``,
-a ``driver``, and screenshot/page-source provider callables — so it is unit-testable with fakes.
+Unlike the old coordinate-guessing approach, this routes through the framework's own keyword
+methods — so ``press_element "Meesho"`` uses the full locate ladder (XPath -> text -> OCR -> image)
+instead of the LLM blindly tapping pixel percentages.
+
+The handler is decoupled from any controller — it depends only on an ``llm``, a keyword executor
+callable, a keyword catalog callable, and screenshot/page-source provider callables — so it is
+unit-testable with fakes.
 """
 
+import shlex
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -25,16 +29,42 @@ from optics_framework.common.logging_config import internal_logger
 ScreenshotProvider = Callable[[], Optional[bytes]]
 PagesourceProvider = Callable[[], Optional[str]]
 
-# Actions that complete the keyword's goal (heal succeeds) vs. intermediate ones that
-# merely change what is on screen (loop continues to re-observe).
-_TERMINAL_ACTIONS = ("tap", "type")
-_LAYOUT_ACTIONS = ("tap", "type", "swipe", "scroll")
 
-# Defaults for driver args the LLM schema does not carry.
-_DEFAULT_SWIPE_LENGTH_PCT = 50
-_DEFAULT_SCROLL_DURATION_MS = 1000
+@dataclass
+class KeywordExecResult:
+    """Outcome of running a single keyword line via :data:`KeywordExecutor`.
+
+    Distinct from :class:`HealResult`, which is the terminal outcome of the whole
+    heal loop (which `HealAction` finished it, every step taken) — this is only the
+    per-call pass/fail that `_dispatch` reads back from the executor.
+    """
+
+    ok: bool
+    message: str = ""
+
+
+# Keyword executor: takes a keyword line string (e.g. 'press_element "Login"'),
+# returns the outcome of running it.
+KeywordExecutor = Callable[[str], KeywordExecResult]
+
+# Keyword catalog entry.
+@dataclass
+class HealKeywordSpec:
+    """A keyword the self-healer may call, with a human-readable signature."""
+    name: str
+    signature: str
+
+
+# Keyword catalog provider.
+KeywordCatalog = Callable[[], List[HealKeywordSpec]]
+
 # Let the UI settle after a layout-changing action before re-screenshotting.
 _SETTLE_SECONDS = 1.5
+
+# Keywords that just change what's on screen but don't complete a locate-based goal.
+_NON_COMPLETING_KEYWORDS = (
+    "scroll", "swipe_by_percentage", "swipe", "press_keycode", "press_by_percentage",
+)
 
 
 @dataclass
@@ -53,12 +83,11 @@ class HealContext:
 class HealAction:
     """A single parsed action the LLM asked for."""
 
-    action: str                  # "tap" | "type" | "swipe" | "scroll" | "give_up"
-    percent_x: Optional[float] = None
-    percent_y: Optional[float] = None
-    text: str = ""
-    direction: str = ""
+    action: str                  # "keyword" | "done" | "give_up"
+    keyword: str = ""            # snake_case keyword name (when action == "keyword")
+    params: List[str] = field(default_factory=list)
     reason: str = ""
+    completed: bool = True       # False for intermediate navigation steps
 
 
 @dataclass
@@ -70,77 +99,154 @@ class HealResult:
     message: str = ""
 
 
-# Flat schema (no anyOf/discriminated unions — Gemini's response_schema support for them is
-# unreliable; same discipline as nl_agent.ACTION_SCHEMA). percent_x/percent_y are also used by
-# the "type" action so the field can be focused (tapped) before typing.
+# Structured-output schema. Mirrors the NL agent's schema pattern (flat, no anyOf).
 HEAL_ACTION_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
         "reason": {
             "type": "string",
-            "description": "Brief reasoning about the screen and the chosen action.",
+            "description": "Brief reasoning about the current screen and the chosen action.",
         },
         "action": {
             "type": "string",
-            "enum": ["tap", "type", "swipe", "scroll", "give_up"],
-            "description": "tap/type complete the goal; swipe/scroll reveal it; give_up if blocked.",
+            "enum": ["keyword", "done", "give_up"],
+            "description": "keyword = run one keyword; done = goal achieved; give_up = blocked.",
         },
-        "percent_x": {
-            "type": "number",
-            "description": "X position 0-100 of screen width (for tap, and the field to tap before type).",
-        },
-        "percent_y": {
-            "type": "number",
-            "description": "Y position 0-100 of screen height (for tap, and the field to tap before type).",
-        },
-        "text": {"type": "string", "description": "Text to type (only when action == type)."},
-        "direction": {
+        "keyword": {
             "type": "string",
-            "enum": ["up", "down", "left", "right"],
-            "description": "Direction for swipe/scroll.",
+            "description": "snake_case keyword name (only when action == keyword).",
+        },
+        "params": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Positional parameters in keyword-signature order (strings).",
+        },
+        "completed": {
+            "type": "boolean",
+            "description": (
+                "Set to true if this keyword call completes the original keyword's goal "
+                "(e.g. pressing the final target element). Set to false if this is an "
+                "intermediate navigation step (e.g. scrolling to reveal the target, pressing "
+                "a menu to navigate, typing in a search bar) and more steps are needed."
+            ),
         },
     },
     "required": ["reason", "action"],
-    "propertyOrdering": ["reason", "action", "percent_x", "percent_y", "text", "direction"],
+    "propertyOrdering": ["reason", "action", "keyword", "params", "completed"],
 }
 
 
 HEAL_SYSTEM_PROMPT = """\
 You are the LAST-RESORT self-healing layer of a UI test-automation framework. The normal element \
 locators (XPath, on-screen text, OCR, image matching) have ALL failed to find the target for the \
-keyword described below. Your job is to look at the current screen and take ONE corrective device \
-action so the keyword's goal is achieved.
+keyword described below. Your job is to look at the current screen and execute framework keywords \
+step-by-step until the original keyword's goal is achieved.
 
-YOU MUST FINISH THE JOB YOURSELF — you cannot hand control back to the normal locators. If the \
-target is not on screen, `scroll` or `swipe` to reveal it, and once it is visible complete the \
-action yourself (`tap` to press it, `type` to enter text). Only use `give_up` when there is no \
-recoverable next action.
+YOU MUST FINISH THE JOB YOURSELF by issuing keyword calls. You have access to the same keywords \
+the framework uses. The most important one is `press_element` — it takes a visible text label \
+as its element parameter and the framework will locate the element using its full strategy ladder \
+(XPath → text → OCR → image matching). NAME TARGETS BY THEIR VISIBLE TEXT whenever possible.
 
-COORDINATES: always express positions as PERCENTAGES of the screen (percent_x, percent_y in 0-100). \
-Read element bounds from the condensed UI hierarchy (when provided) to compute a precise center, \
-or estimate from the screenshot. Percentages are resolution-independent and safer than pixels.
+WORKFLOW:
+1. Look at the screenshot and UI hierarchy to understand the current screen state.
+2. If the target element IS visible on screen, call the appropriate keyword to act on it \
+(e.g. `press_element` with the element's visible text). Set `completed` to true.
+3. If the target element is NOT visible, navigate to reveal it — scroll, swipe, press a menu, \
+or type in a search bar. Set `completed` to false for intermediate steps.
+4. Use `action: "done"` when you believe the original keyword's goal has been fully achieved.
+5. Use `action: "give_up"` only when there is no recoverable next action.
 
-ACTIONS:
-- tap: press at (percent_x, percent_y). Completes a press/click goal.
-- type: focus the field at (percent_x, percent_y) then enter `text`. Completes a text-entry goal.
-- swipe: swipe from (percent_x, percent_y) in `direction`. Intermediate (re-observe afterwards).
-- scroll: scroll the screen in `direction`. Intermediate (re-observe afterwards).
-- give_up: nothing recoverable remains.
+TARGETING POLICY (strict order of preference):
+1. Name the target by its VISIBLE TEXT as the element parameter (e.g. press_element ["Meesho"]). \
+Use the condensed hierarchy for EXACT text / content-desc / resource id.
+2. If the target is not visible, swipe to reveal it, THEN name it by text.
+3. For system buttons (home/back/recents), use press_keycode with the Android keycode \
+(HOME=3, BACK=4, RECENTS=187, ENTER=66).
+4. LAST RESORT: use press_by_percentage with coordinate percentages.
+5. Use swipe instead of scroll.
 
-RULES: emit exactly ONE action as JSON. Keep `reason` short. Be conservative: prefer revealing the \
-real target and tapping it over blindly tapping a guessed position.
+GESTURE DIRECTIONS:
+- To reveal content below (swipe down the list to see lower items), you must use direction "up" (finger drags from bottom to top).
+- To reveal content above (swipe up the list to see upper items), you must use direction "down" (finger drags from top to bottom).
+
+RULES:
+- Emit exactly ONE action per turn as JSON.
+- Keep `reason` short.
+- Prefer naming elements by text over guessing coordinates.
+- Set `completed` to true only when this step achieves the original keyword's goal.
 """
 
 _MAX_THOUGHT_CHARS = 160
 
 
 class AISelfHealHandler:
-    """Bounded loop that drives the device via LLM decisions to land a failed keyword."""
+    """Bounded loop that drives the device via keyword calls to land a failed keyword."""
 
-    def __init__(self, llm: LLMInterface, driver: Any, *, max_steps: int = 2) -> None:
+    def __init__(
+        self,
+        llm: LLMInterface,
+        keyword_executor: KeywordExecutor,
+        keyword_catalog: KeywordCatalog,
+        *,
+        max_steps: int = 5,
+    ) -> None:
         self.llm = llm
-        self.driver = driver
+        self.keyword_executor = keyword_executor
+        self.keyword_catalog = keyword_catalog
         self.max_steps = max_steps
+
+    def _execute_single_step(
+        self,
+        step: int,
+        ctx: HealContext,
+        screenshot_provider: ScreenshotProvider,
+        pagesource_provider: PagesourceProvider,
+        catalog: List[HealKeywordSpec],
+        attempted: List[str],
+    ) -> Optional[HealResult]:
+        """Execute a single iteration of self-healing and return terminal result or None to continue."""
+        png = self._safe_call(screenshot_provider)
+        if not png:
+            return HealResult(False, message="No screenshot available for self-heal.")
+        page_source = self._safe_call(pagesource_provider)
+
+        prompt = self._build_prompt(ctx, step, page_source, catalog)
+        try:
+            raw = self.llm.generate_json(
+                prompt, HEAL_ACTION_SCHEMA, images=[png],
+                system=HEAL_SYSTEM_PROMPT, temperature=0.0,
+            )
+        except OpticsError as exc:
+            return HealResult(False, message=f"LLM error: {exc.message}")
+        except Exception as exc:  # noqa: BLE001 - self-heal must never raise a new error type
+            return HealResult(False, message=f"LLM error: {exc}")
+
+        action = self._validate(raw)
+        internal_logger.info(
+            "AI self-heal step %d/%d for '%s': action=%s keyword=%s params=%s reason=%s",
+            step + 1, self.max_steps, ctx.intent_keyword, action.action,
+            action.keyword, action.params, action.reason[:_MAX_THOUGHT_CHARS],
+        )
+
+        if action.action == "give_up":
+            return HealResult(False, action=action, message=action.reason or "Model gave up.")
+        if action.action == "done":
+            return HealResult(True, action=action, message=action.reason or "Goal reached.")
+
+        # action.action == "keyword"
+        try:
+            done = self._dispatch(action)
+        except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
+            return HealResult(False, action=action, message=f"Keyword failed: {exc}")
+
+        if done:
+            return HealResult(True, action=action, message=action.reason or "Healed.")
+
+        # Intermediate step: record what was tried so a budget-exhausted message
+        # (the only case that reaches the caller without this action already
+        # attached) can still say what the model attempted.
+        attempted.append(self._build_line(action.keyword, action.params))
+        return None
 
     def heal(
         self,
@@ -149,43 +255,19 @@ class AISelfHealHandler:
         pagesource_provider: PagesourceProvider,
     ) -> HealResult:
         """Attempt to recover the failed keyword. Never raises — returns ok=False on any problem."""
+        catalog = self.keyword_catalog()
+        attempted: List[str] = []
+
         for step in range(self.max_steps):
-            png = self._safe_call(screenshot_provider)
-            if not png:
-                return HealResult(False, message="No screenshot available for self-heal.")
-            page_source = self._safe_call(pagesource_provider)
-
-            prompt = self._build_prompt(ctx, step, page_source)
-            try:
-                raw = self.llm.generate_json(
-                    prompt, HEAL_ACTION_SCHEMA, images=[png],
-                    system=HEAL_SYSTEM_PROMPT, temperature=0.0,
-                )
-            except OpticsError as exc:
-                return HealResult(False, message=f"LLM error: {exc.message}")
-            except Exception as exc:  # noqa: BLE001 - self-heal must never raise a new error type
-                return HealResult(False, message=f"LLM error: {exc}")
-
-            action = self._validate(raw)
-            internal_logger.info(
-                "AI self-heal step %d/%d for '%s': action=%s reason=%s",
-                step + 1, self.max_steps, ctx.intent_keyword, action.action,
-                action.reason[:_MAX_THOUGHT_CHARS],
+            result = self._execute_single_step(
+                step, ctx, screenshot_provider, pagesource_provider, catalog, attempted
             )
+            if result is not None:
+                return result
+            # Intermediate step: UI changed, loop to re-observe.
 
-            if action.action == "give_up":
-                return HealResult(False, action=action, message=action.reason or "Model gave up.")
-
-            try:
-                done = self._dispatch(action)
-            except Exception as exc:  # noqa: BLE001 - a driver error ends the heal cleanly
-                return HealResult(False, action=action, message=f"Action failed: {exc}")
-
-            if done:
-                return HealResult(True, action=action, message=action.reason or "Healed.")
-            # Intermediate (scroll/swipe): UI changed, loop to re-observe.
-
-        return HealResult(False, message="Self-heal step budget exhausted.")
+        tried = "; ".join(attempted) if attempted else "no actions attempted"
+        return HealResult(False, message=f"Self-heal step budget exhausted. Tried: {tried}")
 
     # -- internals -------------------------------------------------------------
 
@@ -200,44 +282,67 @@ class AISelfHealHandler:
             return None
 
     def _dispatch(self, action: HealAction) -> bool:
-        """Execute one action via the driver. Returns True when the keyword goal is complete."""
-        px = action.percent_x if action.percent_x is not None else 50.0
-        py = action.percent_y if action.percent_y is not None else 50.0
-
-        if action.action == "tap":
-            self.driver.press_percentage_coordinates(px, py, 1)
-        elif action.action == "type":
-            self.driver.press_percentage_coordinates(px, py, 1)
-            self.driver.enter_text(action.text)
-        elif action.action == "swipe":
-            direction = action.direction or "up"
-            self.driver.swipe_percentage(int(px), int(py), direction, _DEFAULT_SWIPE_LENGTH_PCT)
-        elif action.action == "scroll":
-            direction = action.direction or "down"
-            self.driver.scroll(direction, _DEFAULT_SCROLL_DURATION_MS)
-        else:  # pragma: no cover - _validate guarantees a known action
+        """Execute one keyword via the injected executor. Returns True when the goal is complete."""
+        if not action.keyword:
             return False
 
-        if action.action in _LAYOUT_ACTIONS:
-            # Handler bypasses keyword-level settling; let the UI finish animating.
+        line = self._build_line(action.keyword, action.params)
+        result = self.keyword_executor(line)
+
+        if not result.ok:
+            internal_logger.debug("AI self-heal: keyword '%s' failed: %s", line, result.message)
+            # Don't abort the whole heal on a single keyword failure — the LLM can
+            # try a different approach on the next step, so let the UI settle first.
             time.sleep(_SETTLE_SECONDS)
-        return action.action in _TERMINAL_ACTIONS
+            return False
+
+        # A completing keyword with completed=True means the goal is done — return
+        # immediately without waiting, since there's no next screenshot to settle for.
+        if action.keyword not in _NON_COMPLETING_KEYWORDS and action.completed:
+            return True
+
+        # Intermediate/navigation step: let the UI settle before the next screenshot.
+        time.sleep(_SETTLE_SECONDS)
+        return False
 
     @staticmethod
     def _validate(raw: Dict[str, Any]) -> HealAction:
+        if not isinstance(raw, dict):
+            raw = {}
         action = raw.get("action")
-        if action not in ("tap", "type", "swipe", "scroll", "give_up"):
+        if action not in ("keyword", "done", "give_up"):
             action = "give_up"
+
+        params_raw = raw.get("params") or []
+        params = [str(p) for p in params_raw] if isinstance(params_raw, list) else []
+
+        completed = raw.get("completed")
+        if completed is None:
+            # Default: completing keywords complete by default; navigation ones don't.
+            keyword = str(raw.get("keyword") or "")
+            completed = keyword not in _NON_COMPLETING_KEYWORDS
+        else:
+            completed = bool(completed)
+
         return HealAction(
             action=action,
-            percent_x=_as_float(raw.get("percent_x")),
-            percent_y=_as_float(raw.get("percent_y")),
-            text=str(raw.get("text") or ""),
-            direction=str(raw.get("direction") or ""),
+            keyword=str(raw.get("keyword") or ""),
+            params=params,
             reason=str(raw.get("reason") or ""),
+            completed=completed,
         )
 
-    def _build_prompt(self, ctx: HealContext, step: int, page_source: Optional[str]) -> str:
+    @staticmethod
+    def _build_line(keyword: str, params: List[str]) -> str:
+        """Build a keyword line string from keyword name and params."""
+        if not params:
+            return keyword
+        return keyword + " " + " ".join(shlex.quote(p) for p in params)
+
+    def _build_prompt(
+        self, ctx: HealContext, step: int, page_source: Optional[str],
+        catalog: List[HealKeywordSpec],
+    ) -> str:
         params = " ".join(str(p) for p in ctx.intent_params)
         lines = [
             f"FAILED KEYWORD: {ctx.intent_keyword} {params}".rstrip(),
@@ -248,6 +353,12 @@ class AISelfHealHandler:
             lines.append(f"RESOLVED VARIABLES: {pairs}")
         if ctx.failed_strategies:
             lines.append("STRATEGIES ALREADY TRIED (all failed): " + ", ".join(ctx.failed_strategies))
+
+        lines.append("")
+        lines.append("AVAILABLE KEYWORDS (name and parameters):")
+        for spec in catalog:
+            lines.append(f"  {spec.signature}")
+
         if page_source:
             lines.append("")
             lines.append(
@@ -263,18 +374,9 @@ class AISelfHealHandler:
         if step > 0:
             lines.append("")
             lines.append(
-                f"This is attempt {step + 1}. Your previous action changed the screen; "
-                "re-read the CURRENT screenshot and complete the goal (tap/type)."
+                f"This is attempt {step + 1}. Your previous keyword changed the screen; "
+                "re-read the CURRENT screenshot and complete the goal."
             )
         lines.append("")
         lines.append("The attached image is the CURRENT screen. Decide the SINGLE next action as JSON.")
         return "\n".join(lines)
-
-
-def _as_float(value: Any) -> Optional[float]:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None

--- a/optics_framework/common/elementsource_interface.py
+++ b/optics_framework/common/elementsource_interface.py
@@ -24,6 +24,22 @@ class ElementSourceInterface(ABC):
         """
         pass
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the current screen as encoded PNG bytes.
+
+        Combines the numpy and bytes screenshot paths into one call. Backends that can
+        return native encoded bytes (e.g. Appium, Playwright) should override this for
+        efficiency; the default implementation encodes the result of :meth:`capture`.
+
+        :return: PNG-encoded screenshot bytes.
+        :rtype: bytes
+        """
+        import cv2  # local import — cv2 is a runtime dep, not needed at module load
+        frame = self.capture()
+        _, buf = cv2.imencode(".png", frame)
+        return bytes(buf)
+
     @abstractmethod
     def locate(self, element: Any, index: int | None = None) -> tuple:
         """

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -735,6 +735,27 @@ class StrategyManager:
         internal_logger.debug("No screenshot captured.")
         raise OpticsError(Code.E0303, message="No screenshot captured using available strategies.")
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """Return the current screen as encoded PNG bytes.
+
+        Delegates to :meth:`ElementSourceInterface.capture_screenshot_bytes` on each
+        strategy's source. Backends with a native encoded path (Appium, Playwright,
+        Selenium) override that method for efficiency; others encode the numpy frame
+        via the default base-class implementation.
+        """
+        for strategy in self.screenshot_strategies:
+            source = strategy.element_source
+            try:
+                data = source.capture_screenshot_bytes()
+                if data:
+                    execution_tracer.log_attempt(strategy, "screenshot_bytes", "success")
+                    return data
+            except Exception as e:
+                execution_tracer.log_attempt(strategy, "screenshot_bytes", "fail", error=str(e))
+                internal_logger.debug(
+                    "Screenshot bytes via %s failed: %s", source.__class__.__name__, e)
+        raise OpticsError(Code.E0303, message="No screenshot bytes captured using available strategies.")
+
     def capture_screenshot_stream(self, timeout: int = 30):
         """Capture a screenshot stream using the available strategies."""
         execution_logger.debug("Starting screenshot stream with available strategies.")

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -6,6 +6,7 @@ import os
 import cv2
 import json
 import base64
+import time
 import numpy as np
 from enum import Enum
 from datetime import timezone, timedelta
@@ -235,6 +236,43 @@ def encode_numpy_to_base64(image: np.ndarray) -> str:
     :return: Base64 encoded string.
     """
     return base64.b64encode(encode_numpy_to_png_bytes(image)).decode('utf-8')
+
+
+# Screenshot-bytes retry: backends whose driver exposes a base64-encoded screenshot
+# (Appium, Selenium) share this fetch-and-decode-with-retry helper.
+BASE64_SCREENSHOT_RETRY_ATTEMPTS = 2
+# Delay between retries; a busy remote hub/grid node occasionally returns a
+# truncated base64 payload, and an immediate retry tends to hit the same failure.
+BASE64_SCREENSHOT_RETRY_BACKOFF_S = 0.5
+
+
+def capture_base64_screenshot_bytes(get_base64: Callable[[], str], backend_name: str) -> bytes:
+    """
+    Fetch a base64-encoded screenshot via ``get_base64`` and decode it to PNG bytes,
+    retrying on transient driver/decode failures.
+
+    :param get_base64: Zero-arg callable returning the driver's base64 screenshot string
+        (e.g. ``driver.get_screenshot_as_base64``).
+    :param backend_name: Human-readable backend name for log/error messages (e.g. "Appium").
+    :raises RuntimeError: If every attempt fails.
+    """
+    import binascii
+    from selenium.common.exceptions import WebDriverException  # local: optional runtime dep
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(BASE64_SCREENSHOT_RETRY_ATTEMPTS):
+        try:
+            return base64.b64decode(get_base64())
+        except (WebDriverException, binascii.Error) as e:
+            last_exc = e
+            internal_logger.warning(
+                "%s native screenshot bytes attempt %d/%d failed: %s",
+                backend_name, attempt + 1, BASE64_SCREENSHOT_RETRY_ATTEMPTS, e,
+            )
+            if attempt < BASE64_SCREENSHOT_RETRY_ATTEMPTS - 1:
+                time.sleep(BASE64_SCREENSHOT_RETRY_BACKOFF_S)
+    raise RuntimeError(f"Error capturing {backend_name} screenshot bytes: {last_exc}") from last_exc
+
 
 def compute_hash(xml_string):
     """Computes the SHA-256 hash of the XML string."""

--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -3,6 +3,7 @@ from typing import Optional, Any, List, Tuple
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.common.appiumby import AppiumBy
 from lxml import etree # type: ignore
+from selenium.common.exceptions import NoSuchElementException
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.elementsource_interface import ElementSourceInterface
@@ -113,8 +114,10 @@ class AppiumFindElement(ElementSourceInterface):
             try:
                 found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)
                 return found_element
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.exception(f" element: {element}", exc_info=e)
+                internal_logger.exception(f"Unexpected error finding element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         elif element_type == 'Class':
             try:
@@ -129,8 +132,12 @@ class AppiumFindElement(ElementSourceInterface):
 
                 found_element = found_elements[index_to_use]
                 return found_element
+            except OpticsError:
+                raise
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.exception(f" element: {element}", exc_info=e)
+                internal_logger.exception(f"Unexpected error finding class element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         return None
 

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -3,9 +3,11 @@ from typing import Optional, Any, Tuple, List
 from lxml import etree  # type: ignore
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.common.appiumby import AppiumBy
+from selenium.common.exceptions import NoSuchElementException
 from optics_framework.common.logging_config import internal_logger, execution_logger
 from optics_framework.common import utils
 from optics_framework.common.elementsource_interface import ElementSourceInterface
+from optics_framework.common.error import OpticsError, Code
 
 APPIUM_NOT_INITIALISED_MSG = "Appium driver is not initialized for AppiumPageSource."
 
@@ -77,6 +79,37 @@ class AppiumPageSource(ElementSourceInterface):
         internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
         raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
 
+    def _locate_by_text(self, driver: WebDriver, element: str, element_type: str, index: Optional[int] = None) -> Any:
+        locator = element[len("text="):] if element.lower().startswith("text=") else element
+        if index is not None:
+            xpath = self.find_xpath_from_text_index(locator, index)
+        else:
+            xpath = self.find_xpath_from_text(locator)
+        try:
+            execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
+            element_obj = driver.find_element(AppiumBy.XPATH, xpath)
+            return element_obj
+        except NoSuchElementException as e:
+            raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+        except Exception as e:
+            internal_logger.exception("Error finding element by text: %s: %s", xpath, e)
+            raise RuntimeError("Error finding element by text.") from e
+
+    def _locate_by_xpath(self, driver: WebDriver, element: str, element_type: str) -> Any:
+        if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
+            xpath, _ = self.driver.ui_helper.find_xpath(element)
+            try:
+                element_obj = driver.find_element(AppiumBy.XPATH, xpath)
+                return element_obj
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+            except Exception as e:
+                internal_logger.exception("Error finding element by xpath: %s: %s", xpath, e)
+                raise RuntimeError("Error finding element by xpath.") from e
+        else:
+            internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
+            raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
+
     def locate(self, element: str, index: Optional[int] = None) -> Any:
         """
         Locate a UI element on the current page using Appium.
@@ -99,30 +132,9 @@ class AppiumPageSource(ElementSourceInterface):
             internal_logger.debug('Appium Page Source does not support finding images.')
             return None
         elif element_type == 'Text':
-            locator = element[len("text="):] if element.lower().startswith("text=") else element
-            if index is not None:
-                xpath = self.find_xpath_from_text_index(locator, index)
-            else:
-                xpath = self.find_xpath_from_text(locator)
-            try:
-                execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
-                element_obj = driver.find_element(AppiumBy.XPATH, xpath)
-                return element_obj
-            except Exception:
-                internal_logger.exception("Error finding element by text: %s", xpath)
-                raise RuntimeError("Error finding element by text.")
+            return self._locate_by_text(driver, element, element_type, index)
         elif element_type == 'XPath':
-            if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-                xpath, _ = self.driver.ui_helper.find_xpath(element)
-                try:
-                    element_obj = driver.find_element(AppiumBy.XPATH, xpath)
-                    return element_obj
-                except Exception:
-                    internal_logger.exception("Error finding element by xpath: %s", xpath)
-                    raise RuntimeError("Error finding element by xpath.")
-            else:
-                internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
-                raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
+            return self._locate_by_xpath(driver, element, element_type)
         raise RuntimeError("Unknown element type.")
 
     def get_element_bboxes(
@@ -163,8 +175,10 @@ class AppiumPageSource(ElementSourceInterface):
                 xpath = self.driver.ui_helper.get_view_locator(strategy=strategy, locator=locator)
                 try:
                     element_obj = self._require_webdriver().find_element(AppiumBy.XPATH, xpath)
-                except Exception:
-                    internal_logger.exception("Error finding element by index: %s", xpath)
+                except NoSuchElementException:
+                    return None
+                except Exception as e:
+                    internal_logger.exception("Error finding element by index: %s: %s", xpath, e)
                     return None
                 return element_obj
             return None

--- a/optics_framework/engines/elementsources/appium_screenshot.py
+++ b/optics_framework/engines/elementsources/appium_screenshot.py
@@ -1,11 +1,10 @@
-import base64
 from typing import Optional, Any, List
 import numpy as np
 import cv2
 from appium.webdriver.webdriver import WebDriver
-from selenium.common.exceptions import ScreenshotException
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.common.utils import capture_base64_screenshot_bytes
 
 
 class AppiumScreenshot(ElementSourceInterface):
@@ -47,6 +46,19 @@ class AppiumScreenshot(ElementSourceInterface):
         """
         return self.capture_screenshot_as_numpy()
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the device screen as native PNG bytes via Appium's base64 endpoint.
+
+        Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
+        :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
+        bytes. The retry (shared with :class:`SeleniumScreenshot`) absorbs the
+        truncated-response ("Incorrect padding") base64 failures occasionally seen
+        against busy remote hubs.
+        """
+        driver = self._require_driver()
+        return capture_base64_screenshot_bytes(driver.get_screenshot_as_base64, "Appium")
+
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None):
         internal_logger.exception("AppiumScreenshot does not support getting interactive elements.")
         raise NotImplementedError(
@@ -57,28 +69,15 @@ class AppiumScreenshot(ElementSourceInterface):
         """
         Captures a screenshot using Appium and returns it as a NumPy array.
 
+        Reuses :meth:`capture_screenshot_bytes` (shared fetch + retry) and only adds
+        the decode, so the numpy and bytes paths stay in sync.
+
         Returns:
             numpy.ndarray: The captured screenshot as a NumPy array.
         """
-        try:
-            # Use Base64 encoding for faster processing
-            driver = self._require_driver()
-            internal_logger.debug('driver session_id: %s', driver.session_id)
-            screenshot_base64 = driver.get_screenshot_as_base64()
-            screenshot_bytes = base64.b64decode(screenshot_base64)
-            internal_logger.debug("Screenshot bytes length: %d", len(screenshot_bytes))
-            numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
-            numpy_image = cv2.imdecode(numpy_image, cv2.IMREAD_COLOR) # type: ignore
-            return numpy_image
-
-        except ScreenshotException as se:
-            # internal_logger.debug(f'ScreenshotException: {se}. Using external camera')
-            internal_logger.warning(f'ScreenshotException : {se}. Using external camera.')
-            raise RuntimeError("ScreenshotException occurred.")
-        except Exception as e:
-            # Log the error and fallback to external camera
-            internal_logger.warning(f"Error capturing Appium screenshot: {e}. Using external camera.")
-            raise RuntimeError(f"Error capturing Appium screenshot: {e}") from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
+        return cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)  # type: ignore
 
     def assert_elements(self, elements, timeout=30, rule='any') -> None:
         internal_logger.exception("AppiumScreenshot does not support asserting elements.")

--- a/optics_framework/engines/elementsources/playwright_screenshot.py
+++ b/optics_framework/engines/elementsources/playwright_screenshot.py
@@ -42,43 +42,40 @@ class PlaywrightScreenshot(ElementSourceInterface):
         """
         return self.capture_screenshot_as_numpy()
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the viewport as native PNG bytes.
+
+        ``page.screenshot()`` already returns encoded PNG, so this is the cheapest
+        path of all backends — no base64 decode and no OpenCV decode/encode at all.
+        """
+        page = self._require_page()
+        try:
+            internal_logger.debug("Capturing Playwright screenshot")
+            # Use run_async to handle async page.screenshot() if page is from async_api.
+            return run_async(page.screenshot(full_page=False))
+        except Exception as e:
+            internal_logger.warning(
+                "Error capturing Playwright screenshot bytes: %s", e, exc_info=True
+            )
+            raise RuntimeError(f"Error capturing Playwright screenshot bytes: {e}") from e
+
     def capture_screenshot_as_numpy(self) -> np.ndarray:
         """
         Captures screenshot via Playwright and converts to NumPy image.
         Only captures the viewport, not the full page.
 
+        Reuses :meth:`capture_screenshot_bytes` and only adds the decode.
+
         Returns:
             numpy.ndarray: Screenshot image
         """
-        page = self._require_page()
-        try:
-            internal_logger.debug("Capturing Playwright screenshot")
-
-            # Playwright returns raw PNG bytes
-            # Use run_async to handle async page.screenshot() if page is from async_api
-            screenshot_bytes = run_async(page.screenshot(full_page=False))
-
-            internal_logger.debug(
-                "Playwright screenshot bytes length: %d",
-                len(screenshot_bytes),
-            )
-
-            np_image = np.frombuffer(screenshot_bytes, np.uint8)
-            np_image = cv2.imdecode(np_image, cv2.IMREAD_COLOR)  # type: ignore
-
-            if np_image is None:
-                raise RuntimeError("Failed to decode Playwright screenshot")
-
-            return np_image
-
-        except Exception as e:
-            internal_logger.warning(
-                f"Error capturing Playwright screenshot: {e}",
-                exc_info=True,
-            )
-            raise RuntimeError(
-                f"Error capturing Playwright screenshot: {e}"
-            ) from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        np_image = np.frombuffer(screenshot_bytes, np.uint8)
+        np_image = cv2.imdecode(np_image, cv2.IMREAD_COLOR)  # type: ignore
+        if np_image is None:
+            raise RuntimeError("Failed to decode Playwright screenshot")
+        return np_image
 
     # --------------------------------------------------
     # Unsupported operations

--- a/optics_framework/engines/elementsources/selenium_screenshot.py
+++ b/optics_framework/engines/elementsources/selenium_screenshot.py
@@ -1,10 +1,9 @@
 from typing import Optional, Any, List
-import base64
 import cv2
 import numpy as np
-from selenium.common.exceptions import ScreenshotException
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.common.utils import capture_base64_screenshot_bytes
 
 
 class SeleniumScreenshot(ElementSourceInterface):
@@ -38,25 +37,31 @@ class SeleniumScreenshot(ElementSourceInterface):
         internal_logger.exception("SeleniumScreenshot does not support getting interactive elements.")
         raise NotImplementedError("SeleniumScreenshot does not support getting interactive elements.")
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the screen as native PNG bytes via Selenium's base64 endpoint.
+
+        Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
+        :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
+        bytes. The retry (shared with :class:`AppiumScreenshot`) absorbs
+        transient/truncated responses from remote Grid nodes.
+        """
+        driver = self._require_driver()
+        return capture_base64_screenshot_bytes(driver.get_screenshot_as_base64, "Selenium")
+
     def capture_screenshot_as_numpy(self) -> np.ndarray:
         """
         Captures a screenshot using Selenium and returns it as a NumPy array.
+
+        Reuses :meth:`capture_screenshot_bytes` (shared fetch + retry) and only adds
+        the decode, so the numpy and bytes paths stay in sync.
+
         Returns:
             np.ndarray: The captured screenshot as a NumPy array.
         """
-        try:
-            driver = self._require_driver()
-            screenshot_base64 = driver.get_screenshot_as_base64()
-            screenshot_bytes = base64.b64decode(screenshot_base64)
-            numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
-            numpy_image = cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)
-            return numpy_image
-        except ScreenshotException as se:
-            internal_logger.warning("ScreenshotException : %s. Using external camera.", se)
-            raise RuntimeError("ScreenshotException occurred.") from se
-        except Exception as e:
-            internal_logger.warning("Error capturing Selenium screenshot: %s. Using external camera.", e)
-            raise RuntimeError("Error capturing Selenium screenshot.") from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
+        return cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)
 
     def assert_elements(self, elements, timeout=30, rule='any') -> None:
         internal_logger.exception("SeleniumScreenshot does not support asserting elements.")

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -1096,13 +1096,15 @@ class LiveController:
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:
-        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect."""
+        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect.
+
+        Delegates to ``StrategyManager.capture_screenshot_bytes()`` so the native
+        fast path (when a backend supports it) and the numpy fallback are chosen
+        driver-agnostically.
+        """
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
-        try:
-            return self._action_keyword.strategy_manager.capture_screenshot_bytes()
-        except ValueError as exc:  # pragma: no cover - defensive
-            raise OpticsError(Code.E0303, message="Failed to encode screenshot") from exc
+        return self._action_keyword.strategy_manager.capture_screenshot_bytes()
 
     # -- Natural-language mode ----------------------------------------------------
 

--- a/optics_framework/helper/live_tui.py
+++ b/optics_framework/helper/live_tui.py
@@ -8,6 +8,7 @@ accumulate in a scrollable history pane above that auto-scrolls to the newest en
 
 import asyncio
 import functools
+import os
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from prompt_toolkit.application import Application, get_app
@@ -713,14 +714,13 @@ class LiveTUI:
             self._info(f"Save failed: {exc}")
             return
         self._save_armed = None
-        import os as _os  # local: avoid widening module imports for one count
         verb = "Appended" if (result.appended_module or result.appended_test_case) else "Saved"
         self._info(
             f"{verb} {result.step_count} step(s) → module '{result.module_name}' in "
             f"{result.modules_path}, test case '{result.test_case}' in {result.test_cases_path}"
         )
         if result.artifacts_path:
-            count = len(_os.listdir(result.artifacts_path))
+            count = len(os.listdir(result.artifacts_path))
             self._info(f"Snapshotted {count} artifact(s) → {result.artifacts_path}")
 
     def _cmd_device(self, arg: str) -> None:

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -1,10 +1,13 @@
-"""Unit tests for the AI self-heal handler and its ActionKeyword wiring.
+"""Unit tests for the keyword-based AI self-heal handler and its ActionKeyword wiring.
 
-No network: a scripted fake LLM drives the handler and a fake driver records the primitive
-calls. Covers each action type, the bounded loop, give_up, malformed JSON, LLM/driver errors,
-missing-screenshot inertness, page-source injection, and the ActionKeyword inert/active paths.
+No network: a scripted fake LLM drives the handler and a fake keyword executor records the
+keyword lines dispatched. Covers each action type, the bounded loop, give_up, done, malformed
+JSON, LLM/executor errors, missing-screenshot inertness, page-source injection, the
+ActionKeyword inert/active paths, and ActionKeyword._heal_execute's own shlex parsing,
+dispatch-table lookup, and error surfacing in isolation.
 """
 import json
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
@@ -13,6 +16,7 @@ from optics_framework.common import ai_self_heal as ash
 from optics_framework.common.ai_self_heal import (
     AISelfHealHandler,
     HealContext,
+    HealKeywordSpec,
     HEAL_ACTION_SCHEMA,
 )
 from optics_framework.common.error import OpticsError, Code
@@ -47,23 +51,36 @@ class FakeLLM:
         return self.scripted.pop(0)
 
 
-class FakeDriver:
-    """Records the driver primitive calls the handler dispatches."""
+@dataclass
+class ExecResult:
+    ok: bool
+    message: str = ""
 
-    def __init__(self):
+
+class FakeExecutor:
+    """Records keyword lines dispatched by the handler."""
+
+    def __init__(self, *, fail_keywords=None):
         self.calls = []
+        self._fail_keywords = fail_keywords or set()
 
-    def press_percentage_coordinates(self, px, py, repeat, event_name=None):
-        self.calls.append(("tap", px, py, repeat))
+    def __call__(self, line: str) -> ExecResult:
+        self.calls.append(line)
+        keyword = line.split()[0] if line else ""
+        if keyword in self._fail_keywords:
+            return ExecResult(ok=False, message=f"Element not found for '{keyword}'")
+        return ExecResult(ok=True)
 
-    def enter_text(self, text, event_name=None):
-        self.calls.append(("enter_text", text))
 
-    def swipe_percentage(self, x, y, direction, length, event_name=None):
-        self.calls.append(("swipe", x, y, direction, length))
-
-    def scroll(self, direction, duration, event_name=None):
-        self.calls.append(("scroll", direction, duration))
+def _catalog():
+    return [
+        HealKeywordSpec(name="press_element", signature="press_element <element> [repeat]"),
+        HealKeywordSpec(name="enter_text", signature="enter_text <element> <text>"),
+        HealKeywordSpec(name="scroll", signature="scroll <direction>"),
+        HealKeywordSpec(name="swipe_by_percentage", signature="swipe_by_percentage <percent_x> <percent_y> <direction> [swipe_length]"),
+        HealKeywordSpec(name="press_keycode", signature="press_keycode <keycode>"),
+        HealKeywordSpec(name="press_by_percentage", signature="press_by_percentage <percent_x> <percent_y>"),
+    ]
 
 
 def _shots():
@@ -87,64 +104,129 @@ class TestActionSchema:
 
 
 class TestHandlerActions:
-    def test_tap_completes(self):
-        llm = FakeLLM([{"action": "tap", "percent_x": 50, "percent_y": 60, "reason": "press it"}])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+    def test_press_element_completes(self):
+        """LLM emits press_element with text target — single step, completed."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is True
-        assert driver.calls == [("tap", 50.0, 60.0, 1)]
+        assert executor.calls == ['press_element Meesho']
         assert llm.calls == 1
 
-    def test_type_taps_then_enters(self):
+    def test_scroll_then_press_element(self):
+        """LLM scrolls to reveal target, then presses by text."""
         llm = FakeLLM([
-            {"action": "type", "percent_x": 10, "percent_y": 20, "text": "hello", "reason": "fill"}
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal target"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
         ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
         assert res.ok is True
-        assert driver.calls == [("tap", 10.0, 20.0, 1), ("enter_text", "hello")]
-
-    def test_scroll_then_tap(self):
-        llm = FakeLLM([
-            {"action": "scroll", "direction": "down", "reason": "reveal"},
-            {"action": "tap", "percent_x": 40, "percent_y": 80, "reason": "now press"},
-        ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
-        assert res.ok is True
-        assert driver.calls == [("scroll", "down", 1000), ("tap", 40.0, 80.0, 1)]
+        assert executor.calls == ['scroll down', 'press_element Meesho']
         assert llm.calls == 2
 
-    def test_swipe_uses_int_coords_and_default_length(self):
+    def test_enter_text_completes(self):
+        """LLM emits enter_text — single step completion."""
+        ctx = HealContext(intent_keyword="enter_text", intent_params=["Search", "hello"], element="Search")
         llm = FakeLLM([
-            {"action": "swipe", "percent_x": 50.7, "percent_y": 50.2, "direction": "up", "reason": "x"},
-            {"action": "give_up", "reason": "done trying"},
+            {"action": "keyword", "keyword": "enter_text", "params": ["Search", "hello"],
+             "completed": True, "reason": "type it"},
         ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
-        assert res.ok is False
-        assert driver.calls[0] == ("swipe", 50, 50, "up", 50)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(ctx, _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ["enter_text Search hello"]
+
+    def test_press_keycode_then_press_element(self):
+        """LLM presses back, then targets element by text."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_keycode", "params": ["4"],
+             "completed": False, "reason": "go back"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press it"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ['press_keycode 4', 'press_element Login']
+
+    def test_done_action_succeeds(self):
+        """LLM signals done — goal reached without a keyword."""
+        llm = FakeLLM([
+            {"action": "done", "reason": "target already visible and pressed"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == []
 
     def test_give_up_fails(self):
         llm = FakeLLM([{"action": "give_up", "reason": "blocked"}])
-        res = AISelfHealHandler(llm, FakeDriver()).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "blocked" in res.message
 
     def test_malformed_action_treated_as_give_up(self):
         llm = FakeLLM([{"action": "frobnicate", "reason": "nonsense"}])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
-        assert driver.calls == []
+        assert executor.calls == []
 
     def test_step_budget_exhausted(self):
-        llm = FakeLLM([{"action": "scroll", "direction": "down", "reason": "x"}] * 2)
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"], "reason": "x"}
+        ] * 2)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert llm.calls == 2
-        assert driver.calls == [("scroll", "down", 1000), ("scroll", "down", 1000)]
+        assert executor.calls == ['scroll down', 'scroll down']
+        assert "scroll down" in res.message
+
+    def test_keyword_failure_does_not_abort(self):
+        """A failing keyword lets the LLM retry a different approach."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["WrongText"],
+             "completed": True, "reason": "try pressing"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "correct target"},
+        ])
+        executor = FakeExecutor(fail_keywords={"press_element"})
+        # Both fail because we set press_element as failing, so heal should fail
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is False
+        assert len(executor.calls) == 2
+
+    def test_intermediate_press_then_final_press(self):
+        """LLM presses a menu (completed=False), then the final target (completed=True)."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Apps"],
+             "completed": False, "reason": "open apps drawer"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ['press_element Apps', 'press_element Meesho']
+
+    def test_swipe_uses_percentage(self):
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "swipe_by_percentage", "params": ["50", "80", "up", "30"],
+             "completed": False, "reason": "reveal target"},
+            {"action": "give_up", "reason": "still not visible"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is False
+        assert executor.calls == ['swipe_by_percentage 50 80 up 30']
 
 
 class TestHandlerErrorHandling:
@@ -153,23 +235,22 @@ class TestHandlerErrorHandling:
             def generate_json(self, *a, **k):
                 raise OpticsError(Code.E0801, message="bad json")
 
-        res = AISelfHealHandler(BoomLLM(), FakeDriver()).heal(_ctx(), _shots, _no_ps)
+        res = AISelfHealHandler(BoomLLM(), FakeExecutor(), lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "bad json" in res.message
 
-    def test_driver_error_returns_not_ok(self):
-        class BadDriver(FakeDriver):
-            def press_percentage_coordinates(self, *a, **k):
-                raise RuntimeError("device offline")
+    def test_executor_exception_returns_not_ok(self):
+        def boom_executor(line):
+            raise RuntimeError("device offline")
 
-        llm = FakeLLM([{"action": "tap", "percent_x": 1, "percent_y": 1, "reason": "x"}])
-        res = AISelfHealHandler(llm, BadDriver()).heal(_ctx(), _shots, _no_ps)
+        llm = FakeLLM([{"action": "keyword", "keyword": "press_element", "params": ["X"], "reason": "x"}])
+        res = AISelfHealHandler(llm, boom_executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "device offline" in res.message
 
     def test_no_screenshot_is_inert(self):
-        llm = FakeLLM([{"action": "tap", "percent_x": 1, "percent_y": 1, "reason": "x"}])
-        res = AISelfHealHandler(llm, FakeDriver()).heal(_ctx(), lambda: None, _no_ps)
+        llm = FakeLLM([{"action": "keyword", "keyword": "press_element", "params": ["X"], "reason": "x"}])
+        res = AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(_ctx(), lambda: None, _no_ps)
         assert res.ok is False
         assert llm.calls == 0
 
@@ -185,13 +266,20 @@ class TestPromptContext:
             recent_steps=[("press_element", ["Menu"])],
             failed_strategies=["XPathStrategy", "TextDetectionStrategy"],
         )
-        AISelfHealHandler(llm, FakeDriver()).heal(ctx, _shots, lambda: ps)
+        AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(ctx, _shots, lambda: ps)
         assert "login_field" in llm.last_prompt
         assert "CURRENT SCREEN ELEMENTS" in llm.last_prompt
         assert "enter_text" in llm.last_prompt
         assert "press_element" in llm.last_prompt  # recent step
         assert "TextDetectionStrategy" in llm.last_prompt
         assert "last-resort" in llm.last_system.lower()
+
+    def test_keyword_catalog_in_prompt(self):
+        llm = FakeLLM([{"action": "give_up", "reason": "x"}])
+        AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
+        assert "AVAILABLE KEYWORDS" in llm.last_prompt
+        assert "press_element <element>" in llm.last_prompt
+        assert "scroll <direction>" in llm.last_prompt
 
 
 # --------------------------------------------------------------------------------------------
@@ -256,15 +344,123 @@ class TestActionKeywordWiring:
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
         assert ak._ai_self_heal("X", "press_element", (), {}, shot) is False
 
-    def test_active_tap_heals(self, monkeypatch):
+    def test_heal_catalog_returns_specs(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        catalog = ak._heal_catalog()
+        names = [spec.name for spec in catalog]
+        assert "press_element" in names
+        assert "scroll" in names
+        assert "enter_text" in names
+        # Signatures should be human-readable
+        pe_spec = next(s for s in catalog if s.name == "press_element")
+        assert "<element>" in pe_spec.signature
+
+    def test_active_press_element_heals(self, monkeypatch):
         monkeypatch.setattr(ash.time, "sleep", lambda *_a, **_k: None)
-        llm = FakeLLM([{"action": "tap", "percent_x": 25, "percent_y": 75, "reason": "press"}])
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press it"},
+        ])
         llm.instances = [object()]  # InstanceFallback-like truthiness gate
         ak = _make_action_keyword(ai_self_heal=True, llm=llm)
-        # No page source from the mocked strategy manager.
-        ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
+        # Mock strategy manager to return valid screenshot bytes and no page source.
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
+        ak.strategy_manager.capture_screenshot = MagicMock(return_value=shot)
+        ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
+
+        # scroll is non-self-healing, so `_heal_execute` calls the real method; let it
+        # run against the mocked `ak.driver` and assert the call reached the driver
+        # with the parsed params (`_heal_dispatch` binds the real method at __init__,
+        # so reassigning `ak.scroll` here would never be consulted — see press_element
+        # below for the correct way to intercept a self-healing-decorated method).
+        # press_element goes through `with_self_healing` decorator, which needs a
+        # working strategy_manager.locate; mock it to return a located result.
+        mock_result = MagicMock()
+        mock_result.is_coordinates = False
+        mock_result.value = MagicMock()
+        mock_result.strategy = MagicMock()
+        ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
+
         assert ak._ai_self_heal("Login", "press_element", (), {}, shot) is True
-        ak.driver.press_percentage_coordinates.assert_called_once()
-        # Healed keyword is recorded as a breadcrumb.
-        assert list(ak._recent_steps) == [("press_element", ["Login"])]
+        ak.driver.scroll.assert_called_once_with("down", 1000, None)
+        # Healed keyword is recorded as a breadcrumb (may appear more than once —
+        # the inner press_element records one, and _log_heal_outcome records another).
+        steps = list(ak._recent_steps)
+        assert any(s == ("press_element", ["Login"]) for s in steps)
+
+
+# --------------------------------------------------------------------------------------------
+# ActionKeyword._heal_execute: shlex parsing, dispatch-table lookup, error surfacing.
+#
+# These substitute entries in `_heal_dispatch` directly rather than reassigning
+# `ak.<method>` — `_heal_execute` looks the callable up fresh from `_heal_dispatch` on
+# every call, so that's the correct interception point (see the comment on
+# `test_active_press_element_heals` above for why reassigning the instance attribute
+# doesn't work).
+# --------------------------------------------------------------------------------------------
+
+
+class TestHealExecute:
+    def test_unknown_keyword_returns_not_ok(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        result = ak._heal_execute("frobnicate foo")
+        assert result.ok is False
+        assert "Unknown keyword: frobnicate" in result.message
+
+    def test_empty_line_returns_not_ok(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        result = ak._heal_execute("")
+        assert result.ok is False
+        assert "Empty keyword line" in result.message
+
+    def test_unbalanced_quotes_return_parse_error(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        result = ak._heal_execute('scroll "unterminated')
+        assert result.ok is False
+        assert "Parse error" in result.message
+
+    def test_dispatches_with_parsed_positional_params(self):
+        """A quoted multi-word param built via `_build_line` round-trips through
+        `shlex.split` and reaches the dispatched callable as separate positional args."""
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        captured = []
+        ak._heal_dispatch["enter_text"] = lambda *args: captured.append(args)
+
+        line = AISelfHealHandler._build_line("enter_text", ["Search box", "hello world"])
+        result = ak._heal_execute(line)
+
+        assert result.ok is True
+        assert captured == [("Search box", "hello world")]
+
+    def test_opticserror_from_dispatched_method_surfaces_message(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+
+        def boom(*_args):
+            raise OpticsError(Code.E0201, message="element not found")
+
+        ak._heal_dispatch["press_element"] = boom
+        result = ak._heal_execute("press_element Login")
+
+        assert result.ok is False
+        assert "element not found" in result.message
+
+    def test_recursion_guard_disables_and_restores_toggle(self):
+        """`ai_self_heal_enabled` must be off for the duration of the dispatched call
+        (so a nested locate failure can't re-trigger self-heal) and restored afterwards
+        — even when the dispatched method raises."""
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        seen_enabled = []
+
+        def spy(*_args):
+            seen_enabled.append(ak.ai_self_heal_enabled)
+            raise RuntimeError("device offline")
+
+        ak._heal_dispatch["scroll"] = spy
+        result = ak._heal_execute("scroll down")
+
+        assert result.ok is False
+        assert "device offline" in result.message
+        assert seen_enabled == [False]
+        assert ak.ai_self_heal_enabled is True

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -1,6 +1,10 @@
 """Unit tests for TEXT_ONLY prefix feature and strategy selection."""
+import base64
+import time
+import cv2
 import numpy as np
 import pytest
+from selenium.common.exceptions import WebDriverException
 from unittest.mock import MagicMock, patch
 
 from optics_framework.common import utils
@@ -182,3 +186,137 @@ class TestStrategyManagerAssertPresenceTextOnly:
             assert "Submit" in seen_elements
             assert "Login" in seen_elements
             assert "TEXT_ONLY:Login" not in seen_elements
+
+
+# --- capture_screenshot_bytes (native fast path + numpy fallback) ---
+
+
+def _sm_with_source(source):
+    """StrategyManager wrapping a single element source (screenshot path only)."""
+    return StrategyManager(
+        element_source=InstanceFallback([source]),
+        text_detection=None,
+        image_detection=None,
+    )
+
+
+class TestCaptureScreenshotBytes:
+    """StrategyManager.capture_screenshot_bytes() prefers the native path, else encodes numpy."""
+
+    def test_prefers_native_bytes(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.return_value = b"\x89PNG-native"
+        sm = _sm_with_source(source)
+        assert sm.capture_screenshot_bytes() == b"\x89PNG-native"
+        source.capture.assert_not_called()  # native path => no numpy capture/encode
+
+    def test_raises_optics_error_when_all_sources_fail(self):
+        from optics_framework.common.error import OpticsError
+        source = MagicMock()
+        source.capture_screenshot_bytes.side_effect = RuntimeError("hub timeout")
+        sm = _sm_with_source(source)
+        with pytest.raises(OpticsError):
+            sm.capture_screenshot_bytes()
+
+    def test_interface_default_encodes_numpy_via_capture(self):
+        """ElementSourceInterface.capture_screenshot_bytes() default encodes capture() result."""
+        from optics_framework.common.elementsource_interface import ElementSourceInterface
+
+        class _MinimalSource(ElementSourceInterface):
+            def capture(self) -> np.ndarray:
+                return np.full((8, 8, 3), 255, dtype=np.uint8)
+            def locate(self, element, index=None): raise NotImplementedError
+            def assert_elements(self, elements, timeout=30, rule='any'): raise NotImplementedError
+            def get_interactive_elements(self, filter_config=None): raise NotImplementedError
+
+        source = _MinimalSource()
+        data = source.capture_screenshot_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic bytes from cv2.imencode
+
+
+class _FakeWD:
+    """Stub webdriver (no ``.driver`` attr, so _require_driver returns it as-is)."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def get_screenshot_as_base64(self):
+        self.calls += 1
+        item = self._results.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+@pytest.fixture
+def _no_backoff(monkeypatch):
+    """Skip the inter-retry sleep so retry tests stay fast."""
+    monkeypatch.setattr(time, "sleep", lambda *_a, **_k: None)
+
+
+class TestAppiumScreenshotBytes:
+    """AppiumScreenshot.capture_screenshot_bytes() decodes base64 with a single retry."""
+
+    def test_returns_decoded_base64(self):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNG\r\n\x1a\nDATA"
+        drv = _FakeWD([base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 1
+
+    def test_retries_then_succeeds(self, _no_backoff):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNGok"
+        drv = _FakeWD(["not-valid-base64!!!", base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 2
+
+    def test_raises_after_exhausted_retries(self, _no_backoff):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        drv = _FakeWD([WebDriverException("boom"), WebDriverException("boom")])
+        with pytest.raises(RuntimeError):
+            AppiumScreenshot(driver=drv).capture_screenshot_bytes()
+        assert drv.calls == 2
+
+    def test_numpy_path_reuses_bytes(self, _no_backoff):
+        """capture_screenshot_as_numpy delegates to the bytes path (shared retry)."""
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        # A real 2x2 PNG so cv2.imdecode succeeds; corrupt first to exercise the shared retry.
+        ok_png = cv2.imencode(".png", np.full((2, 2, 3), 255, np.uint8))[1].tobytes()
+        drv = _FakeWD(["bad!!!", base64.b64encode(ok_png).decode("ascii")])
+        img = AppiumScreenshot(driver=drv).capture_screenshot_as_numpy()
+        assert img.shape == (2, 2, 3)
+        assert drv.calls == 2
+
+
+class TestSeleniumScreenshotBytes:
+    """SeleniumScreenshot mirrors the Appium native base64 path."""
+
+    def test_returns_decoded_base64(self):
+        from optics_framework.engines.elementsources.selenium_screenshot import SeleniumScreenshot
+        png = b"\x89PNG\r\n\x1a\nDATA"
+        drv = _FakeWD([base64.b64encode(png).decode("ascii")])
+        assert SeleniumScreenshot(driver=drv).capture_screenshot_bytes() == png
+
+    def test_retries_then_succeeds(self, _no_backoff):
+        from optics_framework.engines.elementsources.selenium_screenshot import SeleniumScreenshot
+        png = b"\x89PNGok"
+        drv = _FakeWD(["bad!!!", base64.b64encode(png).decode("ascii")])
+        assert SeleniumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 2
+
+
+class TestPlaywrightScreenshotBytes:
+    """PlaywrightScreenshot returns page.screenshot()'s PNG bytes verbatim (no decode)."""
+
+    def test_returns_page_screenshot_bytes(self, monkeypatch):
+        pytest.importorskip("playwright")
+        import types as _types
+        import optics_framework.engines.elementsources.playwright_screenshot as pw
+        monkeypatch.setattr(pw, "run_async", lambda coro: coro)
+        png = b"\x89PNG\r\n\x1a\nPLAYWRIGHT"
+        page = MagicMock()
+        page.screenshot.return_value = png
+        src = pw.PlaywrightScreenshot(driver=_types.SimpleNamespace(page=page))
+        assert src.capture_screenshot_bytes() == png


### PR DESCRIPTION
## Summary
This PR refactors the AI self-heal mechanism from coordinate-guessing (which frequently tapped blind/guessed screen coordinates and often missed targets) to a keyword-based execution model. The AI now acts as a ReAct loop over the framework's own action keywords, utilizing more reliable, targeted actions that route through the locating strategies ladder (XPath, text, OCR, image-matching).

Additionally, it cleans up noisy expected element-not-found log output from Appium element sources to prevent the live TUI silent error checker from overriding successful self-heals with failure statuses.

## Changes
### 1. AI Self-Heal Refactor (`optics_framework/common/ai_self_heal.py`)
- Rewrote `AISelfHealHandler` to run a keyword-based loop (similar to the NL agent but lighter).
- Replaced the coordinate schema (`percent_x`, `percent_y`, `text`, `direction`) in `HEAL_ACTION_SCHEMA` with `keyword` name, parameter string list, and a `completed` status flag.
- Added catalog introspection to the prompt so the LLM knows available signatures.
- Instructed the LLM to prefer targeting elements by visible text (using the condensed UI hierarchy) via `press_element` instead of guessing percentages.
- Added explicit prompt guidelines for gesture directions to align the LLM's spatial logical scroll actions with the physical swipe inputs expected by the driver.

### 2. Action Keyword Integration (`optics_framework/api/action_keyword.py`)
- Implemented `_heal_execute()` to parse and execute keywords generated by the LLM during the self-heal process.
- Temporarily disables the self-heal toggle during internal keyword calls to prevent infinite recursion.
- Added `_heal_catalog()` to serve a focused keyword catalog: `press_element`, `enter_text`, `scroll`, `swipe_by_percentage`, `press_keycode`, `press_by_percentage`.

### 3. Log Cleanup for Silent Error Checker
- **`optics_framework/engines/elementsources/appium_find_element.py`**
- **`optics_framework/engines/elementsources/appium_page_source.py`**
  - Caught `NoSuchElementException` specifically and raised `OpticsError` without logging stack tracebacks via `internal_logger.exception` (which is treated as a silent error/failure in `live.py`).

### 4. Tests
- **`tests/units/common/test_ai_self_heal.py`**
  - Updated unit tests to use `FakeExecutor` instead of `FakeDriver`.
  - Added new coverage for keyword execution, multi-step navigation, catalog prompts, done/give_up loops, and `ActionKeyword` integrations.

## Verification
- Ran full test suite:
  ```bash
  poetry run pytest --ignore=tests/feature
