### PR TITLE
feat(live): incremental /save and NL curation for cleaner recordings

### DIFF
--- a/docs/usage/live_usage.md
+++ b/docs/usage/live_usage.md
@@ -80,7 +80,7 @@ sleep 5
 
 | Command          | Description |
 |------------------|-------------|
-| `/save <name>`   | Save the recorded actions to `modules/<name>.csv` + `test_cases/<name>.csv`, **and** snapshot every screenshot/artifact the framework generated this session to `execution_output/<name>/`. Re-saving updates the snapshot. |
+| `/save <test_case> <module_name>` | Save the recorded actions as `<module_name>` in `modules/modules.csv` and add a `(<test_case>, <module_name>)` row to `test_cases/test_cases.csv`. A header-only `elements/elements.csv` stub is created if missing. All three files use fixed names and are **appended** to when they already exist, so you can build a suite one module at a time. A successful save **clears the recording buffer**, so the next actions become the next module. If `<module_name>` or `<test_case>` already exists, the save is refused with a prompt — re-run the identical `/save` to append, or pick a different name. Session screenshots/artifacts are also snapshotted to `execution_output/<module_name>/`. |
 | `/device [id]`   | **Appium sessions only.** List all connected **Android** (`adb`) and **iOS** (`idevice_id`) devices, each labelled by platform; with no argument, pick one to switch the active device's `udid`. The chosen device must match the session's configured platform. For Selenium/Playwright it reports that switching doesn't apply (the target is the configured browser). |
 | `/elements`      | Open a read-only popup of named elements and their locators (Esc closes). |
 | `/screenshot`    | Capture the current device screen to a file and note the path in the history. |
@@ -108,7 +108,15 @@ screenshot **and** a condensed UI hierarchy of the on-screen elements (their tex
 content-desc, resource ids, bounds, and flags — when the driver exposes a page source),
 and drives keywords step-by-step until the goal is reached; `Ctrl-X` aborts. A fully
 successful run is recorded and `/save`-able like any manual session. It works with whatever
-driver your config uses (Appium/Selenium/Playwright). Three steps to enable it:
+driver your config uses (Appium/Selenium/Playwright).
+
+When an instruction completes, the recorded steps are **curated** before they enter the
+`/save` buffer: a final LLM pass keeps only the steps that contribute to the goal and drops
+the agent's dead-ends, backtracks, and no-op gestures — so what you save is a minimal,
+replayable script, not a transcript of everything it tried. An incomplete instruction
+(failed/aborted/step-limit) records nothing. If the curation pass can't produce a usable
+result it safely falls back to keeping every successful step, so a working recording is never
+lost. Three steps to enable AI mode:
 
 **1. Install the optional LLM extra** (the SDK is not in the base install):
 
@@ -153,9 +161,11 @@ you get a clear install hint.
 ## Recording & saving
 
 Recording is always on. Every successful keyword is appended to an in-memory buffer
-in the order it ran. The buffer is only written to disk when you run `/save`. If you
-`/quit` with unsaved actions, you are warned once — run `/save <name>` to keep them,
-or `/quit` again to discard and exit.
+in the order it ran. The buffer is only written to disk when you run
+`/save <test_case> <module_name>`, which persists the buffered actions as one module
+and then **clears the buffer** so the next actions form the next module. If you
+`/quit` with unsaved actions, you are warned once — run `/save <test_case> <module_name>`
+to keep them, or `/quit` again to discard and exit.
 
 ### Screenshots are saved automatically
 
@@ -167,9 +177,9 @@ session these are written to a **persistent per-session folder**,
 matches the session log (`logs/optics_live_<timestamp>.log`) so the two correlate. An
 empty session folder (no screenshots captured) is removed on exit; otherwise it's kept.
 
-`/save <name>` additionally bundles a **copy** of that session's screenshots into
-`execution_output/<name>/`, alongside the saved module, so a saved test is
-self-contained. Re-running `/save` with the same name refreshes the copy.
+`/save <test_case> <module_name>` additionally bundles a **copy** of that session's
+screenshots into `execution_output/<module_name>/`, alongside the saved module, so a
+saved test is self-contained. Re-running `/save` for the same module refreshes the copy.
 
 > The screenshots that the AI mode sends to the model are captured separately and are
 > not written to disk; what you see in `screenshots/session_<timestamp>/` are the

--- a/optics_framework/common/nl_agent.py
+++ b/optics_framework/common/nl_agent.py
@@ -57,10 +57,7 @@ class AgentResult:
     status: str  # "done" | "failed" | "exhausted" | "aborted"
     steps: List[AgentStep] = field(default_factory=list)
     message: Optional[str] = None
-    # The keyword steps to commit to the /save buffer. Normally every step that succeeded,
-    # in order. On a "done" run with curation enabled (see NaturalLanguageAgent
-    # curate_on_done) this is the minimal pruned subset that reproduces the goal, not
-    # literally every step that passed.
+    # Steps to commit to /save: every successful step, or the curated subset if pruned.
     successful_steps: List[Tuple[str, List[str]]] = field(default_factory=list)
 
 
@@ -220,9 +217,7 @@ coordinate guessing has already failed).
 _MAX_THOUGHT_CHARS = 160
 
 
-# Curation schema. After an instruction is fulfilled, the model is asked to reduce the
-# steps it ran to the minimal subset that reproduces the goal. Flat (no anyOf) for the same
-# Gemini-compatibility reasons as ACTION_SCHEMA.
+# Flat (no anyOf) for the same Gemini-compatibility reasons as ACTION_SCHEMA.
 CURATION_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -287,10 +282,7 @@ class NaturalLanguageAgent:
         self.max_consecutive_failures = max_consecutive_failures
         self.max_blind_repeats = max_blind_repeats
         self.non_verifying_keywords = non_verifying_keywords
