### PR TITLE
feat: on-screen error detection for runs and library consumers

### DIFF
--- a/docs/usage/error_detection.md
+++ b/docs/usage/error_detection.md
@@ -1,0 +1,97 @@
+# On-Screen Error Detection
+
+Optics can scan the screen for user-defined error messages (crash dialogs,
+network errors, "Session expired", etc.) and report any matches. Detection runs
+automatically at the end of a CLI run, and is also exposed to library consumers
+as a plain data primitive.
+
+## How matching works
+
+Each error definition has a `match_string`. Optics extracts the **visible text**
+from the current screen and checks whether any `match_string` (or the
+`error_code` itself) appears in it.
+
+!!! important "Matching is case-insensitive substring matching — not regex"
+    `match_string` is treated as **plain text** and tested with a substring
+    (`in`) check, **after lower-casing both sides**. It is **not** a regular
+    expression or a glob pattern.
+
+    - `Session expired` matches `Your session expired, please log in`.
+    - `session expired` also matches `SESSION EXPIRED` (case-insensitive).
+    - Regex metacharacters are **not** interpreted: `error.*` only matches the
+      literal text `error.*`.
+
+### What "visible text" means
+
+Optics only searches text a user can actually see, to avoid false positives
+against internal identifiers:
+
+- **Mobile (Appium / XCUITest XML):** values of the `text`, `content-desc`,
+  `label`, `value`, `hint`, and `name` attributes. Resource-ids, class names,
+  bounds, and other metadata are ignored.
+- **Web (Selenium / Playwright HTML):** the rendered text content
+  (via BeautifulSoup `get_text()`); tags, attributes, and CSS class names are
+  stripped. HTML detection requires the `beautifulsoup4` package (installed as a
+  dependency).
+
+## Defining errors via CSV (CLI)
+
+Place an `error_definitions.csv` file in your project's `test_data/` directory
+(alongside your test cases and modules). Optics discovers it automatically by
+its header row.
+
+```csv
+error_code,match_string,description,severity
+ERR_001,Unfortunately,App has crashed with a system dialog,critical
+ERR_002,has stopped,App stopped unexpectedly,critical
+ERR_009,Session expired,User session timed out,high
+```
+
+| Column         | Required | Meaning                                                        |
+| -------------- | -------- | -------------------------------------------------------------- |
+| `error_code`   | yes      | Stable identifier for the error.                               |
+| `match_string` | yes      | Case-insensitive substring to look for in on-screen text.      |
+| `description`  | no       | Human-readable explanation.                                    |
+| `severity`     | no       | Free-form severity label (e.g. `critical`, `high`, `medium`).  |
+
+At the end of an `optics execute` run, any matches are:
+
+- logged as warnings in the execution log,
+- written to `execution_output/detected_errors_<session_id>.json`,
+- and added to `junit_output.xml` as a synthetic `on-screen-error-detection`
+  testcase with one `<failure>` per match — so CI tools (Jenkins, GitLab CI,
+  GitHub Actions) surface them and fail the build.
+
+## Defining errors via the library (Python)
+
+When using the `Optics` class directly, you decide how to supply the
+definitions — no CSV required. Pass a raw dict or an `ErrorDefinitions` model:
+
+```python
+from optics_framework import Optics
+
+optics = Optics()
+optics.setup(...)
+
+# Register error definitions (merges on repeated calls)
+optics.add_error_definitions({
+    "ERR_009": {
+        "match_string": "Session expired",
+        "description": "User session timed out",
+        "severity": "high",
+    },
+})
+
+# ... drive the app ...
+
+# Scan the current screen; returns a list of matched dicts (never raises).
+matches = optics.capture_and_detect(context_label="after_login", test_case="login_flow")
+for m in matches:
+    print(m["error_code"], m["matched_on"], m["match_string"])
+```
+
+`capture_and_detect` is a pure data primitive: it writes no files and swallows
+driver errors (returning `[]`) so a flaky session never breaks your workflow.
+Each returned dict contains `error_code`, `matched_on` (`"match_string"` or
+`"code"`), `match_string`, `description`, `severity`, plus `detected_at`
+(the `context_label`) and, when provided, `test_case`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Robot Framework Usage: usage/robot_usage.md
     - REST API Usage: usage/REST_API_usage.md
     - MCP Usage: usage/mcp_usage.md
+    - Error Detection: usage/error_detection.md
   - Architecture:
     - Architecture Overview: architecture.md
     - Components: architecture/components.md

