### PR TITLE
Catch OpticsError in swipe_until_element_appears for retry loop

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -479,10 +479,14 @@ class ActionKeyword:
         self._save_screenshot_if_available(screenshot_np, "swipe_until_element_appears")
         start_time = time.time()
         while time.time() - start_time < int(timeout):
-            result = self.verifier.assert_presence(
-                element, timeout_str="3", rule="any")
-            if result:
-                break
+            try:
+                result = self.verifier.assert_presence(
+                    element, timeout_str="3", rule="any")
+                if result:
+                    break
+            except OpticsError as e:
+                if e.code != Code.E0201:
+                    raise
             self.driver.swipe_percentage(10, 50, direction, 25, event_name)
             time.sleep(3)
 

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -390,3 +390,68 @@ class TestSelectDropdownOption:
         ):
             with pytest.raises(OpticsError):
                 action_keyword.select_dropdown_option("Country", "India")
+
+
+class TestSwipeUntilElementAppears:
+    """Tests for OpticsError(E0201) handling in swipe_until_element_appears."""
+
+    @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
+    @patch('optics_framework.api.action_keyword.time.time')
+    def test_e0201_continues_loop_until_found(self, mock_time, mock_sleep, action_keyword):
+        """E0201 is caught, loop continues, element found on second call."""
+        mock_time.side_effect = [0, 0, 3, 6, 9]
+        call_count = 0
+
+        def assert_presence_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OpticsError(Code.E0201, message="Element not found")
+            return True
+
+        with patch.object(action_keyword.verifier, 'assert_presence', side_effect=assert_presence_side_effect):
+            action_keyword.swipe_until_element_appears("element", "down", "10")
+
+        assert call_count == 2
+        action_keyword.driver.swipe_percentage.assert_called_once_with(10, 50, "down", 25, None)
+
+    @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
+    @patch('optics_framework.api.action_keyword.time.time')
+    def test_non_e0201_is_reraised(self, mock_time, mock_sleep, action_keyword):
+        """Non-E0201 OpticsError is re-raised immediately."""
+        mock_time.side_effect = [0, 0]
+
+        with patch.object(
+            action_keyword.verifier, 'assert_presence',
+            side_effect=OpticsError(Code.E0303, message="Screenshot failed")
+        ):
+            with pytest.raises(OpticsError) as exc_info:
+                action_keyword.swipe_until_element_appears("element", "down", "10")
+
+        assert exc_info.value.code == Code.E0303
+        action_keyword.driver.swipe_percentage.assert_not_called()
+
+    @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
+    @patch('optics_framework.api.action_keyword.time.time')
+    def test_element_found_stops_loop(self, mock_time, mock_sleep, action_keyword):
+        """Element found on first call, no swipe performed."""
+        mock_time.side_effect = [0, 0]
+
+        with patch.object(action_keyword.verifier, 'assert_presence', return_value=True):
+            action_keyword.swipe_until_element_appears("element", "down", "10")
+
+        action_keyword.driver.swipe_percentage.assert_not_called()
+
+    @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
+    @patch('optics_framework.api.action_keyword.time.time')
+    def test_timeout_stops_loop(self, mock_time, mock_sleep, action_keyword):
+        """Element never found, loop exits after timeout."""
+        mock_time.side_effect = [0, 0, 3, 6, 9, 12]
+
+        with patch.object(
+            action_keyword.verifier, 'assert_presence',
+            side_effect=OpticsError(Code.E0201, message="Element not found")
+        ):
+            action_keyword.swipe_until_element_appears("element", "down", "10")
+
+        assert action_keyword.driver.swipe_percentage.call_count == 4


### PR DESCRIPTION
- The `assert_presence` call throws `OpticsError(Code.E0201)` when the element is not found, which killed the while loop on the first miss. Wrap in try/except to catch only E0201 (element not found) so the loop continues swiping until timeout. Re-raise any other `OpticsError` codes.