-        # When True, a successful ("done") run gets an extra LLM pass that prunes the
-        # recorded steps to the minimal set reproducing the goal (see
-        # _curate_successful_steps). Off by default so the agent stays a pure primitive;
-        # LiveController enables it because /save wants a minimal replayable script.
+        # Off by default; LiveController enables it so /save gets a minimal script.
         self.curate_on_done = curate_on_done
 
     def run(

--- a/optics_framework/common/nl_agent.py
+++ b/optics_framework/common/nl_agent.py
@@ -57,6 +57,10 @@ class AgentResult:
     status: str  # "done" | "failed" | "exhausted" | "aborted"
     steps: List[AgentStep] = field(default_factory=list)
     message: Optional[str] = None
+    # The keyword steps to commit to the /save buffer. Normally every step that succeeded,
+    # in order. On a "done" run with curation enabled (see NaturalLanguageAgent
+    # curate_on_done) this is the minimal pruned subset that reproduces the goal, not
+    # literally every step that passed.
     successful_steps: List[Tuple[str, List[str]]] = field(default_factory=list)
 
 
@@ -216,6 +220,45 @@ coordinate guessing has already failed).
 _MAX_THOUGHT_CHARS = 160
 
 
+# Curation schema. After an instruction is fulfilled, the model is asked to reduce the
+# steps it ran to the minimal subset that reproduces the goal. Flat (no anyOf) for the same
+# Gemini-compatibility reasons as ACTION_SCHEMA.
+CURATION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keep": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "1-based indices of the CANDIDATE steps to keep, in any order.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Brief justification for which steps were dropped.",
+        },
+    },
+    "required": ["keep", "reason"],
+    "propertyOrdering": ["keep", "reason"],
+}
+
+
+CURATION_SYSTEM_PROMPT = """\
+You are cleaning up a UI-automation recording. An instruction was just fulfilled by running a \
+sequence of keywords, one at a time. Some of those keywords were dead-ends, backtracks (e.g. \
+navigating somewhere then pressing back), overshoot-then-correct gestures, or no-op actions that \
+did not contribute to the final result.
+
+Your job: return the MINIMAL ordered subset of the CANDIDATE steps that a fresh run must execute, \
+top to bottom, to reproduce the goal deterministically. Drop steps that do not contribute.
+
+RULES:
+- `keep` is a list of the 1-based CANDIDATE step numbers to keep. Only CANDIDATE numbers are valid.
+- Never reference the FAILED context steps — they already failed and are excluded.
+- Order in `keep` does not matter; it will be re-sorted into execution order.
+- When in doubt, KEEP the step. Never drop a step that might be needed — a broken script is far \
+worse than a slightly long one. If every step contributed, keep them all.
+"""
+
+
 class NaturalLanguageAgent:
     """Bounded ReAct loop translating an instruction into keyword executions."""
 
@@ -232,6 +275,7 @@ class NaturalLanguageAgent:
         max_consecutive_failures: int = 3,
         max_blind_repeats: int = 3,
         non_verifying_keywords: Tuple[str, ...] = DEFAULT_NON_VERIFYING_KEYWORDS,
+        curate_on_done: bool = False,
     ) -> None:
         self.llm = llm
         self.screenshot_provider = screenshot_provider
@@ -243,6 +287,11 @@ class NaturalLanguageAgent:
         self.max_consecutive_failures = max_consecutive_failures
         self.max_blind_repeats = max_blind_repeats
         self.non_verifying_keywords = non_verifying_keywords