--- a/optics_framework/common/Junit_eventhandler.py
+++ b/optics_framework/common/Junit_eventhandler.py
@@ -113,7 +113,6 @@ class JUnitEventHandler(EventSubscriber):
         self.testsuites = ET.Element("testsuites")
         self.session_suites: Dict[str, ET.Element] = {}
         self.testcase_cases: Dict[str, ET.Element] = {}
-        self.keyword_elements: Dict[str, List[ET.Element]] = {}  # per testcase
         self.start_times: Dict[str, float] = {}
         self.module_names: Dict[str, str] = {}
         self.module_elements: Dict[str, ET.Element] = {}
@@ -170,9 +169,6 @@ class JUnitEventHandler(EventSubscriber):
             elapsed = event_time - self.start_times.get(event.entity_id, event_time)
             testcase.set("time", f"{elapsed:.2f}")
             self._update_testcase_status(testcase, event, session_suite)
-            # Attach all collected keywords as children
-            for kw_element in self.keyword_elements.get(event.entity_id, []):
-                testcase.append(kw_element)
 
             total_time = float(session_suite.get("time", "0")) + elapsed
             session_suite.set("time", f"{total_time:.2f}")
@@ -180,7 +176,6 @@ class JUnitEventHandler(EventSubscriber):
             # cleanup
             del self.testcase_cases[event.entity_id]
             del self.start_times[event.entity_id]
-            del self.keyword_elements[event.entity_id]
             if event.entity_id in self.module_names:
                 del self.module_names[event.entity_id]
 
@@ -227,11 +222,6 @@ class JUnitEventHandler(EventSubscriber):
                 log_element = ET.SubElement(kw_element, "log")
                 log_element.text = senitised_message
 
-        if event.parent_id not in self.keyword_elements:
-            self.keyword_elements[event.parent_id] = []
-        self.keyword_elements[event.parent_id].append(kw_element)
-
-
     def _update_testcase_status(self, testcase: ET.Element, event: Event, testsuite: ET.Element) -> None:
         testcase.set("status", event.status.value)
         if event.status == EventStatus.FAIL:
@@ -249,6 +239,35 @@ class JUnitEventHandler(EventSubscriber):
             ET.SubElement(testcase, "skipped")
             testsuite.set("skipped", str(
                 int(testsuite.get("skipped", "0")) + 1))
+
+    def add_detected_errors(self, session_id: str, detected: list) -> None:
+        """Insert a synthetic testcase with <failure> elements for detected on-screen errors.
+
+        Using a real testcase (rather than <properties>) means standard CI tools
+        (Jenkins, GitLab CI, GitHub Actions) will surface the failures and mark
+        the build accordingly.
+        """
+        session_suite = self.session_suites.get(session_id)
+        if session_suite is None or not detected:
+            return
+        testcase = ET.SubElement(
+            session_suite, "testcase",
+            name="on-screen-error-detection",
+            classname=f"session_{session_id}",
+            time="0",
+        )
+        for err in detected:
+            parts = filter(None, [
+                err["error_code"],
+                err.get("severity", ""),
+                err.get("match_string", ""),
+                err.get("description", ""),
+            ])
+            msg = " | ".join(parts)
+            failure = ET.SubElement(testcase, "failure", message=msg, type="OnScreenError")
+            failure.text = msg
+        session_suite.set("tests", str(int(session_suite.get("tests", "0")) + 1))
+        session_suite.set("failures", str(int(session_suite.get("failures", "0")) + len(detected)))
 
     def flush(self):
         try:

