### PR TITLE
Fix scroll direction and handle OpticsError in scrolling logic

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -535,10 +535,14 @@ class ActionKeyword:
         self._save_screenshot_if_available(screenshot_np, "scroll_until_element_appears")
         start_time = time.time()
         while time.time() - start_time < int(timeout):
-            result = self.verifier.assert_presence(
-                element, timeout_str="3", rule="any")
-            if result:
-                break
+            try:
+                result = self.verifier.assert_presence(
+                    element, timeout_str="3", rule="any")
+                if result:
+                    break
+            except OpticsError as e:
+                if e.code != Code.E0201:
+                    raise
             self.driver.scroll(direction, 1000, event_name)
             time.sleep(3)
 

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -543,6 +543,9 @@ class ActionKeyword:
             except OpticsError as e:
                 if e.code != Code.E0201:
                     raise
+                # Don't hide configuration/strategy issues; scrolling won't fix these.
+                if "No strategies found" in e.message or "No valid strategies found" in e.message:
+                    raise
             self.driver.scroll(direction, 1000, event_name)
             time.sleep(3)
 

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -916,12 +916,12 @@ class Appium(DriverInterface):
         end_y: int
         if direction == "up":
             start_x = width // 2
-            start_y = int(height * 0.8)
-            end_y = int(height * 0.2)
-        elif direction == "down":
-            start_x = width // 2
             start_y = int(height * 0.2)
             end_y = int(height * 0.8)
+        elif direction == "down":
+            start_x = width // 2
+            start_y = int(height * 0.8)
+            end_y = int(height * 0.2)
         else:
             internal_logger.error(f"Scroll direction '{direction}' not supported.")
             return


### PR DESCRIPTION
- Fixed the reverse scroll direction for up/down in `optics_framework/engines/drivers/appium.py`
- Caught `OpticsError` error code E0201 which corresponds to element location issues in `optics_framework/api/action_keyword.py`

The call chain which leads to `OpticsError` is:
1. [scroll_until_element_appears](https://github.com/kun-codes/optics-framework/blob/064d6006acfcd85aa05007f4116dae81457bf8d3/optics_framework/api/action_keyword.py#L525) calls self.verifier.assert_presence(element, timeout_str="3", rule="any", fail=False)
2. [verifier.assert_presence (verifier.py:89)](https://github.com/kun-codes/optics-framework/blob/064d6006acfcd85aa05007f4116dae81457bf8d3/optics_framework/api/verifier.py#L89) calls [self._process_element_groups(...) at line 107](https://github.com/kun-codes/optics-framework/blob/064d6006acfcd85aa05007f4116dae81457bf8d3/optics_framework/api/verifier.py#L107)
3. [ _process_element_groups (verifier.py:107)](https://github.com/kun-codes/optics-framework/blob/064d6006acfcd85aa05007f4116dae81457bf8d3/optics_framework/api/verifier.py#L107) calls [self.strategy_manager.assert_presence(elem_group, elem_type, timeout, rule)](https://github.com/kun-codes/optics-framework/blob/064d6006acfcd85aa05007f4116dae81457bf8d3/optics_framework/api/verifier.py#L114) at line 114 — no try/except around it
4. strategy_manager.assert_presence (strategies.py) raises OpticsError(Code.E0201, ...) when the element is not found

I have tested out my pull request on an Android device