+        # When True, a successful ("done") run gets an extra LLM pass that prunes the
+        # recorded steps to the minimal set reproducing the goal (see
+        # _curate_successful_steps). Off by default so the agent stays a pure primitive;
+        # LiveController enables it because /save wants a minimal replayable script.
+        self.curate_on_done = curate_on_done
 
     def run(
         self,
@@ -295,7 +344,14 @@ class NaturalLanguageAgent:
 
         if step.action == "done":
             state.history.append(step)
-            return AgentResult("done", state.history, step.reason or "Goal reached.", state.successful)
+            successful = state.successful
+            message = step.reason or "Goal reached."
+            if self.curate_on_done:
+                curated = self._curate_successful_steps(instruction, state)
+                if curated is not None:
+                    message = f"{message} (kept {len(curated)} of {len(state.successful)} steps)"
+                    successful = curated
+            return AgentResult("done", state.history, message, successful)
         if step.action == "fail":
             state.history.append(step)
             return AgentResult("failed", state.history, step.reason or "Model gave up.", state.successful)
@@ -462,4 +518,88 @@ class NaturalLanguageAgent:
 
         lines.append("")
         lines.append("The attached image is the CURRENT screen. Decide the SINGLE next action as JSON.")
+        return "\n".join(lines)
+
+    def _curate_successful_steps(
+        self, instruction: str, state: "_RunState"
+    ) -> Optional[List[Tuple[str, List[str]]]]:
+        """Prune ``state.successful`` to the minimal subset that reproduces the goal.
+
+        Returns the curated ``(keyword, params)`` list, or ``None`` to signal "keep all"
+        (the caller commits ``state.successful`` unchanged). Every abnormal outcome — too
+        few steps to prune, an LLM error, a malformed response, no valid indices, or the
+        model keeping everything — returns ``None``, so a working recording is never lost.
+        """
+        n = len(state.successful)
+        if n <= 1:
+            return None  # nothing to prune
+
+        prompt = self._build_curation_prompt(instruction, state)
+        try:
+            raw = self.llm.generate_json(
+                prompt, CURATION_SCHEMA, images=None,
+                system=CURATION_SYSTEM_PROMPT, temperature=0.0,
+            )
+        except OpticsError as exc:
+            internal_logger.debug("NL curation: LLM error, keeping all steps: %s", exc.message)
+            return None
+        except Exception as exc:  # noqa: BLE001 - curation must never break a working recording
+            internal_logger.debug("NL curation: unexpected error, keeping all steps: %s", exc)
+            return None
+
+        if not isinstance(raw, dict):
+            return None
+        keep_raw = raw.get("keep")
+        if not isinstance(keep_raw, list):
+            return None
+
+        # Coerce to 0-based indices: reject bools/non-ints, range-check, dedup, sort.
+        seen: set[int] = set()
+        indices: List[int] = []
+        for value in keep_raw:
+            if isinstance(value, bool) or not isinstance(value, int):
+                continue
+            zero = value - 1  # prompt uses 1-based candidate numbering
+            if 0 <= zero < n and zero not in seen:
+                seen.add(zero)
+                indices.append(zero)
+        if not indices or len(indices) == n:
+            return None  # dropped everything, or kept everything -> keep all
+        indices.sort()
+        curated = [state.successful[i] for i in indices]
+        internal_logger.debug(
+            "NL curation: kept %d of %d steps (%s)", len(curated), n, raw.get("reason", "")
+        )
+        return curated
+
+    def _build_curation_prompt(self, instruction: str, state: "_RunState") -> str:
+        """Text-only prompt for the curation pass.
+
+        CANDIDATE steps are the successful keyword steps, numbered 1-based so index ``k``
+        maps to ``state.successful[k-1]``. Failed keyword steps are listed as read-only
+        context (no number) so the model can recognise overshoot/correction, but they are
+        not selectable.
+        """
+        lines = [
+            f"INSTRUCTION (goal that was achieved): {instruction}",
+            "",
+            "CANDIDATE STEPS (selectable — put these numbers in `keep`):",
+        ]
+        candidate = 0
+        for step in state.history:
+            if step.action != "keyword" or step.exec_result is None:
+                continue
+            thought = step.thought[:_MAX_THOUGHT_CHARS]
+            if step.exec_result.ok:
+                candidate += 1
+                lines.append(f"  {candidate}. {step.keyword} {step.params}  | {thought}")
+            else:
+                fail = step.observation or (step.exec_result.message or "FAIL")
+                lines.append(f"  - [FAILED, not selectable] {step.keyword} {step.params} -> {fail}")
+        lines.append("")
+        lines.append(
+            "Return `keep` = the 1-based CANDIDATE numbers to run, in any order, that reproduce "
+            "the goal. Drop dead-ends, backtracks, overshoot-then-correct, and no-op steps. When "
+            "unsure, KEEP."
+        )
         return "\n".join(lines)

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -153,6 +153,36 @@ def keyword_to_title(func_name: str) -> str:
     return " ".join(word.capitalize() for word in func_name.split("_"))
 
 
+class SaveConflictError(Exception):
+    """Raised by :meth:`LiveController.save` when the requested test case or module
+    name already exists in the standard CSVs and the caller has not opted into
+    appending.
+
+    ``conflicts`` is a list of ``(kind, name)`` tuples, e.g. ``[("module", "login")]``,
+    so the caller can ask the user whether to append or pick a new name.
+    """
+
+    def __init__(self, conflicts: List[Tuple[str, str]]):
+        self.conflicts = conflicts
+        joined = ", ".join(f"{kind} {name!r}" for kind, name in conflicts)
+        super().__init__(f"Already exists: {joined}")
+
+
+@dataclass
+class SaveResult:
+    """Outcome of a successful :meth:`LiveController.save`."""
+
+    modules_path: str
+    test_cases_path: str
+    elements_path: str
+    artifacts_path: Optional[str]
+    test_case: str
+    module_name: str
+    step_count: int
+    appended_module: bool
+    appended_test_case: bool
+
+
 _CONFIG_KEYS = frozenset({
     "driver_sources", "element_sources", "elements_sources",
     "text_detection", "image_detection", "llm_models",
@@ -729,67 +759,172 @@ class LiveController:
 
     # -- Recording / save ---------------------------------------------------------
 
-    def save(self, name: str) -> Tuple[str, str, Optional[str]]:
-        """Persist the recorded actions and their accompanying artifacts.
+    def save(
+        self,
+        test_case: str,
+        module_name: str,
+        *,
+        allow_append: bool = False,
+    ) -> SaveResult:
+        """Persist the recorded actions to the project's standard CSV files.
 
-        Writes:
+        Everything is written to three fixed-name files, appending when they already
+        exist so a session can build up a test suite one module at a time:
 
-        * ``modules/<name>.csv`` — Title Case keywords + ``param_N`` columns, matching
-          :class:`CSVDataReader` exactly.
-        * ``test_cases/<name>.csv`` — a single test case referencing the module.
-        * ``execution_output/<name>/`` — a snapshot of every artifact the framework
-          generated during the session so far (the auto pre-/post-action screenshots
-          written by ``@with_self_healing``, AOI captures, annotated detections,
-          per-session logs). These otherwise live only in the tempdir and would
-          vanish on ``/quit``.
+        * ``modules/modules.csv`` — the recorded keywords as one module named
+          ``module_name`` (Title Case ``module_step`` + ``param_N`` columns, matching
+          :class:`CSVDataReader`).
+        * ``test_cases/test_cases.csv`` — a ``(test_case, module_name)`` row linking the
+          test case to the module it should run.
+        * ``elements/elements.csv`` — a header-only stub (``Element_Name,Element_ID``)
+          created once so the standard file exists for manual editing (live recording
+          captures inline locators, not named elements).
 
-        Artifacts are **copied** (not moved) so further keyword runs continue to
-        accumulate into the same tempdir; re-saving captures the up-to-date set.
+        Session artifacts are snapshotted to ``execution_output/<module_name>/`` — the
+        auto pre-/post-action screenshots written by ``@with_self_healing``, AOI
+        captures, annotated detections, per-session logs. They are **copied** (not
+        moved) so further keyword runs keep accumulating in the tempdir.
 
-        Returns ``(modules_path, test_cases_path, artifacts_path or None)``.
-        ``artifacts_path`` is ``None`` only when the session has produced no
-        artifacts yet, not when the copy itself fails (that raises).
+        If ``module_name`` (in modules.csv) or ``test_case`` (in test_cases.csv) already
+        exists and ``allow_append`` is ``False``, raises :class:`SaveConflictError` so
+        the caller can ask the user whether to append or choose a new name. With
+        ``allow_append=True`` the new rows are merged into the existing files.
+
+        On success the in-memory recording buffer is cleared, so subsequent keywords
+        form the next module.
         """
         if not self.recorded:
             raise OpticsError(Code.E0501, message="Nothing recorded to save")
-        safe = re.sub(r"[^A-Za-z0-9_ -]", "", name).strip()
-        if not safe:
-            raise OpticsError(Code.E0501, message=f"Invalid module name: {name!r}")
+        tc = self._sanitize_name(test_case)
+        if not tc:
+            raise OpticsError(Code.E0501, message=f"Invalid test case name: {test_case!r}")
+        mod = self._sanitize_name(module_name)
+        if not mod:
+            raise OpticsError(Code.E0501, message=f"Invalid module name: {module_name!r}")
 
         modules_dir = os.path.join(self.folder_path, "modules")
         test_cases_dir = os.path.join(self.folder_path, "test_cases")
-        os.makedirs(modules_dir, exist_ok=True)
-        os.makedirs(test_cases_dir, exist_ok=True)
-        modules_path = os.path.join(modules_dir, f"{safe}.csv")
-        test_cases_path = os.path.join(test_cases_dir, f"{safe}.csv")
+        elements_dir = os.path.join(self.folder_path, "elements")
+        for directory in (modules_dir, test_cases_dir, elements_dir):
+            os.makedirs(directory, exist_ok=True)
+        modules_path = os.path.join(modules_dir, "modules.csv")
+        test_cases_path = os.path.join(test_cases_dir, "test_cases.csv")
+        elements_path = os.path.join(elements_dir, "elements.csv")
 
-        max_params = max((len(params) for _kw, params in self.recorded), default=0)
-        with open(modules_path, "w", encoding="utf-8", newline="") as fh:
-            writer = csv.writer(fh)
-            writer.writerow(
-                ["module_name", "module_step"] + [f"param_{i}" for i in range(1, max_params + 1)]
-            )
-            for func_name, params in self.recorded:
-                row = [safe, keyword_to_title(func_name)]
-                row.extend(escape_csv_value(p) for p in params)
-                row.extend([""] * (max_params - len(params)))
-                writer.writerow(row)
+        module_exists = mod in self._existing_names(modules_path, "module_name")
+        test_case_exists = tc in self._existing_names(test_cases_path, "test_case")
+        if not allow_append:
+            conflicts: List[Tuple[str, str]] = []
+            if module_exists:
+                conflicts.append(("module", mod))
+            if test_case_exists:
+                conflicts.append(("test case", tc))
+            if conflicts:
+                raise SaveConflictError(conflicts)
 
-        with open(test_cases_path, "w", encoding="utf-8", newline="") as fh:
-            writer = csv.writer(fh)
-            writer.writerow(["test_case", "test_step"])
-            writer.writerow([safe, safe])
+        step_count = len(self.recorded)
+        self._append_module_csv(modules_path, mod)
+        self._append_test_case_csv(test_cases_path, tc, mod)
+        self._ensure_elements_stub(elements_path)
 
         artifacts_path: Optional[str] = None
         if os.path.isdir(self._artifacts_dir) and os.listdir(self._artifacts_dir):
-            destination = os.path.join(self.folder_path, "execution_output", safe)
+            destination = os.path.join(self.folder_path, "execution_output", mod)
             if os.path.isdir(destination):
                 shutil.rmtree(destination)
             shutil.copytree(self._artifacts_dir, destination)
             artifacts_path = destination
 
+        # Clear the buffer so the next keywords form a fresh module (one module per
+        # /save), and mark the (now empty) recording as saved.
+        self.recorded = []
         self.saved = True
-        return modules_path, test_cases_path, artifacts_path
+        return SaveResult(
+            modules_path=modules_path,
+            test_cases_path=test_cases_path,
+            elements_path=elements_path,
+            artifacts_path=artifacts_path,
+            test_case=tc,
+            module_name=mod,
+            step_count=step_count,
+            appended_module=module_exists,
+            appended_test_case=test_case_exists,
+        )
+
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        """Strip anything outside ``[A-Za-z0-9_ -]`` and surrounding whitespace."""
+        return re.sub(r"[^A-Za-z0-9_ -]", "", name).strip()
+
+    @staticmethod
+    def _read_rows(path: str) -> List[Dict[str, str]]:
+        """Existing CSV rows as dicts (empty list when the file does not exist)."""
+        if not os.path.isfile(path):
+            return []
+        with open(path, "r", encoding="utf-8", newline="") as fh:
+            return list(csv.DictReader(fh))
+
+    def _existing_names(self, path: str, column: str) -> set[str]:
+        """Distinct stripped values of ``column`` already present in a CSV."""
+        return {
+            (row.get(column) or "").strip()
+            for row in self._read_rows(path)
+            if (row.get(column) or "").strip()
+        }
+
+    @staticmethod
+    def _write_rows(path: str, header: List[str], rows: List[Dict[str, str]]) -> None:
+        """Rewrite ``path`` with ``header`` and ``rows``, coercing missing cells to ``""``."""
+        with open(path, "w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=header, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({key: (row.get(key) or "") for key in header})
+
+    def _append_module_csv(self, path: str, module_name: str) -> None:
+        """Append the recorded keywords as rows for ``module_name``.
+
+        The whole file is rewritten so the ``param_N`` header always spans the widest
+        row across both pre-existing and newly-recorded steps.
+        """
+        rows = self._read_rows(path)
+        for func_name, params in self.recorded:
+            row: Dict[str, str] = {
+                "module_name": module_name,
+                "module_step": keyword_to_title(func_name),
+            }
+            for index, value in enumerate(params, start=1):
+                row[f"param_{index}"] = escape_csv_value(value)
+            rows.append(row)
+
+        max_params = 0
+        for row in rows:
+            for key, value in row.items():
+                if key.startswith("param_") and value and key[len("param_"):].isdigit():
+                    max_params = max(max_params, int(key[len("param_"):]))
+        header = ["module_name", "module_step"] + [
+            f"param_{i}" for i in range(1, max_params + 1)
+        ]
+        self._write_rows(path, header, rows)
+
+    def _append_test_case_csv(self, path: str, test_case: str, module_name: str) -> None:
+        """Append a ``(test_case, module_name)`` step, skipping an exact duplicate row."""
+        rows = self._read_rows(path)
+        existing_pairs = {
+            ((row.get("test_case") or "").strip(), (row.get("test_step") or "").strip())
+            for row in rows
+        }
+        if (test_case, module_name) not in existing_pairs:
+            rows.append({"test_case": test_case, "test_step": module_name})
+        self._write_rows(path, ["test_case", "test_step"], rows)
+
+    @staticmethod
+    def _ensure_elements_stub(path: str) -> None:
+        """Create a header-only ``elements.csv`` if one does not already exist."""
+        if os.path.isfile(path):
+            return
+        with open(path, "w", encoding="utf-8", newline="") as fh:
+            csv.writer(fh).writerow(["Element_Name", "Element_ID"])
 
     # -- Devices ------------------------------------------------------------------
 
@@ -975,12 +1110,16 @@ class LiveController:
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:
-        """Capture the current screen as raw PNG bytes (for the LLM); no file side-effect."""
+        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect.
+
+        Delegates to ``StrategyManager.capture_screenshot_bytes()`` so the native
+        fast path (when a backend supports it) and the numpy fallback are chosen
+        driver-agnostically.
+        """
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
-        image = self._action_keyword.strategy_manager.capture_screenshot()
         try:
-            return utils.encode_numpy_to_png_bytes(image)
+            return self._action_keyword.strategy_manager.capture_screenshot_bytes()
         except ValueError as exc:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Failed to encode screenshot") from exc
 
@@ -1048,6 +1187,9 @@ class LiveController:
             keyword_catalog=self._nl_catalog,
             element_names=self.element_names,
             pagesource_provider=self.page_source,
+            # Prune a completed run to the minimal replayable script before it reaches
+            # the /save buffer — dead-ends and backtracks that "passed" are dropped.
+            curate_on_done=True,
         )
         return self._nl_agent
 

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -768,30 +768,17 @@ class LiveController:
     ) -> SaveResult:
         """Persist the recorded actions to the project's standard CSV files.
 
-        Everything is written to three fixed-name files, appending when they already
-        exist so a session can build up a test suite one module at a time:
+        Appends to three fixed-name files so a session can build up a test suite one
+        module at a time: ``modules/modules.csv`` (the recorded keywords as one module
+        named ``module_name``), ``test_cases/test_cases.csv`` (a ``(test_case,
+        module_name)`` row), and ``elements/elements.csv`` (a header-only stub for
+        manual editing).
 
-        * ``modules/modules.csv`` — the recorded keywords as one module named
-          ``module_name`` (Title Case ``module_step`` + ``param_N`` columns, matching
-          :class:`CSVDataReader`).
-        * ``test_cases/test_cases.csv`` — a ``(test_case, module_name)`` row linking the
-          test case to the module it should run.
-        * ``elements/elements.csv`` — a header-only stub (``Element_Name,Element_ID``)
-          created once so the standard file exists for manual editing (live recording
-          captures inline locators, not named elements).
+        Session artifacts are copied to ``execution_output/<module_name>/``.
 
-        Session artifacts are snapshotted to ``execution_output/<module_name>/`` — the
-        auto pre-/post-action screenshots written by ``@with_self_healing``, AOI
-        captures, annotated detections, per-session logs. They are **copied** (not
-        moved) so further keyword runs keep accumulating in the tempdir.
-
-        If ``module_name`` (in modules.csv) or ``test_case`` (in test_cases.csv) already
-        exists and ``allow_append`` is ``False``, raises :class:`SaveConflictError` so
-        the caller can ask the user whether to append or choose a new name. With
-        ``allow_append=True`` the new rows are merged into the existing files.
-
-        On success the in-memory recording buffer is cleared, so subsequent keywords
-        form the next module.
+        Raises :class:`SaveConflictError` if ``module_name`` or ``test_case`` already
+        exists and ``allow_append`` is ``False``; with ``allow_append=True`` the new
+        rows are merged in. On success the recording buffer is cleared.
         """
         if not self.recorded:
             raise OpticsError(Code.E0501, message="Nothing recorded to save")
@@ -835,8 +822,7 @@ class LiveController:
             shutil.copytree(self._artifacts_dir, destination)
             artifacts_path = destination
 
-        # Clear the buffer so the next keywords form a fresh module (one module per
-        # /save), and mark the (now empty) recording as saved.
+        # One module per /save; clear the buffer for the next one.
         self.recorded = []
         self.saved = True
         return SaveResult(
@@ -1110,12 +1096,7 @@ class LiveController:
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:
-        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect.
-
-        Delegates to ``StrategyManager.capture_screenshot_bytes()`` so the native
-        fast path (when a backend supports it) and the numpy fallback are chosen
-        driver-agnostically.
-        """
+        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect."""
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
         try:
@@ -1187,8 +1168,6 @@ class LiveController:
             keyword_catalog=self._nl_catalog,
             element_names=self.element_names,
             pagesource_provider=self.page_source,
-            # Prune a completed run to the minimal replayable script before it reaches
-            # the /save buffer — dead-ends and backtracks that "passed" are dropped.
             curate_on_done=True,
         )
         return self._nl_agent

--- a/optics_framework/helper/live_tui.py
+++ b/optics_framework/helper/live_tui.py
@@ -37,7 +37,7 @@ from prompt_toolkit.widgets import Frame
 
 from optics_framework.helper.live import (
     LiveController, ActionResult, NLStep, NLSummary,
-    ActionStatus, NLRunStatus, NLStepKind,
+    ActionStatus, NLRunStatus, NLStepKind, SaveConflictError,
 )
 
 
@@ -69,7 +69,10 @@ Natural-language mode (Ctrl-N)
   Requires an enabled 'llm_models' entry (e.g. gemini) in config.yaml.
 
 Slash commands (work in both modes)
-  /save <name>   Save recorded actions to modules/<name>.csv + a test case
+  /save <test_case> <module_name>
+                 Save recorded actions as <module_name> in modules/modules.csv and a
+                 <test_case> row in test_cases/test_cases.csv (appends if they exist;
+                 clears the buffer so the next actions form the next module)
   /device [id]   List/switch connected Android + iOS devices (Appium sessions only)
   /elements      Show named elements and their locators (read-only)
   /screenshot    Capture the device screen to a file
@@ -169,6 +172,9 @@ class LiveTUI:
         self.entries: List[ActionResult] = []
         self._busy = False
         self._quit_armed = False
+        # Set to the (test_case, module_name) of the last /save that hit a name
+        # conflict; re-running the identical /save then confirms the append.
+        self._save_armed: Optional[Tuple[str, str]] = None
         self._known_devices: List[str] = []
 
         # Natural-language mode: when on, the whole input box is treated as English and
@@ -684,21 +690,38 @@ class LiveTUI:
         handler(arg)
 
     def _cmd_save(self, arg: str) -> None:
-        if not arg:
-            self._info("Usage: /save <name>")
+        tokens = arg.split()
+        if len(tokens) != 2:
+            self._info("Usage: /save <test_case> <module_name>")
             return
+        test_case, module_name = tokens
+        allow_append = self._save_armed == (test_case, module_name)
         try:
-            modules_path, test_cases_path, artifacts_path = self.controller.save(arg)
+            result = self.controller.save(
+                test_case, module_name, allow_append=allow_append
+            )
+        except SaveConflictError as conflict:
+            self._save_armed = (test_case, module_name)
+            existing = ", ".join(f"{kind} '{name}'" for kind, name in conflict.conflicts)
+            self._info(
+                f"{existing} already exist(s). Re-run the same /save to append, "
+                "or run /save with a different name."
+            )
+            return
         except Exception as exc:  # noqa: BLE001
+            self._save_armed = None
             self._info(f"Save failed: {exc}")
             return
+        self._save_armed = None
         import os as _os  # local: avoid widening module imports for one count
+        verb = "Appended" if (result.appended_module or result.appended_test_case) else "Saved"
         self._info(
-            f"Saved {len(self.controller.recorded)} step(s) → {modules_path} + {test_cases_path}"
+            f"{verb} {result.step_count} step(s) → module '{result.module_name}' in "
+            f"{result.modules_path}, test case '{result.test_case}' in {result.test_cases_path}"
         )
-        if artifacts_path:
-            count = len(_os.listdir(artifacts_path))
-            self._info(f"Snapshotted {count} artifact(s) → {artifacts_path}")
+        if result.artifacts_path:
+            count = len(_os.listdir(result.artifacts_path))
+            self._info(f"Snapshotted {count} artifact(s) → {result.artifacts_path}")
 
     def _cmd_device(self, arg: str) -> None:
         if not self.controller.supports_device_switching():
@@ -787,7 +810,8 @@ class LiveTUI:
             self._quit_armed = True
             self._info(
                 f"{len(self.controller.recorded)} recorded step(s) are unsaved. "
-                "Use /save <name> to keep them, or /quit again to discard and exit."
+                "Use /save <test_case> <module_name> to keep them, or /quit again to "
+                "discard and exit."
             )
             return
         get_app().exit()

--- a/tests/units/common/test_nl_agent.py
+++ b/tests/units/common/test_nl_agent.py
@@ -12,6 +12,7 @@ from optics_framework.common.nl_agent import (
     KeywordSpec,
     ExecResult,
     ACTION_SCHEMA,
+    CURATION_SCHEMA,
     SYSTEM_PROMPT,
 )
 from optics_framework.common.error import OpticsError, Code
@@ -53,6 +54,35 @@ def _ok_executor(recorder):
         return ExecResult(ok=True, strategy="OCR", elapsed=0.1)
 
     return _exec
+
+
+class CuratingFakeLLM(FakeLLM):
+    """FakeLLM that also serves the post-'done' curation turn.
+
+    ACTION_SCHEMA turns come from the base ``scripted`` list; the single CURATION_SCHEMA
+    turn returns ``curation_reply``. Curation is text-only, so ``images`` must be None.
+    """
+
+    def __init__(self, scripted, curation_reply):
+        super().__init__(scripted)
+        self.curation_reply = curation_reply
+        self.curation_calls = 0
+
+    def generate_json(self, prompt, response_schema, images=None, system=None, temperature=None):
+        if response_schema is CURATION_SCHEMA:
+            self.curation_calls += 1
+            assert images is None
+            return self.curation_reply
+        return super().generate_json(prompt, response_schema, images, system, temperature)
+
+
+def _kw(keyword, params):
+    return {"thought": f"do {keyword}", "action": "keyword", "keyword": keyword,
+            "params": params, "reason": ""}
+
+
+def _done():
+    return {"thought": "ok", "action": "done", "reason": "goal reached"}
 
 
 class TestAgentControlFlow:
@@ -323,3 +353,132 @@ class TestGeminiMissingDependency:
             gemini.GeminiLLM({"capabilities": {}})
         assert exc_info.value.code == Code.E0601
         assert "optics-framework[llm]" in exc_info.value.message
+
+
+class TestCurationSchema:
+    def test_no_anyof_in_schema(self):
+        import json
+
+        assert "anyOf" not in json.dumps(CURATION_SCHEMA)
+
+    def test_required_fields(self):
+        assert CURATION_SCHEMA["required"] == ["keep", "reason"]
+
+
+class TestCurateOnDone:
+    """The post-'done' curation pass (curate_on_done=True) prunes to a replayable subset."""
+
+    def _agent(self, llm, executed=None, curate=True):
+        return NaturalLanguageAgent(
+            llm, _shots, _ok_executor(executed if executed is not None else []),
+            _catalog, curate_on_done=curate,
+        )
+
+    def test_curation_prunes_non_contributing_step(self):
+        executed = []
+        llm = CuratingFakeLLM(
+            [_kw("press_element", ["Menu"]),      # 1 - dead end
+             _kw("press_element", ["Search"]),    # 2 - needed
+             _kw("enter_text", ["Search", "kids"]),  # 3 - needed
+             _done()],
+            curation_reply={"keep": [2, 3], "reason": "step 1 was a dead-end"},
+        )
+        result = self._agent(llm, executed).run("search kids movies")
+        assert result.status == "done"
+        assert llm.curation_calls == 1
+        assert result.successful_steps == [
+            ("press_element", ["Search"]),
+            ("enter_text", ["Search", "kids"]),
+        ]
+        # All three still executed live; curation is post-hoc.
+        assert len(executed) == 3
+        assert "kept 2 of 3 steps" in (result.message or "")
+
+    def test_curation_sorts_dedups_and_range_checks(self):
+        llm = CuratingFakeLLM(
+            [_kw("press_element", ["A"]), _kw("press_element", ["B"]),
+             _kw("press_element", ["C"]), _done()],
+            curation_reply={"keep": [3, 1, 1, 99, 0], "reason": "reorder/dup/out-of-range"},
+        )
+        result = self._agent(llm).run("go")
+        assert result.successful_steps == [("press_element", ["A"]), ("press_element", ["C"])]
+
+    @pytest.mark.parametrize("bad_reply", [
+        {"keep": [], "reason": "drop all"},          # empty -> keep all
+        {"keep": "nope", "reason": "r"},             # not a list
+        {"reason": "no keep key"},                   # missing keep
+        {"keep": ["x", 2.5, True], "reason": "r"},   # no valid ints (bool rejected)
+        {"keep": [1, 2], "reason": "kept all"},      # kept everything -> no-op
+        [1, 2],                                      # non-dict response
+        "garbage",                                   # non-dict scalar
+    ])
+    def test_curation_falls_back_to_all_steps(self, bad_reply):
+        llm = CuratingFakeLLM(
+            [_kw("press_element", ["A"]), _kw("press_element", ["B"]), _done()],
+            curation_reply=bad_reply,
+        )
+        result = self._agent(llm).run("go")
+        assert result.successful_steps == [("press_element", ["A"]), ("press_element", ["B"])]
+
+    def test_curation_llm_error_keeps_all_steps(self):
+        class Raising(CuratingFakeLLM):
+            def generate_json(self, prompt, schema, images=None, system=None, temperature=None):
+                if schema is CURATION_SCHEMA:
+                    raise OpticsError(Code.E0801, message="boom")
+                return super().generate_json(prompt, schema, images, system, temperature)
+
+        llm = Raising(
+            [_kw("press_element", ["A"]), _kw("press_element", ["B"]), _done()],
+            curation_reply=None,
+        )
+        result = self._agent(llm).run("go")
+        assert result.status == "done"
+        assert result.successful_steps == [("press_element", ["A"]), ("press_element", ["B"])]
+
+    def test_curation_skipped_for_single_step(self):
+        llm = CuratingFakeLLM(
+            [_kw("press_element", ["A"]), _done()],
+            curation_reply={"keep": [1], "reason": "r"},
+        )
+        result = self._agent(llm).run("go")
+        assert llm.curation_calls == 0
+        assert result.successful_steps == [("press_element", ["A"])]
+
+    def test_toggle_off_disables_curation(self):
+        llm = CuratingFakeLLM(
+            [_kw("press_element", ["A"]), _kw("press_element", ["B"]), _done()],
+            curation_reply={"keep": [1], "reason": "r"},
+        )
+        result = self._agent(llm, curate=False).run("go")
+        assert llm.curation_calls == 0
+        assert len(result.successful_steps) == 2
+
+    def test_failed_steps_are_not_selectable_candidates(self):
+        # A failing keyword between two passing ones: it must not appear in successful_steps,
+        # and the curation prompt must number only the passing steps as candidates.
+        captured = {}
+
+        def executor(raw):
+            # "press_element B" fails; A and C pass.
+            ok = "B" not in raw
+            return ExecResult(ok=ok, strategy="OCR", message=None if ok else "not found")
+
+        class Capturing(CuratingFakeLLM):
+            def generate_json(self, prompt, schema, images=None, system=None, temperature=None):
+                if schema is CURATION_SCHEMA:
+                    captured["prompt"] = prompt
+                return super().generate_json(prompt, schema, images, system, temperature)
+
+        llm = Capturing(
+            [_kw("press_element", ["A"]), _kw("press_element", ["B"]),
+             _kw("press_element", ["C"]), _done()],
+            curation_reply={"keep": [1, 2], "reason": "both real steps"},
+        )
+        agent = NaturalLanguageAgent(llm, _shots, executor, _catalog, curate_on_done=True)
+        result = agent.run("go")
+        # Only A and C succeeded; curation keeps both (candidates 1 and 2).
+        assert result.successful_steps == [("press_element", ["A"]), ("press_element", ["C"])]
+        prompt = captured["prompt"]
+        assert "1. press_element ['A']" in prompt
+        assert "2. press_element ['C']" in prompt
+        assert "[FAILED, not selectable] press_element ['B']" in prompt

--- a/tests/units/helpers/test_live_save.py
+++ b/tests/units/helpers/test_live_save.py
@@ -1,0 +1,172 @@
+"""Unit tests for the `optics live` `/save` workflow (``LiveController.save``).
+
+These exercise the CSV serialisation directly, without a device or session: a
+lightweight subclass overrides ``__init__`` to set only the attributes ``save``
+touches (``folder_path``, ``_artifacts_dir``, ``recorded``, ``saved``). The output
+is validated both structurally and by round-tripping through ``CSVDataReader`` so it
+stays compatible with the batch runner.
+"""
+import csv
+import os
+import tempfile
+
+import pytest
+
+from optics_framework.helper.live import LiveController, SaveConflictError, SaveResult
+from optics_framework.common.runner.data_reader import CSVDataReader
+
+pytestmark = pytest.mark.white_box
+
+
+class _Controller(LiveController):
+    """LiveController with the heavy session __init__ bypassed."""
+
+    def __init__(self, folder: str):
+        self.folder_path = folder
+        self._artifacts_dir = os.path.join(folder, "no_artifacts")  # absent -> no snapshot
+        self.recorded = []
+        self.saved = False
+
+
+def _ctl() -> _Controller:
+    return _Controller(tempfile.mkdtemp(prefix="optics_live_save_"))
+
+
+def _rows(path: str) -> list[dict]:
+    with open(path, encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_first_save_writes_standard_files_and_clears_buffer():
+    c = _ctl()
+    c.recorded = [("launch_app", []), ("press_element", ["${login_btn}", "index=0"])]
+
+    result = c.save("Login Test", "login_module")
+
+    assert isinstance(result, SaveResult)
+    assert result.appended_module is False and result.appended_test_case is False
+    assert result.step_count == 2
+    # Fixed, standard file names in their respective folders.
+    assert result.modules_path.endswith(os.path.join("modules", "modules.csv"))
+    assert result.test_cases_path.endswith(os.path.join("test_cases", "test_cases.csv"))
+    assert result.elements_path.endswith(os.path.join("elements", "elements.csv"))
+    # Buffer is cleared so the next actions form the next module.
+    assert c.recorded == []
+    assert c.saved is True
+
+    mods = _rows(result.modules_path)
+    assert [m["module_name"] for m in mods] == ["login_module", "login_module"]
+    assert mods[1]["module_step"] == "Press Element"
+    assert mods[1]["param_1"] == "${login_btn}"
+    assert _rows(result.test_cases_path) == [
+        {"test_case": "Login Test", "test_step": "login_module"}
+    ]
+    # elements.csv is a header-only stub (no named elements from live).
+    assert os.path.isfile(result.elements_path)
+    assert _rows(result.elements_path) == []
+
+
+def test_second_module_appends_and_reconciles_param_columns():
+    c = _ctl()
+    c.recorded = [("enter_text", ["${user}", "bob"])]
+    first = c.save("TC one", "mod_a")
+
+    c.recorded = [("scroll", [])]  # fewer params than mod_a
+    second = c.save("TC two", "mod_b")
+
+    assert second.modules_path == first.modules_path  # same fixed file, appended
+    mods = _rows(second.modules_path)
+    assert [m["module_name"] for m in mods] == ["mod_a", "mod_b"]
+    # param_1 header spans the widest row; the param-less row is padded empty.
+    assert mods[0]["param_1"] == "${user}"
+    assert mods[1]["param_1"] == ""
+    tcs = _rows(second.test_cases_path)
+    assert [(t["test_case"], t["test_step"]) for t in tcs] == [
+        ("TC one", "mod_a"),
+        ("TC two", "mod_b"),
+    ]
+
+
+def test_duplicate_module_name_raises_conflict():
+    c = _ctl()
+    c.recorded = [("launch_app", [])]
+    c.save("TC", "dup_module")
+
+    c.recorded = [("scroll", [])]
+    with pytest.raises(SaveConflictError) as exc:
+        c.save("Other TC", "dup_module")
+    assert ("module", "dup_module") in exc.value.conflicts
+    # A rejected save leaves the buffer intact for a retry.
+    assert c.recorded == [("scroll", [])]
+
+
+def test_duplicate_test_case_name_raises_conflict():
+    c = _ctl()
+    c.recorded = [("launch_app", [])]
+    c.save("Shared TC", "mod_a")
+
+    c.recorded = [("scroll", [])]
+    with pytest.raises(SaveConflictError) as exc:
+        c.save("Shared TC", "mod_b")
+    assert ("test case", "Shared TC") in exc.value.conflicts
+
+
+def test_allow_append_merges_into_existing_module():
+    c = _ctl()
+    c.recorded = [("launch_app", [])]
+    c.save("TC", "mod_a")
+
+    c.recorded = [("scroll", [])]
+    result = c.save("TC 2", "mod_a", allow_append=True)
+
+    assert result.appended_module is True
+    mod_rows = [m for m in _rows(result.modules_path) if m["module_name"] == "mod_a"]
+    assert [m["module_step"] for m in mod_rows] == ["Launch App", "Scroll"]
+
+
+def test_exact_duplicate_test_case_row_is_not_repeated():
+    c = _ctl()
+    c.recorded = [("launch_app", [])]
+    c.save("TC", "mod_a")
+
+    c.recorded = [("scroll", [])]
+    result = c.save("TC", "mod_a", allow_append=True)  # same (test_case, module) pair
+
+    pairs = [(t["test_case"], t["test_step"]) for t in _rows(result.test_cases_path)]
+    assert pairs.count(("TC", "mod_a")) == 1
+
+
+def test_empty_buffer_is_refused():
+    c = _ctl()
+    with pytest.raises(Exception, match="Nothing recorded"):
+        c.save("TC", "mod")
+
+
+@pytest.mark.parametrize(
+    "test_case,module,message",
+    [("!!!", "mod", "Invalid test case"), ("TC", "@@@", "Invalid module")],
+)
+def test_invalid_names_are_refused(test_case, module, message):
+    c = _ctl()
+    c.recorded = [("launch_app", [])]
+    with pytest.raises(Exception, match=message):
+        c.save(test_case, module)
+
+
+def test_saved_files_round_trip_through_csv_reader():
+    c = _ctl()
+    c.recorded = [("launch_app", []), ("enter_text", ["${user}", "hello, world"])]
+    first = c.save("TC one", "mod_a")
+    c.recorded = [("scroll", [])]
+    c.save("TC two", "mod_b")
+
+    reader = CSVDataReader()
+    modules = reader.read_modules(first.modules_path)
+    assert modules == {
+        "mod_a": [("Launch App", []), ("Enter Text", ["${user}", "hello, world"])],
+        "mod_b": [("Scroll", [])],
+    }
+    assert reader.read_test_cases(first.test_cases_path) == {
+        "TC one": ["mod_a"],
+        "TC two": ["mod_b"],
+    }

--- a/tests/units/helpers/test_live_save.py
+++ b/tests/units/helpers/test_live_save.py
@@ -19,9 +19,14 @@ pytestmark = pytest.mark.white_box
 
 
 class _Controller(LiveController):
-    """LiveController with the heavy session __init__ bypassed."""
+    """LiveController with the heavy session __init__ bypassed.
 
-    def __init__(self, folder: str):
+    Intentionally does not call super().__init__() since we're unit-testing
+    the save logic without a real session. Only the attributes that save()
+    touches are initialized.
+    """
+
+    def __init__(self, folder: str):  # noqa: super-init-not-called
         self.folder_path = folder
         self._artifacts_dir = os.path.join(folder, "no_artifacts")  # absent -> no snapshot
         self.recorded = []


### PR DESCRIPTION
## Summary

Two complementary improvements to the optics live workflow:

1. **Incremental /save with fixed filenames**: `/save <test_case> <module_name>` now writes to standard files (modules/modules.csv, test_cases/test_cases.csv, elements/elements.csv) that APPEND when they exist. This enables building a test suite one module at a time without name confusion. If a name conflicts, you're prompted to choose a different one or confirm the append. The recording buffer is cleared after each /save so the next actions form the next module.

2. **NL-mode curation on completion**: When an AI instruction finishes successfully, an extra LLM pass prunes the recorded steps to a minimal replayable script—dropping dead-ends, backtracks, and no-op gestures. If curation fails or produces no usable result, it safely falls back to keeping all successful steps.

Together, these make it practical to interactively build a clean test suite from AI-driven recordings, one focused module per instruction.

## Test Plan

- 10 new tests for /save workflow (append, conflicts, dedup, buffer clear)
- 13 new tests for NL curation (prune, normalize, all fallback paths, LLM errors, toggle-off, failed-step handling)
- All 290 existing unit tests pass (common + helpers)
- Pre-commit (ruff, bandit) clean

## Follow-up Work

Two enhancements identified for future PRs:

- **#328**: Goal verification—re-screenshot after `done` to confirm the model's claim actually matches the screen, catching hallucinations before they're saved.
- **#329**: Auto-assertion—append an `assert_presence` step to saved modules so the test validates the outcome, not just the actions.

These would make AI-generated tests even more robust for CI/automation.