--- a/optics_framework/common/error_detection.py
+++ b/optics_framework/common/error_detection.py
@@ -1,0 +1,119 @@
+"""Shared on-screen error-detection primitives.
+
+Used by both the CLI/TestRunner path (`_capture_end_of_run_artifacts`) and the
+library `Optics` class (`capture_and_detect`) so the matching logic lives in
+one place.
+"""
+import re
+import xml.etree.ElementTree as ET  # nosec B405
+from typing import Dict, List, Optional
+
+from optics_framework.common.logging_config import internal_logger
+
+try:
+    from bs4 import BeautifulSoup as _BeautifulSoup
+    _BS4_AVAILABLE = True
+except ImportError:
+    _BeautifulSoup = None  # type: ignore[assignment,misc]
+    _BS4_AVAILABLE = False
+
+# Attributes in mobile XML (Appium/XCUITest) that carry user-visible text.
+# NOTE: kept platform-neutral on purpose — these names are common across
+# Android (uiautomator) and iOS (XCUITest) page sources. Add new on-screen-text
+# attributes here as other element sources are supported.
+_MOBILE_TEXT_ATTRS = ("text", "content-desc", "label", "value", "hint", "name")
+
+# Regex fallback for when the XML is malformed and ElementTree can't parse it.
+# The leading ``(?<![\w-])`` ensures we only match a *whole* attribute name and
+# never a suffix of a longer one — e.g. ``data-text``, ``aria-label`` and
+# ``tab-name`` must NOT match ``text``/``label``/``name``.
+_MOBILE_TEXT_ATTRS_RE = re.compile(
+    r'(?<![\w-])(?:text|content-desc|label|value|hint|name)="([^"]*)"'
+)
+
+
+def extract_visible_text(page_source: str) -> str:
+    """Extract only user-visible text from a page source string.
+
+    For HTML (Selenium/Playwright): strips all tags via BeautifulSoup,
+    returning only rendered text content.  Returns ``""`` when bs4 is
+    unavailable or parsing fails — raw HTML is never returned as it would
+    cause severe false positives (CSS class names like ``class="error"``).
+
+    For Appium / mobile XML: parses via ElementTree and collects values of
+    the attributes that carry on-screen text (text, content-desc, label,
+    value, hint, name), ignoring resource-ids, class names, bounds, and
+    other metadata.  Falls back to regex extraction when the XML is
+    malformed.
+    """
+    stripped = page_source.lstrip()
+    if stripped.lower().startswith(("<html", "<!doctype")):
+        if not _BS4_AVAILABLE or _BeautifulSoup is None:
+            internal_logger.warning(
+                "beautifulsoup4 is not installed; cannot extract visible text "
+                "from HTML page source. Install the 'beautifulsoup4' package to "
+                "enable HTML error detection."
+            )
+            return ""
+        # Only guard against malformed-markup parse failures here — the import
+        # is handled at module load, so this never masks an ImportError.
+        try:
+            return _BeautifulSoup(page_source, "lxml").get_text(separator=" ", strip=True)
+        except (ValueError, TypeError) as exc:
+            internal_logger.warning("Failed to parse HTML page source: %s", exc)
+            return ""
+
+    # Mobile / Appium XML — prefer ElementTree over regex.
+    try:
+        root = ET.fromstring(page_source)  # nosec B314
+        texts: List[str] = []
+        for elem in root.iter():
+            for attr in _MOBILE_TEXT_ATTRS:
+                val = (elem.get(attr) or "").strip()
+                if val:
+                    texts.append(val)
+        return " ".join(texts)
+    except ET.ParseError:
+        return " ".join(_MOBILE_TEXT_ATTRS_RE.findall(page_source))
+
+
+def detect_errors_in_text(
+    searchable: str,
+    error_definitions: Dict[str, Dict[str, str]],
+    context_label: Optional[str] = None,
+    test_case: Optional[str] = None,
+) -> List[Dict]:
+    """OR-match each error definition's ``match_string`` OR ``error_code`` against ``searchable``.
+
+    Matching is **case-insensitive substring** matching — the ``match_string``
+    value (and the ``error_code``) are treated as plain text and tested with
+    ``in``; they are *not* interpreted as regular expressions or glob patterns.
+
+    Returns a list of matched dicts of shape
+    ``{error_code, matched_on, match_string, description, severity, ...}``.
+    When ``context_label`` is provided, each entry also carries
+    ``detected_at=context_label``; when ``test_case`` is provided, the entry
+    carries ``test_case=...``. These two keys are the only ones that vary
+    between callers; the core fields are always present.
+
+    ``matched_on`` is ``"match_string"`` when the ``match_string`` column
+    triggered the match, or ``"code"`` when only the ``error_code`` substring
+    was present.
+    """
+    searchable_lower = searchable.lower()
+    matched: List[Dict] = []
+    for code, meta in error_definitions.items():
+        match_string = meta.get("match_string", "")
+        matched_on: Optional[str] = None
+        if match_string and match_string.lower() in searchable_lower:
+            matched_on = "match_string"
+        elif code and code.lower() in searchable_lower:
+            matched_on = "code"
+        if matched_on:
+            entry: Dict = {"error_code": code, "matched_on": matched_on, **meta}
+            if context_label:
+                entry["detected_at"] = context_label
+            if test_case:
+                entry["test_case"] = test_case
+            matched.append(entry)
+    return matched

--- a/optics_framework/common/models.py
+++ b/optics_framework/common/models.py
@@ -303,3 +303,18 @@ class TemplateData(BaseModel):
 
     def get_template_path(self, name: str) -> Optional[str]:
         return self.templates.get(name)
+
+
+class ErrorDefinitions(BaseModel):
+    """Stores user-defined error strings for end-of-run screen detection.
+
+    ``match_string`` is matched against on-screen text as a case-insensitive
+    substring (not a regex). See ``error_detection.detect_errors_in_text``.
+    """
+    errors: Dict[str, Dict[str, str]] = Field(default_factory=dict)
+
+    def add_error(self, code: str, match_string: str, description: str = "", severity: str = ""):
+        self.errors[code] = {"match_string": match_string, "description": description, "severity": severity}
+
+    def get_all(self) -> Dict[str, Dict[str, str]]:
+        return self.errors

--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -60,7 +60,7 @@ class DataReader(ABC):
         :return: True if the parameter is in key=value format, False otherwise.
         :rtype: bool
         """
-        return "=" in param and not (param.startswith("/") or param.startswith("//") or param.startswith("("))
+        return "=" in param and not param.startswith(("/", "//", "("))
 
     @abstractmethod
     def read_test_cases(self, file_path: str) -> dict:
@@ -202,6 +202,25 @@ class CSVDataReader(DataReader):
                     elements[element_name] = []
                 elements[element_name].extend(element_ids)
         return elements
+
+    def read_error_definitions(self, file_path: str) -> dict:
+        """Read error_code, match_string, description, severity columns from a CSV file.
+
+        ``match_string`` is matched as a case-insensitive substring against
+        on-screen text (not a regex).
+        """
+        result = {}
+        rows = self.read_file(file_path)
+        for row in rows:
+            code = row.get("error_code", "").strip()
+            match_string = row.get("match_string", "").strip()
+            if code and match_string:
+                result[code] = {
+                    "match_string": match_string,
+                    "description": row.get("description", "").strip(),
+                    "severity": row.get("severity", "").strip(),
+                }
+        return result
 
 
 class YAMLDataReader(DataReader):

--- a/optics_framework/common/runner/test_runnner.py
+++ b/optics_framework/common/runner/test_runnner.py
@@ -1,3 +1,5 @@
+import json
+import os
 import time
 import uuid
 import asyncio
@@ -40,6 +42,13 @@ from optics_framework.common.events import (
     Event,
 )
 from optics_framework.common.runner.data_reader import DataReader
+from optics_framework.common.strategies import StrategyManager
+from optics_framework.common import utils
+from optics_framework.common.Junit_eventhandler import get_junit_handler_registry
+from optics_framework.common.error_detection import (
+    extract_visible_text,
+    detect_errors_in_text,
+)
 
 
 class Runner:
@@ -475,6 +484,71 @@ class TestRunner(Runner):
         )
         self._update_status(keyword_result, "FAIL", time.time() - start_time, test_case_result.name)
 
+    def _capture_end_of_run_artifacts(self) -> None:
+        try:
+            output_dir = self.session.config.execution_output_path
+            strategy_manager = StrategyManager(
+                self.session.optics.get_element_source(),
+                self.session.optics.get_text_detection(),
+                self.session.optics.get_image_detection(),
+            )
+            self._save_end_of_run_screenshot(strategy_manager, output_dir)
+            page_source, timestamp = self._save_end_of_run_pagesource(strategy_manager, output_dir)
+            self._run_end_of_run_detection(page_source, timestamp, output_dir)
+        except Exception as e:
+            internal_logger.warning("End-of-run artifact capture failed: %s", e)
+
+    def _save_end_of_run_screenshot(self, strategy_manager: StrategyManager, output_dir: str) -> None:
+        try:
+            screenshot = strategy_manager.capture_screenshot()
+            utils.save_screenshot(screenshot, "end_of_run", output_dir)
+            internal_logger.debug("End-of-run screenshot saved.")
+        except Exception as e:
+            internal_logger.warning("Failed to capture end-of-run screenshot: %s", e)
+
+    def _save_end_of_run_pagesource(
+        self, strategy_manager: StrategyManager, output_dir: str
+    ) -> tuple[Optional[str], Optional[str]]:
+        try:
+            page_source, timestamp = strategy_manager.capture_pagesource()
+            if page_source.lstrip().lower().startswith(("<html", "<!doctype")):
+                utils.save_page_source_html(page_source, timestamp, output_dir)
+            else:
+                utils.save_page_source(page_source, timestamp, output_dir)
+            internal_logger.debug("End-of-run page source saved.")
+            return page_source, timestamp
+        except Exception as e:
+            internal_logger.warning("Failed to capture end-of-run page source: %s", e)
+            return None, None
+
+    def _run_end_of_run_detection(
+        self, page_source: Optional[str], timestamp: Optional[str], output_dir: str
+    ) -> None:
+        try:
+            error_defs = getattr(self.session, "error_definitions", None)
+            if not (error_defs and error_defs.get_all() and page_source):
+                return
+            searchable = extract_visible_text(page_source)
+            matched = detect_errors_in_text(searchable, error_defs.get_all(), context_label="end_of_run")
+            if not matched:
+                internal_logger.debug("No user-defined errors detected in end-of-run page source.")
+                return
+            for m in matched:
+                execution_logger.warning(
+                    "ON-SCREEN ERROR DETECTED — code: %s | matched_on: %s | match_string: '%s' | severity: %s | %s",
+                    m["error_code"], m["matched_on"], m.get("match_string", ""),
+                    m.get("severity", ""), m.get("description", ""),
+                )
+            out_path = os.path.join(output_dir, f"detected_errors_{self.session_id}.json")
+            with open(out_path, "w", encoding="utf-8") as f:
+                json.dump({"timestamp": timestamp, "detected": matched}, f, indent=2)
+            internal_logger.debug("Detected errors written to %s", out_path)
+            handler = get_junit_handler_registry().get_handler(self.session_id)
+            if handler:
+                handler.add_detected_errors(self.session_id, matched)
+        except Exception as e:
+            internal_logger.warning("Error detection scan failed: %s", e)
+
     async def _process_module(
         self,
         module_node: ModuleNode,
@@ -733,6 +807,7 @@ class TestRunner(Runner):
             await self.execute_test_case(current.name)
             current = current.next
         self.result_printer.stop_live()
+        self._capture_end_of_run_artifacts()
 
     async def dry_run_all(self) -> None:
         current = self.test_cases

--- a/optics_framework/common/runner/test_runnner.py
+++ b/optics_framework/common/runner/test_runnner.py
@@ -701,7 +701,7 @@ class TestRunner(Runner):
         await self._send_event(
             "test_case",
             current,
-            EventStatus.FAIL,
+            EventStatus.PASS,
             start_time=start_time,
             end_time=time.time(),
             elapsed=time.time() - start_time,

--- a/optics_framework/common/session_manager.py
+++ b/optics_framework/common/session_manager.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from optics_framework.common.Junit_eventhandler import setup_junit, cleanup_junit
 from optics_framework.common.config_handler import Config, ConfigHandler
 from optics_framework.common.optics_builder import OpticsBuilder
-from optics_framework.common.models import TestCaseNode, ElementData, ApiData, ModuleData, TemplateData
+from optics_framework.common.models import TestCaseNode, ElementData, ApiData, ModuleData, TemplateData, ErrorDefinitions
 from optics_framework.common.eventSDK import EventSDK
 from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.events import get_event_manager_registry
@@ -55,11 +55,12 @@ class SessionHandler(ABC):
     """Abstract interface for session management."""
     @abstractmethod
     def create_session(self, config: Config,
-                       test_cases: TestCaseNode,
-                       modules: ModuleData,
-                       elements: ElementData,
-                       apis: ApiData,
-                       templates: Optional[TemplateData] = None) -> str:
+                       test_cases: Optional[TestCaseNode],
+                       modules: Optional[ModuleData],
+                       elements: Optional[ElementData],
+                       apis: Optional[ApiData],
+                       templates: Optional[TemplateData] = None,
+                       error_definitions: Optional[ErrorDefinitions] = None) -> str:
         pass
 
     @abstractmethod
@@ -104,7 +105,8 @@ class Session:
                  modules: Optional[ModuleData],
                  elements: Optional[ElementData],
                  apis: Optional[ApiData],
-                 templates: Optional[TemplateData] = None):
+                 templates: Optional[TemplateData] = None,
+                 error_definitions: Optional[ErrorDefinitions] = None):
         self.session_id = session_id
         self.config_handler = ConfigHandler(config)
         self.config = self.config_handler.config
@@ -113,6 +115,7 @@ class Session:
         self.elements = elements
         self.apis = apis
         self.templates = templates
+        self.error_definitions = error_definitions
         self.request_template_overrides: Dict[str, str] = {}
         self.inline_templates: Dict[str, str] = {}
         self._inline_templates_dir: str = tempfile.mkdtemp(prefix="optics_session_")
@@ -153,10 +156,11 @@ class SessionManager(SessionHandler):
                        modules: Optional[ModuleData],
                        elements: Optional[ElementData],
                        apis: Optional[ApiData],
-                       templates: Optional[TemplateData] = None) -> str:
+                       templates: Optional[TemplateData] = None,
+                       error_definitions: Optional[ErrorDefinitions] = None) -> str:
         """Creates a new session with a unique ID."""
         session_id = str(uuid.uuid4())
-        self.sessions[session_id] = Session(session_id, config, test_cases, modules, elements, apis, templates)
+        self.sessions[session_id] = Session(session_id, config, test_cases, modules, elements, apis, templates, error_definitions)
         return session_id
 
     def get_session(self, session_id: str) -> Optional[Session]:

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -580,7 +580,7 @@ class Appium(DriverInterface):
         output = ""
         try:
             internal_logger.info(f"Executing adb command: {' '.join(dumpsys_cmd)}")
-            output = subprocess.check_output(  # nosec - static trusted arguments, not completely a user input, command injection attack is prevented
+            output = subprocess.check_output(  # nosec B603 - static trusted args; package name sourced from session caps
                 dumpsys_cmd,
                 stderr=subprocess.STDOUT,
                 text=True

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -24,6 +24,7 @@ from optics_framework.common.models import (
     TestSuite,
     ModuleData,
     TemplateData,
+    ErrorDefinitions,
 )
 
 
@@ -50,12 +51,12 @@ def discover_templates(project_path: str) -> TemplateData:
     return template_data
 
 
-def find_files(folder_path: str) -> tuple[list[Any], list[Any], list[Any], list[Any], Config | None]:
+def find_files(folder_path: str) -> tuple[list[Any], list[Any], list[Any], list[Any], list[Any], Config | None]:
     """
     Recursively search for CSV and YAML files under `folder_path` and categorize them by content.
 
-    Returns lists of discovered test case, module, element and api files and an optional
-    Config object (if a suitable YAML config is found).
+    Returns lists of discovered test case, module, element, api and error_definitions files
+    and an optional Config object (if a suitable YAML config is found).
     """
     file_collections = _initialize_file_collections()
     config_obj: Config | None = None
@@ -78,6 +79,7 @@ def find_files(folder_path: str) -> tuple[list[Any], list[Any], list[Any], list[
         file_collections["module"],
         file_collections["element"],
         file_collections["api"],
+        file_collections["error_definitions"],
         config_obj,
     )
 
@@ -88,7 +90,8 @@ def _initialize_file_collections():
         'test_case': [],
         'module': [],
         'element': [],
-        'api': []
+        'api': [],
+        'error_definitions': [],
     }
 
 
@@ -146,6 +149,8 @@ def _categorize_file_by_content(file_path: str, file_collections: dict):
         file_collections['element'].append(file_path)
     if "api" in content_type:
         file_collections['api'].append(file_path)
+    if "error_definitions" in content_type:
+        file_collections['error_definitions'].append(file_path)
 
 
 def _identify_csv_content(headers: Optional[Set[str]]) -> Set[str]:
@@ -163,6 +168,8 @@ def _identify_csv_content(headers: Optional[Set[str]]) -> Set[str]:
             content_types.add("modules")
         if {"element_name", "element_id"}.issubset(headers):
             content_types.add("elements")
+        if {"error_code", "match_string"}.issubset(headers):
+            content_types.add("error_definitions")
     return content_types
 
 
@@ -496,6 +503,7 @@ class BaseRunner:
             module_files,
             element_files,
             api_files,
+            error_definition_files,
             config_obj,
         ) = find_files(self.folder_path)
 
@@ -504,6 +512,7 @@ class BaseRunner:
         self._load_modules(module_files)
         self._load_elements(element_files)
         self._load_api_data(api_files)
+        self._load_error_definitions(error_definition_files)
 
         if not self.test_cases_data:
             internal_logger.debug(f"No test cases found in {test_case_files}")
@@ -584,6 +593,13 @@ class BaseRunner:
             reader = self.yaml_reader  # API files are expected to be YAML
             self.api_data = reader.read_api_data(file_path, existing_api_data=self.api_data)
 
+    def _load_error_definitions(self, error_definition_files):
+        self.error_definitions_data: ErrorDefinitions = ErrorDefinitions()
+        for file_path in error_definition_files:
+            raw = self.csv_reader.read_error_definitions(file_path)
+            for code, meta in raw.items():
+                self.error_definitions_data.add_error(code, **meta)
+
     def _load_templates(self):
         """Load template data by discovering image files in the project directory."""
         self.templates_data: TemplateData = TemplateData()
@@ -611,6 +627,7 @@ class BaseRunner:
             self.elements_data,
             self.api_data,
             self.templates_data,
+            self.error_definitions_data,
         )
         self.engine: ExecutionEngine = ExecutionEngine(self.manager)
     async def run(self, mode: str):

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -37,6 +37,7 @@ from optics_framework.common.models import (
     ModuleData,
     ElementData,
     ApiData,
+    ErrorDefinitions,
 )
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -172,7 +173,7 @@ class Optics:
         """
         config_string = config_string.strip()
         try:
-            if config_string.startswith("{") or config_string.startswith("["):
+            if config_string.startswith(("{", "[")):
                 return json.loads(config_string)
             else:
                 return yaml.safe_load(config_string)
@@ -515,6 +516,98 @@ class Optics:
             session.modules.modules[module_name] = module_def
         else:
             raise ValueError("Session does not have a modules store.")
+
+    @keyword("Add Error Definitions")
+    def add_error_definitions(
+        self,
+        source: Union[Dict[str, Dict[str, str]], ErrorDefinitions],
+    ) -> None:
+        """Load user-defined error strings onto the active session.
+
+        Accepts a raw dict ``{code: {match_string, description, severity}}`` or
+        an :class:`ErrorDefinitions` model.  Repeated calls merge into the
+        existing set (later additions overwrite same-code earlier entries).
+
+        ``match_string`` is matched against on-screen text as a case-insensitive
+        substring (not a regex).
+
+        CSV loading is the responsibility of the runner/CLI layer; use the
+        auto-discovered ``error_definitions.csv`` file in the project folder
+        for that path.
+
+        Required before :meth:`capture_and_detect` can return any matches.
+        """
+        if not self.session_id or self.session_id not in self.session_manager.sessions:
+            raise OpticsError(Code.E0101, message=INVALID_SETUP)
+        session = self.session_manager.sessions[self.session_id]
+        if session.error_definitions is None:
+            session.error_definitions = ErrorDefinitions()
+
+        if isinstance(source, ErrorDefinitions):
+            raw = source.get_all()
+        elif isinstance(source, dict):
+            raw = source
+        else:
+            raise TypeError(
+                "add_error_definitions: source must be a dict or ErrorDefinitions instance"
+            )
+        for code, meta in raw.items():
+            session.error_definitions.add_error(
+                code,
+                match_string=meta.get("match_string", ""),
+                description=meta.get("description", ""),
+                severity=meta.get("severity", ""),
+            )
+
+    @keyword("Capture And Detect Errors")
+    def capture_and_detect(
+        self,
+        context_label: str = "end_of_run",
+        test_case: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Capture page source and run on-screen error detection.
+
+        Returns a list of matched error dicts (may be empty). Each entry carries
+        ``error_code``, ``matched_on`` (``"match_string"`` or ``"code"``),
+        ``match_string``, ``description``, ``severity``, and
+        ``detected_at=context_label``; the optional ``test_case`` argument adds a
+        ``test_case`` field on each entry. Matching is case-insensitive substring
+        matching (not regex).
+
+        No files are written; the caller decides where the data lands.
+        Wraps all driver I/O in try/except so a flaky session returns ``[]``
+        instead of raising — this is a diagnostic primitive and must never
+        break the surrounding workflow.
+        """
+        from optics_framework.common.strategies import StrategyManager
+        from optics_framework.common.error_detection import (
+            extract_visible_text,
+            detect_errors_in_text,
+        )
+
+        if not self.session_id or self.session_id not in self.session_manager.sessions:
+            return []
+        session = self.session_manager.sessions[self.session_id]
+        error_defs = getattr(session, "error_definitions", None)
+        if not error_defs or not error_defs.get_all():
+            return []
+        try:
+            sm = StrategyManager(
+                session.optics.get_element_source(),
+                session.optics.get_text_detection(),
+                session.optics.get_image_detection(),
+            )
+            page_source, _ts = sm.capture_pagesource()
+            searchable = extract_visible_text(page_source)
+            return detect_errors_in_text(
+                searchable,
+                error_defs.get_all(),
+                context_label=context_label,
+                test_case=test_case,
+            )
+        except Exception as e:
+            internal_logger.warning("capture_and_detect failed: %s", e)
+            return []
 
     ### AppManagement Methods ###
     @keyword("Launch App")

--- a/optics_framework/samples/contact/test_data/error_definitions.csv
+++ b/optics_framework/samples/contact/test_data/error_definitions.csv
@@ -1,0 +1,11 @@
+error_code,match_string,description,severity
+ERR_001,Unfortunately,App has crashed with a system dialog,critical
+ERR_002,has stopped,App stopped unexpectedly,critical
+ERR_003,No internet connection,Device lost network connectivity,high
+ERR_004,Network error,Network request failed,high
+ERR_005,Connection timed out,Request timed out before completing,high
+ERR_006,Something went wrong,Generic app error screen,medium
+ERR_007,An error occurred,Generic error message detected,medium
+ERR_008,Page not found,404 or missing page error,medium
+ERR_009,Session expired,User session timed out,high
+ERR_010,Permission denied,Access control error on screen,medium

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,6 +197,29 @@ test-tox = ["celery", "click", "docutils (>=0.22.0)", "equinox ; sys_platform ==
 test-tox-coverage = ["coverage (>=5.5)"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"},
+    {file = "beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"},
+]
+
+[package.dependencies]
+soupsieve = ">=1.6.1"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "cachetools"
 version = "7.1.3"
 description = "Extensible memoizing collections and decorators"
@@ -1228,7 +1251,7 @@ description = "A minimal low-level HTTP client."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"mcp\" or extra == \"llm\""
+markers = "extra == \"llm\" or extra == \"mcp\""
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1251,7 +1274,7 @@ description = "The next generation HTTP client."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"mcp\" or extra == \"llm\""
+markers = "extra == \"llm\" or extra == \"mcp\""
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -3063,9 +3086,10 @@ typing-extensions = ">=4.14.1"
 name = "pydantic-settings"
 version = "2.14.2"
 description = "Settings management using Pydantic"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\""
 files = [
     {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
     {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
@@ -3292,9 +3316,10 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pyt
 name = "python-dotenv"
 version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"mcp\""
 files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
@@ -4034,6 +4059,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.4"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
+    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.0.3"
 description = "SSE plugin for Starlette"
@@ -4503,7 +4540,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"mcp\" or extra == \"llm\""
+markers = "extra == \"llm\" or extra == \"mcp\""
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -4678,4 +4715,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "cddede14a6f39a5859006e37b4641e4ed9d9daec3f0d3b145badf83883a83b54"
+content-hash = "b84096b9ab4e0a0564c1c407a22f81702b72ec3d19ff5027380b84d75ae89dea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pydantic = "^2.11.2"
 scikit-image = "^0.25.2"
 uvicorn = ">=0.35,<0.43"
 jsonpath-ng = "^1.7.0"
+beautifulsoup4 = "^4.12"
 google-genai = { version = ">=2.0.0,<3.0.0", optional = true }
 # >=3.4.2: earlier 3.4.x omit the starlette>=1.0 pin, letting the resolver keep
 # starlette 0.48 (a combo fastmcp's own code is incompatible with at runtime).


### PR DESCRIPTION
## What

Adds **on-screen error detection**: a project can declare a set of error strings, and the framework scans the screen at the end of a run (and on demand from the library API) and reports any that appear.

## How it works

- Define errors in an auto-discovered `error_definitions.csv` (`error_code, match_string, description, severity`).
- The runner loads them onto the session; after the live run it captures a final screenshot + page source and scans the **visible** text for matches.
- `match_string` (or the code itself) is matched as a **case-insensitive substring** — not a regex. HTML is stripped via BeautifulSoup so CSS class names can't cause false positives; mobile XML is parsed for text-bearing attributes only.
- Matches are logged at WARNING, written to `detected_errors_<session>.json`, and surfaced as a failing JUnit testcase so CI (Jenkins/GitLab/GitHub Actions) fails the build.
- Library/Robot consumers get the same capability via two keywords: **Add Error Definitions** and **Capture And Detect Errors**.

## Changes

| Area | Change |
|------|--------|
| `common/error_detection.py` | New shared `extract_visible_text` / `detect_errors_in_text` primitives |
| `common/models.py` | `ErrorDefinitions` model |
| `common/runner/data_reader.py` | Parse `error_definitions.csv` |
| `helper/execute.py` | Auto-discover and load error definition files |
| `common/session_manager.py` | Thread error definitions through `Session` |
| `common/runner/test_runnner.py` | Capture end-of-run artifacts and run the scan |
| `common/Junit_eventhandler.py` | Report detected errors as JUnit failures |
| `optics.py` | Expose the two library keywords |
| `samples/contact/...` | Example `error_definitions.csv` |
| `docs/usage/error_detection.md` | Usage guide |

Also folds in two small fixes found along the way: a completed test case now emits `PASS` (was `FAIL`) on its completion event, and the bandit `nosec` on the adb dumpsys call is scoped to `B603` with a real justification.

## Notes

This supersedes #285 with a cleaner, incremental commit history; the net diff is identical.
