### PR TITLE
Fix/fix multiple keywords

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1630,7 +1630,7 @@ Manages application lifecycle.
 - `launch_app()` - Launch with identifier/activity
 - `launch_other_app()` - Launch different app
 - `start_appium_session()` - Start Appium session
-- `close_and_terminate_app()` - Cleanup
+- `close_and_terminate_app()` - Tear down driver session and flush events
 - `force_terminate_app()` - Force kill
 - `get_app_version()` - Version info
 

--- a/docs/architecture/library_layer.md
+++ b/docs/architecture/library_layer.md
@@ -197,7 +197,7 @@ optics.validate_screen(["element1", "element2"])
 
 # Screenshots and page source
 screenshot = optics.capture_screenshot()
-page_source = optics.capture_page_source()
+page_source = optics.capture_pagesource()
 ```
 
 ### Flow Control

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,9 +125,9 @@ All configurations are defined in YAML format. The main configuration file (`con
 
     ### `execution_output_path`
 
-    **Type:** `Optional[str]` | **Default:** `null` (auto-generated if `project_path` is set)
+    **Type:** `Optional[str]` | **Default:** `null` (auto-generated)
 
-    Directory where execution outputs (logs, screenshots, etc.) are stored. If not specified and `project_path` is set, defaults to `{project_path}/execution_output`.
+    Directory where execution outputs (logs, screenshots, etc.) are stored. If not specified, defaults to `{project_path}/execution_output` when `project_path` is set, or `{cwd}/execution_output` (current working directory) otherwise.
 
     ```yaml
     execution_output_path: "./outputs"

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -424,6 +424,24 @@ Execute Script,{"script": "mobile:pressKey", "args": {"keycode": 3}},execute_bac
 
 These keywords handle verification and validation operations.
 
+### Assert Equality
+
+Compares two values for equality. Both values are converted to strings and stripped of leading/trailing whitespace before comparison. Returns `true` if equal, `false` otherwise. Either value can be a `${variable}` reference.
+
+**Parameters:**
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `output` | Required | The actual value to check (e.g. result of `Get Text`) | - |
+| `expression` | Required | The expected value | - |
+| `event_name` | Optional | A string identifier for the event | - |
+
+**Example:**
+
+```csv
+Assert Equality,${price_text},9.99,price_verified
+```
+
 ### Validate Element
 
 Verifies the specified element is present on the screen.

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -642,7 +642,9 @@ Launch Other App,com.example.otherapp,launch_other
 
 ### Close And Terminate App
 
-Closes and terminates the current application.
+Tears down the active driver session and flushes all pending events. The exact
+behaviour depends on the configured driver (Appium, Selenium, Playwright, BLE)
+but in all cases the driver reference is released after this call.
 
 **Parameters:**
 

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -539,7 +539,7 @@ Captures a screenshot of the current screen.
 Capture Screenshot,screenshot_before_action
 ```
 
-### Capture Page Source
+### Capture Pagesource
 
 Captures the page source of the current screen.
 
@@ -552,7 +552,7 @@ Captures the page source of the current screen.
 **Example:**
 
 ```csv
-Capture Page Source,get_source
+Capture Pagesource,get_source
 ```
 
 ### Get Interactive Elements

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -443,6 +443,30 @@ Verifies the specified element is present on the screen.
 Validate Element,login_button.png,10,any,verify_login
 ```
 
+### Is Element
+
+Checks if an element is in a given state: `visible`, `invisible`, `enabled`, or `disabled`. Raises an error if the element's actual state does not match the expected state.
+
+- **visible / invisible** — asserts presence or absence of the element on screen within the timeout.
+- **enabled / disabled** — locates the element and checks its interactive state via the accessibility tree. Coordinate-based results (e.g. from OCR) are not supported for enabled/disabled checks.
+
+**Parameters:**
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `element` | Required | The element to check (Image template, OCR template, or XPath) | - |
+| `element_state` | Required | Expected state: `visible`, `invisible`, `enabled`, or `disabled` | - |
+| `timeout` | Required | Time to wait for the element in seconds (integer) | - |
+| `event_name` | Optional | A string identifier for the event | - |
+
+**Example:**
+
+```csv
+Is Element,login_button.png,visible,10,check_login_visible
+Is Element,//android.widget.Button[@text="Submit"],enabled,5,check_submit_enabled
+Is Element,loading_spinner.png,invisible,15,wait_for_load
+```
+
 ### Assert Presence
 
 Asserts the presence of elements. Can check multiple elements with pipe separator (`|`).

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -428,19 +428,41 @@ These keywords handle verification and validation operations.
 
 Compares two values for equality. Both values are converted to strings and stripped of leading/trailing whitespace before comparison. Returns `true` if equal, `false` otherwise. Either value can be a `${variable}` reference.
 
+**Usage note:** `Evaluate` writes its result directly into `session.elements`, so `${var}` from `Evaluate` can be passed straight into `Assert Equality`.
+
+**No expression evaluation:** `Assert Equality` only resolves `${var}` references to their stored string value, then compares the two resulting strings as-is — it does not evaluate anything as Python. Quote characters you type are compared literally, not stripped. So a stored value of `9.99` must be compared against the bare literal `9.99` (not `'9.99'`).
+
 **Parameters:**
 
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `output` | Required | The actual value to check (e.g. result of `Get Text`) | - |
+| `output` | Required | The actual value to check — typically a `${variable}` already populated by `Evaluate`, or a value read back from a keyword like `Get Text` | - |
 | `expression` | Required | The expected value | - |
 | `event_name` | Optional | A string identifier for the event | - |
 
-**Example:**
+**Example (direct literal comparison):**
 
 ```csv
 Assert Equality,${price_text},9.99,price_verified
 ```
+
+**Example (chained after `Evaluate`):**
+
+```csv
+Evaluate,${price},'9.99'
+Assert Equality,${price},9.99
+```
+
+**Example (chained after `Get Text`):**
+
+`Get Text` doesn't store its result automatically, so capture the returned text and compare it directly:
+
+```csv
+Get Text,//android.widget.TextView[@resource-id="price_label"]
+Assert Equality,9.99,9.99
+```
+
+Here, the first `9.99` in `Assert Equality` is the text `Get Text` returned from the label. You paste in whatever value it gave back, not a fresh literal.
 
 ### Validate Element
 

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -798,7 +798,7 @@ Read Data,${filtered},users.csv,role=='${expected_role}';select=id,name
 
 ### Evaluate
 
-Evaluates an expression and stores the result in session.elements.
+Evaluates an expression and stores the result in `session.elements` under the given variable name.
 
 **Parameters:**
 
@@ -807,17 +807,70 @@ Evaluates an expression and stores the result in session.elements.
 | `param1` | Required | The variable name where the result will be stored (e.g., `${result}`) | - |
 | `param2` | Required | The expression to evaluate (can use variables like `${var1} + ${var2}`) | - |
 
-**Example:**
+**How `param2` is evaluated:**
+
+- Every `${var}` in `param2` is first replaced, as plain text, with the variable's *stored string value* — before anything is evaluated as Python.
+- The result of that substitution is then run through a restricted `eval()`. Only arithmetic (`+ - * / % **`), comparisons (`> < >= <= == !=`), boolean logic (`and or not`), a ternary `... if ... else ...`, and literal `list`/`tuple` values are allowed. Anything else (function calls, attribute access, imports, f-strings, etc.) is rejected with `Code.E0403 Unsafe expression detected`.
+- Because the substitution is textual and unquoted, a `${var}` that holds **text** must be wrapped in quotes *inside the expression* (e.g. `'${name}'`), otherwise the substituted word is treated as a bare Python name and raises a `NameError`. A `${var}` that holds a **number** does not need quotes.
+- The final result is stored via `str(result)`, so even numbers and booleans end up as strings in `session.elements` (e.g. `True` → `"True"`).
+- `param1` must be in `${name}` form; if it isn't, a warning is logged and the raw string is used as the variable name as-is.
+
+**Example (numeric arithmetic):**
 
 ```csv
+Evaluate,${a},5
+Evaluate,${b},3
 Evaluate,${sum},${a} + ${b}
 ```
 
-**Example (with comparison):**
+`${sum}` → `8`
+
+**Example (comparison):**
 
 ```csv
+Evaluate,${count},15
 Evaluate,${is_valid},${count} > 10
 ```
+
+`${is_valid}` → `True`
+
+**Example (string literal):**
+
+Wrap plain text in quotes so it's evaluated as a Python string, not as bare identifiers:
+
+```csv
+Evaluate,${greeting},'hello world'
+```
+
+`${greeting}` → `hello world`
+
+**Example (concatenating a stored text variable):**
+
+`${name}` holds text, so it must be quoted inside the expression once substituted:
+
+```csv
+Evaluate,${name},'Alice'
+Evaluate,${message},'Hello, ' + '${name}'
+```
+
+`${message}` → `Hello, Alice`
+
+**Example (ternary if/else):**
+
+```csv
+Evaluate,${score},72
+Evaluate,${result},'Pass' if ${score} >= 50 else 'Fail'
+```
+
+`${result}` → `Pass`
+
+**Example (list literal):**
+
+```csv
+Evaluate,${numbers},[1, 2, 3, 4]
+```
+
+`${numbers}` → `[1, 2, 3, 4]`
 
 ### Date Evaluate
 

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -92,6 +92,26 @@ Detects a specified element and presses it if found.
 Detect And Press,login_button.png,30,detect_login
 ```
 
+### Select Dropdown Option
+
+Opens a dropdown and selects one of its options.
+
+Presses the dropdown element to open it, validates that the option text is visible in the resulting page source, then presses it. Raises an error (`E0201`) when the specified option is not found among the dropdown's visible items, preventing a silent mis-selection.
+
+**Parameters:**
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `element` | Required | The dropdown element (Image template, OCR template, or XPath) | - |
+| `option` | Required | The option to select (visible label text, OCR template, or XPath) | - |
+| `event_name` | Optional | A string identifier for the selection event | - |
+
+**Example:**
+
+```csv
+Select Dropdown Option,${country_dropdown},India,country_selected
+```
+
 ### Swipe
 
 Performs a swipe action in a specified direction from given coordinates.

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -154,7 +154,7 @@ Swipe By Percentage,50,50,up,25,swipe_up
 
 ### Swipe Until Element Appears
 
-Swipes in a specified direction until an element appears.
+Swipes in a specified direction until an element appears. Raises an error if the element does not appear within the timeout.
 
 **Parameters:**
 
@@ -162,7 +162,7 @@ Swipes in a specified direction until an element appears.
 |-----------|------|-------------|---------|
 | `element` | Required | The target element to find (Image template, OCR template, or XPath) | - |
 | `direction` | Required | The swipe direction: `up`, `down`, `left`, or `right` | - |
-| `timeout` | Required | Timeout in seconds until element search is performed (integer) | - |
+| `timeout` | Required | Maximum time in seconds to keep swiping before raising an error (integer) | - |
 | `event_name` | Optional | A string identifier for the swipe event | - |
 
 **Example:**

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -213,7 +213,7 @@ Scroll,down,scroll_down
 
 ### Scroll Until Element Appears
 
-Scrolls in a specified direction until an element appears.
+Scrolls in a specified direction until an element appears. Raises an error if the element does not appear within the timeout.
 
 **Parameters:**
 
@@ -221,7 +221,7 @@ Scrolls in a specified direction until an element appears.
 |-----------|------|-------------|---------|
 | `element` | Required | The target element to find (Image template, OCR template, or XPath) | - |
 | `direction` | Required | The scroll direction: `up`, `down`, `left`, or `right` | - |
-| `timeout` | Required | Timeout in seconds for the scroll operation (integer) | - |
+| `timeout` | Required | Maximum time in seconds to keep scrolling before raising an error (integer) | - |
 | `event_name` | Optional | A string identifier for the scroll event | - |
 
 **Example:**

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -571,6 +571,20 @@ Retrieves a list of interactive elements on the current screen.
 Get Interactive Elements,buttons
 ```
 
+### Get Screen Elements
+
+Captures a screenshot and retrieves interactive elements from the current screen in a single call. Returns a dict with a base64-encoded screenshot and a list of elements.
+
+**Parameters:**
+
+None.
+
+**Example:**
+
+```csv
+Get Screen Elements
+```
+
 ## App Management Keywords
 
 These keywords handle application lifecycle operations.

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -132,7 +132,7 @@ Performs a swipe action in a specified direction from given coordinates.
 Swipe,500,800,down,100,swipe_down
 ```
 
-### Swipe Percentage
+### Swipe By Percentage
 
 Performs a swipe action in a specified direction by percentage of the screen (0-100).
 
@@ -149,7 +149,7 @@ Performs a swipe action in a specified direction by percentage of the screen (0-
 **Example:**
 
 ```csv
-Swipe Percentage,50,50,up,25,swipe_up
+Swipe By Percentage,50,50,up,25,swipe_up
 ```
 
 ### Swipe Until Element Appears

--- a/docs/usage/library_usage.md
+++ b/docs/usage/library_usage.md
@@ -269,8 +269,8 @@ optics.validate_screen(["header", "content", "footer"])
 screenshot = optics.capture_screenshot()
 print(f"Screenshot: {screenshot}")
 
-# Capture page source
-page_source = optics.capture_page_source()
+# Capture pagesource
+page_source = optics.capture_pagesource()
 print(f"Page source: {page_source}")
 
 # Get interactive elements

--- a/docs/usage/robot_usage.md
+++ b/docs/usage/robot_usage.md
@@ -274,8 +274,8 @@ Capture Test
     ${screenshot}=    Capture Screenshot
     Log    Screenshot: ${screenshot}
 
-    # Capture page source
-    ${page_source}=    Capture Page Source
+    # Capture pagesource
+    ${page_source}=    Capture Pagesource
     Log    Page source: ${page_source}
 
     # Get interactive elements

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -409,11 +409,10 @@ class ActionKeyword:
         """
         Open a dropdown and select one of its options.
 
-        Opens the dropdown by pressing ``element``, then selects ``option`` by pressing it.
-        Both presses go through :meth:`press_element`'s self-healing location
-        (XPath -> text -> OCR -> image), so either step raises ``OpticsError`` (``E0201`` /
-        ``X0201``) when its target can't be found — an honest failure rather than a
-        silent no-op.
+        Opens the dropdown by pressing ``element``, then validates that ``option`` is visible
+        in the page source before pressing it. Raises ``OpticsError`` (``E0201``) when the
+        option text is not found among the dropdown's visible items, preventing a silent
+        mis-selection. Falls back to pressing without validation when page source is unavailable.
 
         :param element: The dropdown element (Image template, OCR template, or XPath).
         :param option: The option to select (visible label, OCR/Image template, or XPath).
@@ -421,7 +420,27 @@ class ActionKeyword:
         """
         internal_logger.info(f"Selecting '{option}' from dropdown '{element}'")
         self.press_element(element, event_name=event_name)
+        self._assert_option_in_dropdown(element, option)
         self.press_element(option, event_name=event_name)
+
+    def _assert_option_in_dropdown(self, dropdown_element: str, option: str) -> None:
+        """Validate that option text is present in the open dropdown via page source."""
+        try:
+            interactive = self.strategy_manager.get_interactive_elements()
+        except (OpticsError, NotImplementedError):
+            return
+        option_normalized = option.strip().lower()
+        available_texts = [
+            el.get("text") or "" for el in interactive if isinstance(el, dict)
+        ]
+        if not any(option_normalized == t.strip().lower() for t in available_texts if t):
+            raise OpticsError(
+                Code.E0201,
+                message=(
+                    f"Option '{option}' not found in dropdown '{dropdown_element}'. "
+                    f"Available options: {[t for t in available_texts if t]}"
+                ),
+            )
 
     # Swipe and Scroll actions
     def swipe(self, coor_x: str, coor_y: str, direction: str = 'right', swipe_length: str = "50", event_name: Optional[str] = None) -> None:

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -593,9 +593,9 @@ class ActionKeyword:
         :param event_name: The event triggering the input.
         """
 
-        special_key = str(utils.parse_special_key(text))
-        if special_key != "None":
-            text = special_key
+        parsed = utils.parse_special_key(text)
+        if parsed is not None:
+            text = parsed
 
         if isinstance(located, tuple):
             x, y = located
@@ -632,9 +632,9 @@ class ActionKeyword:
         :param event_name: Optional event label for logging.
         """
 
-        special_key = str(utils.parse_special_key(text_input))
-        if special_key != "None":
-            text_input = special_key
+        parsed = utils.parse_special_key(text_input)
+        if parsed is not None:
+            text_input = parsed
         try:
             screenshot_np = self.strategy_manager.capture_screenshot()
             utils.save_screenshot(screenshot_np, "enter_text_using_keyboard", output_dir=self.execution_dir)

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -662,14 +662,9 @@ class ActionKeyword:
             internal_logger.debug(f"Entering number '{number}' at coordinates ({x}, {y})")
             self.driver.press_coordinates(x, y, event_name=event_name)
             self.driver.enter_text(str(number), event_name)
-        elif isinstance(located, str):
-            self.driver.enter_text_element(located, str(number), event_name)
         else:
-            internal_logger.error(
-                "Element location %s is not provided correctly for entering number.", element)
-            raise ValueError(
-                f"Element location {element} is not provided correctly for entering number."
-            )
+            internal_logger.debug(f"Entering number '{number}' into element '{element}'")
+            self.driver.enter_text_element(located, str(number), event_name)
 
     def press_keycode(self, keycode: str, event_name: Optional[str] = None) -> None:
         """

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -497,17 +497,21 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "swipe_until_element_appears")
         start_time = time.time()
+        found = False
         while time.time() - start_time < int(timeout):
             try:
                 result = self.verifier.assert_presence(
                     element, timeout_str="3", rule="any")
                 if result:
+                    found = True
                     break
             except OpticsError as e:
                 if e.code != Code.E0201:
                     raise
             self.driver.swipe_percentage(10, 50, direction, 25, event_name)
             time.sleep(3)
+        if not found:
+            raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after swiping {direction} for {timeout}s.")
 
     @with_self_healing
     def swipe_from_element(self, element: str, direction: str, swipe_length: str, aoi_x: str = "0", aoi_y: str = "0",

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -711,34 +711,21 @@ class ActionKeyword:
             internal_logger.debug(f"Clearing text from element '{element}'")
             self.driver.clear_text_element(located, event_name)
 
-    def get_text(self, element: str) -> Optional[str]:
+    @with_self_healing
+    def get_text(self, element: str, *, located=None) -> Optional[str]:
         """
         Get the text from a specified element.
 
         :param element: The target element (Image template, OCR template, or XPath).
         :return: The text from the element or None if not supported.
         """
-        screenshot_np = self._capture_screenshot_safe()
-        self._save_screenshot_if_available(screenshot_np, "get_text")
-        element_source_type = type(
-            self.element_source.current_instance).__name__
-        element_type = utils.determine_element_type(element)
-        if element_type in ["Text", "XPath"]:
-            if 'appium' in element_source_type.lower():
-                result = self.element_source.locate(element)
-                if result is not None:
-                    return self.driver.get_text_element(result)
-                else:
-                    internal_logger.error('Locate returned None for get_text.')
-                    return None
-            else:
-                internal_logger.error(
-                    'Get Text is not supported for vision based search yet.')
-                return None
-        else:
-            internal_logger.error(
-                'Get Text is not supported for image based search yet.')
+        if located is None:
+            internal_logger.error('get_text: located is None, element could not be found.')
             return None
+        if isinstance(located, tuple):
+            internal_logger.error('Get Text is not supported for coordinate-based (vision) results.')
+            return None
+        return self.driver.get_text_element(located)
 
     def sleep(self, duration: str) -> None:
         """

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -561,11 +561,13 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "scroll_until_element_appears")
         start_time = time.time()
+        found = False
         while time.time() - start_time < int(timeout):
             try:
                 result = self.verifier.assert_presence(
                     element, timeout_str="3", rule="any")
                 if result:
+                    found = True
                     break
             except OpticsError as e:
                 if e.code != Code.E0201:
@@ -575,6 +577,8 @@ class ActionKeyword:
                     raise
             self.driver.scroll(direction, 1000, event_name)
             time.sleep(3)
+        if not found:
+            raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after scrolling {direction} for {timeout}s.")
 
     @with_self_healing
     def scroll_from_element(self, element: str, direction: str, scroll_length: str, aoi_x: str = "0", aoi_y: str = "0",

--- a/optics_framework/api/app_management.py
+++ b/optics_framework/api/app_management.py
@@ -66,10 +66,12 @@ class AppManagement:
 
     def close_and_terminate_app(self) -> None:
         """
-        Closes and terminates a specified application.
+        Tears down the active driver session and flushes all pending events.
 
-        :param package_name: The package name of the application.
-        :param event_name: The event triggering the app termination, if any.
+        Behaviour depends on the configured driver: WebDriver-based drivers
+        (Appium, Selenium) call quit(); Playwright closes the page, context,
+        and browser; BLE closes the serial port. All variants flush pending
+        EventSDK events and release the driver reference.
         """
         self.driver.terminate()
 

--- a/optics_framework/api/app_management.py
+++ b/optics_framework/api/app_management.py
@@ -28,6 +28,9 @@ class AppManagement:
 
         This method should be called before performing any application
         management operations.
+
+        Not exposed on the Optics SDK because it currently performs no operation and doesn't
+        delegate to the driver's own initialise_setup (e.g. AppiumDriver.initialise_setup).
         """
         internal_logger.debug("Initialising setup for AppManagement.")
 

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -16,6 +16,7 @@ from optics_framework.common.logging_config import internal_logger, execution_lo
 from optics_framework.common.session_manager import Session
 from optics_framework.common.models import ApiData, ElementData
 from optics_framework.common.error import OpticsError, Code
+from optics_framework.common import utils
 
 
 NO_SESSION_PRESENT = "Session is None after ensure_session call."
@@ -58,28 +59,9 @@ class FlowControl:
 
     def _resolve_param(self, param: str) -> str:
         """Resolve ${variable} references from session.elements, always returning a scalar (first value if list)."""
-        param = param.strip()
-        if (
-            not isinstance(param, str)
-            or not param.startswith("${")
-            or not param.endswith("}")
-        ):
-            return str(param)
         if self.session is None:
             raise OpticsError(Code.E0702, message="Session is None in resolve_param.")
-        var_name = param[2:-1].strip()
-        elements = getattr(self.session, "elements", None)
-        if not isinstance(elements, ElementData):
-            raise OpticsError(Code.E0702, message=NO_SESSION_ELEMENT_PRESENT)
-        value = elements.get_element(var_name)
-        if value is None:
-            raise OpticsError(Code.E0702, message=f"Variable '{param}' not found in elements dictionary")
-        # If value is a list, return the first item
-        if isinstance(value, list):
-            if not value:
-                raise OpticsError(Code.E0702, message=f"Variable '{param}' is an empty list in elements dictionary")
-            return str(value[0])
-        return str(value)
+        return utils.resolve_scalar_param(self.session, param)
 
     def _get_validated_module_def(self, module_name: str) -> List[Tuple[str, List]]:
         """Validate session and modules, return the module definition or raise."""

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -822,11 +822,11 @@ class FlowControl:
         if self.session is None:
             raise OpticsError(Code.E0501, message=NO_SESSION_PRESENT)
         var_name = self._extract_variable_name(param1)
-        result = self._compute_expression(param2)
         runner_elements = getattr(self.session, "elements", None)
         if not isinstance(runner_elements, ElementData):
             runner_elements = ElementData()
             setattr(self.session, "elements", runner_elements)
+        result = self._compute_expression(param2)
         runner_elements.remove_element(var_name)
         runner_elements.add_element(var_name, str(result))
         return result

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -143,7 +143,12 @@ class FlowControl:
         raise OpticsError(Code.E0402, message=f"Keyword '{keyword}' not found in keyword_map.")
 
     def execute_module(self, module_name: str) -> List[Any]:
-        """Executes a module's keywords using the session's keyword_map."""
+        """Executes a module's keywords using the session's keyword_map.
+
+        Not exposed on the Optics SDK — session.modules is only populated by
+        CSV/YAML-driven execution; SDK/Robot Framework users should call keywords
+        directly or write a real function/keyword instead.
+        """
         module_def = self._get_validated_module_def(module_name)
         results = []
         execution_logger.info(f"Executing module: {module_name}")

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -851,7 +851,7 @@ class FlowControl:
 
         def replace_var(match):
             var_name = match.group(1)
-            value = runner_elements.get_element(var_name)
+            value = runner_elements.get_first(var_name)
             if value is None:
                 raise OpticsError(Code.E0702, message=f"Variable '{var_name}' not found in elements.")
             return str(value)
@@ -905,7 +905,7 @@ class FlowControl:
             return eval(
                 expression,
                 {"__builtins__": None},
-                {k: str(v) for k, v in runner_elements.elements.items()},
+                {k: v[0] for k, v in runner_elements.elements.items() if v},
             )  # nosec B307 # pylint: disable=eval-used
             # Note: eval() is used here for simplicity, i know it should be should be avoided in production code.
             # In some time, i will replace it with a safer alternative.

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -1,9 +1,10 @@
 from typing import Optional, Any, List
 
-from optics_framework.common.error import OpticsError, Code, Code, Code
+from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common import utils
 from optics_framework.common.base_factory import InstanceFallback
+from optics_framework.common.models import ElementData
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import StrategyManager
 from optics_framework.common.eventSDK import EventSDK
@@ -23,6 +24,7 @@ class Verifier:
         )
         self.event_sdk: EventSDK = builder.event_sdk
         self.execution_dir = builder.session_config.execution_output_path
+        self.session = builder.session
 
     def validate_element(
         self,
@@ -84,7 +86,7 @@ class Verifier:
             if located is None:
                 raise OpticsError(Code.E0201, message=f"Element '{element}' not found.")
             if isinstance(located, tuple):
-                raise OpticsError(Code.E0401, message=f"Cannot check enabled/disabled state for coordinate-based elements.")
+                raise OpticsError(Code.E0401, message="Cannot check enabled/disabled state for coordinate-based elements.")
 
             is_enabled = located.is_enabled()
             if state == "enabled" and not is_enabled:
@@ -100,15 +102,40 @@ class Verifier:
                 message=f"Unknown element_state '{element_state}'. Expected: visible, invisible, enabled, disabled."
             )
 
-    def assert_equality(self, output: Any, expression: Any, event_name: Optional[str] = None) -> None:
-        """
-        Compares two values for equality.
+    def _resolve_param(self, param: str) -> str:
+        """Resolve a `${variable}` reference from session elements, returning its first value."""
+        param = str(param).strip()
+        if not (param.startswith("${") and param.endswith("}")):
+            return param
+        var_name = param[2:-1].strip()
+        elements = getattr(self.session, "elements", None)
+        if not isinstance(elements, ElementData):
+            raise OpticsError(Code.E0702, message=f"Cannot resolve '{param}': no element data in session.")
+        value = elements.get_element(var_name)
+        if value is None:
+            raise OpticsError(Code.E0702, message=f"Variable '{param}' not found in session elements.")
+        if isinstance(value, list):
+            if not value:
+                raise OpticsError(Code.E0702, message=f"Variable '{param}' is an empty list.")
+            return str(value[0])
+        return str(value)
 
-        :param output: The first value to be compared.
-        :param expression: The second value to be compared.
-        :param event_name: The name of the event associated with the comparison, if any.
+    def assert_equality(self, output: Any, expression: Any, event_name: Optional[str] = None) -> bool:
         """
-        pass
+        Compares two values for equality. Both values are resolved from session
+        elements if they are ``${variable}`` references before comparison.
+
+        :param output: The actual value or ``${variable}`` reference.
+        :param expression: The expected value or ``${variable}`` reference.
+        :param event_name: The name of the event associated with the comparison, if any.
+        :return: True if equal, False otherwise.
+        """
+        actual = self._resolve_param(str(output)).strip()
+        expected = self._resolve_param(str(expression)).strip()
+        result = actual == expected
+        if result and event_name:
+            self.event_sdk.capture_event(event_name)
+        return result
 
 
     def assert_presence(self, elements: str, timeout_str: str = "30", rule: str = 'any', event_name: Optional[str] = None, fail=True) -> bool:

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -4,7 +4,6 @@ from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common import utils
 from optics_framework.common.base_factory import InstanceFallback
-from optics_framework.common.models import ElementData
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import StrategyManager
 from optics_framework.common.eventSDK import EventSDK
@@ -104,21 +103,7 @@ class Verifier:
 
     def _resolve_param(self, param: str) -> str:
         """Resolve a `${variable}` reference from session elements, returning its first value."""
-        param = str(param).strip()
-        if not (param.startswith("${") and param.endswith("}")):
-            return param
-        var_name = param[2:-1].strip()
-        elements = getattr(self.session, "elements", None)
-        if not isinstance(elements, ElementData):
-            raise OpticsError(Code.E0702, message=f"Cannot resolve '{param}': no element data in session.")
-        value = elements.get_element(var_name)
-        if value is None:
-            raise OpticsError(Code.E0702, message=f"Variable '{param}' not found in session elements.")
-        if isinstance(value, list):
-            if not value:
-                raise OpticsError(Code.E0702, message=f"Variable '{param}' is an empty list.")
-            return str(value[0])
-        return str(value)
+        return utils.resolve_scalar_param(self.session, param)
 
     def assert_equality(self, output: Any, expression: Any, event_name: Optional[str] = None) -> bool:
         """

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -248,6 +248,7 @@ class Verifier:
         screenshot = self.strategy_manager.capture_screenshot()
         if screenshot is not None:
             internal_logger.debug("Screenshot captured successfully")
+            utils.save_screenshot(screenshot, "capture_screenshot", output_dir=self.execution_dir)
             screenshot = utils.encode_numpy_to_base64(screenshot)
         else:
             internal_logger.warning("Screenshot capture returned None.")

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -23,6 +23,7 @@ class Verifier:
         )
         self.event_sdk: EventSDK = builder.event_sdk
         self.execution_dir = builder.session_config.execution_output_path
+        self.capture_output_dir = self.execution_dir if builder.session_config.save_captures else None
         self.session = builder.session
 
     def validate_element(
@@ -233,7 +234,7 @@ class Verifier:
         screenshot = self.strategy_manager.capture_screenshot()
         if screenshot is not None:
             internal_logger.debug("Screenshot captured successfully")
-            utils.save_screenshot(screenshot, "capture_screenshot", output_dir=self.execution_dir)
+            utils.save_screenshot(screenshot, "capture_screenshot", output_dir=self.capture_output_dir)
             screenshot = utils.encode_numpy_to_base64(screenshot)
         else:
             internal_logger.warning("Screenshot capture returned None.")
@@ -255,7 +256,7 @@ class Verifier:
         if result is not None:
             page_source, timestamp = result
             internal_logger.debug(f"Page source captured at timestamp: {timestamp}")
-            utils.save_page_source(page_source, timestamp, self.execution_dir)
+            utils.save_page_source(page_source, timestamp, self.capture_output_dir)
             if event_name:
                 self.event_sdk.capture_event(event_name)
             return {"page_source": page_source, "timestamp": timestamp}

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -244,8 +244,10 @@ class Verifier:
         :param event_name: The name of the event associated with the screenshot capture, if any.
         :return: The path to the captured screenshot.
         """
+        internal_logger.debug("Capturing screenshot")
         screenshot = self.strategy_manager.capture_screenshot()
         if screenshot is not None:
+            internal_logger.debug("Screenshot captured successfully")
             screenshot = utils.encode_numpy_to_base64(screenshot)
         else:
             internal_logger.warning("Screenshot capture returned None.")

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -1,6 +1,6 @@
 from typing import Optional, Any, List
 
-from optics_framework.common.error import OpticsError
+from optics_framework.common.error import OpticsError, Code, Code, Code
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common import utils
 from optics_framework.common.base_factory import InstanceFallback
@@ -58,7 +58,47 @@ class Verifier:
         :param timeout: The time to wait for the element in seconds.
         :param event_name: The name of the event associated with the check, if any.
         """
-        pass
+        state = element_state.strip().lower()
+
+        if state in ("visible", "invisible"):
+            try:
+                present = self.assert_presence(element, str(timeout), "any", event_name=None, fail=False)
+            except OpticsError:
+                present = False
+            if state == "visible" and not present:
+                raise OpticsError(Code.E0401, message=f"Element '{element}' is not visible.")
+            if state == "invisible" and present:
+                raise OpticsError(Code.E0401, message=f"Element '{element}' is visible but expected invisible.")
+            if event_name:
+                self.event_sdk.capture_event(event_name)
+
+        elif state in ("enabled", "disabled"):
+            located = None
+            try:
+                for result in self.strategy_manager.locate(element):
+                    located = result.value
+                    break
+            except OpticsError:
+                pass
+
+            if located is None:
+                raise OpticsError(Code.E0201, message=f"Element '{element}' not found.")
+            if isinstance(located, tuple):
+                raise OpticsError(Code.E0401, message=f"Cannot check enabled/disabled state for coordinate-based elements.")
+
+            is_enabled = located.is_enabled()
+            if state == "enabled" and not is_enabled:
+                raise OpticsError(Code.E0401, message=f"Element '{element}' is not enabled.")
+            if state == "disabled" and is_enabled:
+                raise OpticsError(Code.E0401, message=f"Element '{element}' is enabled but expected disabled.")
+            if event_name:
+                self.event_sdk.capture_event(event_name)
+
+        else:
+            raise OpticsError(
+                Code.E0403,
+                message=f"Unknown element_state '{element_state}'. Expected: visible, invisible, enabled, disabled."
+            )
 
     def assert_equality(self, output: Any, expression: Any, event_name: Optional[str] = None) -> None:
         """

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -265,6 +265,7 @@ class Verifier:
         result = self.strategy_manager.capture_pagesource()
         if result is not None:
             page_source, timestamp = result
+            utils.save_page_source(page_source, timestamp, self.execution_dir)
             if event_name:
                 self.event_sdk.capture_event(event_name)
             return {"page_source": page_source, "timestamp": timestamp}

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -263,10 +263,10 @@ class Verifier:
         :return: Dict with "page_source" and "timestamp" keys.
         """
         result = self.strategy_manager.capture_pagesource()
-        if event_name:
-            self.event_sdk.capture_event(event_name)
         if result is not None:
             page_source, timestamp = result
+            if event_name:
+                self.event_sdk.capture_event(event_name)
             return {"page_source": page_source, "timestamp": timestamp}
         raise ValueError("Page source capture returned None.")
 

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -262,9 +262,11 @@ class Verifier:
         :param event_name: The name of the event associated with the page source capture, if any.
         :return: Dict with "page_source" and "timestamp" keys.
         """
+        internal_logger.debug("Capturing page source")
         result = self.strategy_manager.capture_pagesource()
         if result is not None:
             page_source, timestamp = result
+            internal_logger.debug(f"Page source captured at timestamp: {timestamp}")
             utils.save_page_source(page_source, timestamp, self.execution_dir)
             if event_name:
                 self.event_sdk.capture_event(event_name)

--- a/optics_framework/common/config_handler.py
+++ b/optics_framework/common/config_handler.py
@@ -122,12 +122,16 @@ class ConfigHandler:
     def __init__(self, config: Config):
         self.project_name: Optional[str] = None
         self.global_config_path: str = self.DEFAULT_GLOBAL_CONFIG_PATH
-        if config.execution_output_path is None and config.project_path is not None:
-            config.execution_output_path = os.path.join(
-                config.project_path, "execution_output"
-            )
-            if not os.path.exists(config.execution_output_path):
-                os.makedirs(config.execution_output_path, exist_ok=True)
+        if config.execution_output_path is None:
+            if config.project_path is not None:
+                config.execution_output_path = os.path.join(
+                    config.project_path, "execution_output"
+                )
+            else:
+                config.execution_output_path = os.path.join(
+                    os.getcwd(), "execution_output"
+                )
+            os.makedirs(config.execution_output_path, exist_ok=True)
 
         self.config: Config = config
         self._enabled_configs: Dict[str, List[str]] = {}

--- a/optics_framework/common/config_handler.py
+++ b/optics_framework/common/config_handler.py
@@ -29,6 +29,7 @@ class Config(BaseModel):
     llm_models: List[Dict[str, DependencyConfig]] = Field(default_factory=list)
     file_log: bool = False
     json_log: bool = False
+    save_captures: bool = True
     json_path: Optional[str] = None
     log_level: str = "INFO"
     log_path: Optional[str] = None

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -1074,12 +1074,12 @@ def _empty_workspace_data(include_source: bool) -> Dict[str, Any]:
 
 
 async def _capture_source_safe(verifier: Verifier) -> str:
-    """Capture page source, returning empty string on failure."""
+    """Capture pagesource, returning empty string on failure."""
     try:
         source = await asyncio.to_thread(verifier.capture_pagesource)
         return source or ""
     except Exception as e:
-        internal_logger.warning(f"Failed to capture page source: {e}")
+        internal_logger.warning(f"Failed to capture pagesource: {e}")
         return ""
 
 

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -432,7 +432,8 @@ async def create_session(config: SessionConfig):
             text_detection=text_detection,
             image_detection=image_detection,
             project_path=config.project_path,
-            log_level=LOG_LEVEL_DEBUG
+            log_level=LOG_LEVEL_DEBUG,
+            save_captures=False  # do not save screenshots or pagesource when using `optics serve`
         )
         templates = (
             discover_templates(config.project_path) if config.project_path else None

--- a/optics_framework/common/logging_config.py
+++ b/optics_framework/common/logging_config.py
@@ -34,10 +34,16 @@ class LoggingManager:
             log_dir.mkdir(parents=True, exist_ok=True)
             internal_log_path = Path(log_path or log_dir / "internal_logs.log").expanduser()
             execution_log_path = Path(log_path or log_dir / "execution_logs.log").expanduser()
-            internal_file_handler = create_file_handler(internal_log_path, log_level, LOG_FORMATTER, use_sensitive=True)
-            execution_file_handler = create_file_handler(execution_log_path, log_level, LOG_FORMATTER, use_sensitive=True)
-            self.internal_logger.addHandler(internal_file_handler)
-            self.execution_logger.addHandler(execution_file_handler)
+            existing_internal = {getattr(h, "baseFilename", None) for h in self.internal_logger.handlers}
+            existing_execution = {getattr(h, "baseFilename", None) for h in self.execution_logger.handlers}
+            if str(internal_log_path) not in existing_internal:
+                self.internal_logger.addHandler(
+                    create_file_handler(internal_log_path, log_level, LOG_FORMATTER, use_sensitive=True)
+                )
+            if str(execution_log_path) not in existing_execution:
+                self.execution_logger.addHandler(
+                    create_file_handler(execution_log_path, log_level, LOG_FORMATTER, use_sensitive=True)
+                )
 
     def stop_listeners(self):
         def safe_stop(listener, name):

--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -60,7 +60,10 @@ class DataReader(ABC):
         :return: True if the parameter is in key=value format, False otherwise.
         :rtype: bool
         """
-        return "=" in param and not param.startswith(("/", "//", "("))
+        if param.startswith(("/", "//", "(")):
+            return False
+        # Must have a single = that is not part of ==, !=, <=, >=
+        return bool(re.search(r'(?<![=!<>])=(?!=)', param))
 
     @abstractmethod
     def read_test_cases(self, file_path: str) -> dict:

--- a/optics_framework/common/runner/test_runnner.py
+++ b/optics_framework/common/runner/test_runnner.py
@@ -325,46 +325,51 @@ class TestRunner(Runner):
     ) -> bool:
         capture_handler = LogCaptureBuffer()
         execution_logger.addHandler(capture_handler)
+        should_retry = False
+        try:
+            keyword_result = self._find_result(
+                test_case_result.name, module_node.name, keyword_node.id
+            )
+            internal_logger.debug(
+                "Executing keyword: %s (id: %s)", keyword_node.name, keyword_node.id
+            )
+            start_time = time.time()
 
-        keyword_result = self._find_result(
-            test_case_result.name, module_node.name, keyword_node.id
-        )
-        internal_logger.debug(
-            "Executing keyword: %s (id: %s)", keyword_node.name, keyword_node.id
-        )
-        start_time = time.time()
+            keyword_node.state = State.RUNNING
+            await self._send_event(
+                "keyword",
+                keyword_node,
+                EventStatus.RUNNING,
+                parent_id=module_node.id,
+                start_time=start_time,
+            )
+            self._update_status(
+                keyword_result, "RUNNING", time.time() - start_time, test_case_result.name
+            )
 
-        keyword_node.state = State.RUNNING
-        await self._send_event(
-            "keyword",
-            keyword_node,
-            EventStatus.RUNNING,
-            parent_id=module_node.id,
-            start_time=start_time,
-        )
-        self._update_status(
-            keyword_result, "RUNNING", time.time() - start_time, test_case_result.name
-        )
+            func_name = "_".join(keyword_node.name.split()).lower()
+            method = self.keyword_map.get(func_name)
+            if not method:
+                await self._handle_keyword_not_found(keyword_node, module_node, keyword_result, start_time, test_case_result)
+                return False
 
-        func_name = "_".join(keyword_node.name.split()).lower()
-        method = self.keyword_map.get(func_name)
-        if not method:
-            await self._handle_keyword_not_found(keyword_node, module_node, keyword_result, start_time, test_case_result)
-            return False
+            param_candidates = await self._build_param_candidates(keyword_node, keyword_node.params, module_node, keyword_result, start_time, test_case_result, capture_handler)
+            if param_candidates is None:
+                return False
 
-        param_candidates = await self._build_param_candidates(keyword_node, keyword_node.params, module_node, keyword_result, start_time, test_case_result, capture_handler)
-        if param_candidates is None:
-            return False
+            result = await self._try_execute_with_fallback(
+                method, param_candidates, keyword_node, module_node, keyword_result, start_time, test_case_result, capture_handler
+            )
+            if result is not None:
+                return result
 
-        result = await self._try_execute_with_fallback(
-            method, param_candidates, keyword_node, module_node, keyword_result, start_time, test_case_result, capture_handler
-        )
-        if result is not None:
-            return result
+            await self._handle_fallback_exhausted(keyword_node, module_node, keyword_result, start_time, test_case_result, capture_handler)
+            await asyncio.sleep(self.config.halt_duration)
+            should_retry = await self._process_commands(keyword_node, module_node)
+        finally:
+            execution_logger.removeHandler(capture_handler)
 
-        await self._handle_fallback_exhausted(keyword_node, module_node, keyword_result, start_time, test_case_result, capture_handler)
-        await asyncio.sleep(self.config.halt_duration)
-        if await self._process_commands(keyword_node, module_node):
+        if should_retry:
             return await self._execute_keyword(
                 keyword_node, module_node, test_case_result, extra
             )

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -415,7 +415,7 @@ class PagesourceStrategy:
 
     def capture_pagesource(self) -> Optional[Tuple[str, str]]:
         """
-        Capture page source and timestamp from the element source.
+        Capture pagesource and timestamp from the element source.
         Returns:
             Optional[Tuple[str, str]]: (page_source, timestamp) or None
         """

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -13,9 +13,39 @@ from typing import Callable, List, Optional, Tuple, Any, Union, get_origin, get_
 import inspect
 from skimage.metrics import structural_similarity as ssim
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.common.error import OpticsError, Code
+from optics_framework.common.models import ElementData
 
 OUTPUT_PATH_NOT_SET_MSG = "output_dir is required. Pass it from the session's execution_output_path."
 TEXT_ONLY_PREFIX = "text_only:"
+WHOLE_VAR_PATTERN = re.compile(r"^\$\{([^}]+)\}$")
+
+
+def resolve_scalar_param(session: Any, param: str) -> str:
+    """
+    Resolve a `${name}` reference from `session.elements`, returning its first value as a string.
+
+    Only resolves when the *entire* param is exactly one `${name}` reference (anchored match) —
+    a param that embeds `${var}` inside a larger expression (e.g. `${a} + ${b}`) is left
+    untouched, since that's for the keyword itself to substitute (see `Evaluate`/`Condition`).
+    Non-matching input is returned unchanged (stripped).
+    """
+    if not isinstance(param, str):
+        param = str(param)
+    param = param.strip()
+    match = WHOLE_VAR_PATTERN.match(param)
+    if not match:
+        return param
+    var_name = match.group(1).strip()
+    elements = getattr(session, "elements", None)
+    if not isinstance(elements, ElementData):
+        raise OpticsError(Code.E0702, message=f"Cannot resolve '{param}': no element data in session.")
+    value = elements.get_element(var_name)
+    if value is None:
+        raise OpticsError(Code.E0201, message=f"Variable '{param}' not found in session elements.")
+    if not value:
+        raise OpticsError(Code.E0201, message=f"Variable '{param}' is an empty list.")
+    return str(value[0])
 
 
 class SpecialKey(Enum):

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -1117,7 +1117,12 @@ class Appium(DriverInterface):
         return mapping.get(char.lower())
 
     def get_text_element(self, element: Any) -> str:
-        text = element.get_attribute("text") or element.get_attribute("value")
+        text = element.get_attribute("text")
+        if text is None:
+            try:
+                text = element.get_attribute("value")
+            except Exception:
+                text = None
         internal_logger.info(f"Text of element: {text}")
         if text is None:
             raise OpticsError(Code.E0401, message="Element text is None")

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 from appium import webdriver
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.client_config import AppiumClientConfig
+from selenium.common import WebDriverException
 from selenium.webdriver.remote.command import Command  # type: ignore
 from appium.options.android.uiautomator2.base import UiAutomator2Options
 from appium.options.ios import XCUITestOptions # type: ignore
@@ -1121,7 +1122,7 @@ class Appium(DriverInterface):
         if text is None:
             try:
                 text = element.get_attribute("value")
-            except Exception:
+            except WebDriverException:
                 text = None
         internal_logger.info(f"Text of element: {text}")
         if text is None:

--- a/optics_framework/engines/drivers/appium_UI_helper.py
+++ b/optics_framework/engines/drivers/appium_UI_helper.py
@@ -1171,10 +1171,13 @@ class UIHelper:
     def _is_input(self, node: etree.Element) -> bool:
         """Check if element is an input/text field."""
         tag = node.tag or ""
-        # Android: EditText, TextView (when editable)
+        # Android: EditText, TextView (when editable/focusable)
         # iOS: XCUIElementTypeTextField, XCUIElementTypeSecureTextField, XCUIElementTypeTextView
-        input_tags = ["TextField", "EditText", "SecureTextField", "TextView"]
-        return any(input_tag in tag for input_tag in input_tags)
+        if any(t in tag for t in ["TextField", "EditText", "SecureTextField"]):
+            return True
+        if "TextView" in tag and node.attrib.get("focusable") == "true":
+            return True
+        return False
 
     def _is_image(self, node: etree.Element) -> bool:
         """Check if element is an image."""

--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -109,8 +109,9 @@ class AppiumFindElement(ElementSourceInterface):
                 internal_logger.error('Error finding element: %s', element, exc_info=True)
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         elif element_type == 'Text':
+            locator = element[len("text="):] if element.lower().startswith("text=") else element
             try:
-                found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, element)
+                found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)
                 return found_element
             except Exception as e:
                 internal_logger.exception(f" element: {element}", exc_info=e)

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -99,12 +99,13 @@ class AppiumPageSource(ElementSourceInterface):
             internal_logger.debug('Appium Page Source does not support finding images.')
             return None
         elif element_type == 'Text':
+            locator = element[len("text="):] if element.lower().startswith("text=") else element
             if index is not None:
-                xpath = self.find_xpath_from_text_index(element, index)
+                xpath = self.find_xpath_from_text_index(locator, index)
             else:
-                xpath = self.find_xpath_from_text(element)
+                xpath = self.find_xpath_from_text(locator)
             try:
-                execution_logger.debug(f"Finding element by text: {element} with xpath: {xpath}")
+                execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
                 element_obj = driver.find_element(AppiumBy.XPATH, xpath)
                 return element_obj
             except Exception:

--- a/optics_framework/helper/generate.py
+++ b/optics_framework/helper/generate.py
@@ -163,7 +163,7 @@ class YAMLDataReader(DataReader):
             "Validate Screen",
             "Get Interactive Elements",
             "Capture Screenshot",
-            "Capture Page Source",
+            "Capture Pagesource",
             "Quit",
         }
         modules_list = data.get("Modules", [])
@@ -226,7 +226,7 @@ class TestFrameworkGenerator(ABC):
             "Validate Screen": "validate_screen",
             "Get Interactive Elements": "get_interactive_elements",
             "Capture Screenshot": "capture_screenshot",
-            "Capture Page Source": "capture_pagesource",
+            "Capture Pagesource": "capture_pagesource",
             "Quit": "quit",
         }
 

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -1019,6 +1019,23 @@ class Optics:
             raise ValueError(INVALID_SETUP)
         return self.action_keyword.get_text(cast(str, element))
 
+    @keyword("Select Dropdown Option")
+    @fallback_params
+    def select_dropdown_option(
+        self,
+        element: fallback_str,
+        option: fallback_str,
+        event_name: Optional[fallback_str] = None,
+    ) -> None:
+        """Open a dropdown and select one of its options."""
+        if not self.action_keyword:
+            raise ValueError(INVALID_SETUP)
+        self.action_keyword.select_dropdown_option(
+            element=cast(str, element),
+            option=cast(str, option),
+            event_name=cast(Optional[str], event_name),
+        )
+
     @keyword("Sleep")
     @fallback_params
     def sleep(self, duration: fallback_str) -> None:
@@ -1110,6 +1127,42 @@ class Optics:
             event_name=cast(Optional[str], event_name),
         )
 
+    @keyword("Assert Equality")
+    @fallback_params
+    def assert_equality(
+        self,
+        output: fallback_str,
+        expression: fallback_str,
+        event_name: Optional[fallback_str] = None,
+    ) -> bool:
+        """Compare two values (or ${variable} references) for equality."""
+        if not self.verifier:
+            raise ValueError(INVALID_SETUP)
+        return self.verifier.assert_equality(
+            output=cast(str, output),
+            expression=cast(str, expression),
+            event_name=cast(Optional[str], event_name),
+        )
+
+    @keyword("Is Element")
+    @fallback_params
+    def is_element(
+        self,
+        element: fallback_str,
+        element_state: fallback_str,
+        timeout: fallback_str,
+        event_name: Optional[fallback_str] = None,
+    ) -> None:
+        """Check if the specified element is in a given state (visible/invisible/enabled/disabled)."""
+        if not self.verifier:
+            raise ValueError(INVALID_SETUP)
+        self.verifier.is_element(
+            element=cast(str, element),
+            element_state=cast(str, element_state),
+            timeout=int(cast(str, timeout)),
+            event_name=cast(Optional[str], event_name),
+        )
+
     @keyword("Get Interactive Elements")
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None) -> List:
         """
@@ -1142,6 +1195,13 @@ class Optics:
         if not self.verifier:
             raise ValueError(INVALID_SETUP)
         return self.verifier.capture_pagesource()
+
+    @keyword("Get Screen Elements")
+    def get_screen_elements(self) -> dict:
+        """Capture a screenshot and retrieve interactive elements for API response."""
+        if not self.verifier:
+            raise ValueError(INVALID_SETUP)
+        return self.verifier.get_screen_elements()
 
     @keyword("Invoke API")
     @fallback_params

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -1189,7 +1189,7 @@ class Optics:
             raise ValueError(INVALID_SETUP)
         return self.verifier.capture_screenshot()
 
-    @keyword("Capture Page Source")
+    @keyword("Capture Pagesource")
     def capture_pagesource(self) -> dict:
         """Capture the page source and timestamp of the current screen."""
         if not self.verifier:

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -284,6 +284,7 @@ class Optics:
         project_path = None
         execution_output_path = execution_output_path_param
         event_attributes_json = None
+        save_captures = None
         _driver_config = driver_sources
         _element_source_config = elements_sources
         _image_config = image_detection
@@ -311,6 +312,7 @@ class Optics:
                 "execution_output_path", execution_output_path_param
             )
             event_attributes_json = parsed_config.get("event_attributes_json")
+            save_captures = parsed_config.get("save_captures")
         elif _driver_config is not None and _element_source_config is not None:
             internal_logger.warning(
                 "Using deprecated parameter format. Consider migrating to the new config parameter."
@@ -328,6 +330,7 @@ class Optics:
             "project_path": project_path,
             "execution_output_path": execution_output_path,
             "event_attributes_json": event_attributes_json,
+            "save_captures": save_captures,
         }
 
     def discover_templates(self, project_path: str) -> TemplateData:

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -449,13 +449,15 @@ class TestSwipeUntilElementAppears:
     @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
     @patch('optics_framework.api.action_keyword.time.time')
     def test_timeout_stops_loop(self, mock_time, mock_sleep, action_keyword):
-        """Element never found, loop exits after timeout."""
+        """Element never found, loop exits after timeout and raises."""
         mock_time.side_effect = [0, 0, 3, 6, 9, 12]
 
         with patch.object(
             action_keyword.verifier, 'assert_presence',
             side_effect=OpticsError(Code.E0201, message="Element not found")
         ):
-            action_keyword.swipe_until_element_appears("element", "down", "10")
+            with pytest.raises(OpticsError) as exc_info:
+                action_keyword.swipe_until_element_appears("element", "down", "10")
 
+        assert exc_info.value.code == Code.E0201
         assert action_keyword.driver.swipe_percentage.call_count == 4

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -22,6 +22,9 @@ class MockOpticsBuilder(OpticsBuilder):
         self.session_config = MagicMock()
         self.session_config.execution_output_path = self.temp_dir
 
+        # Mock session (Verifier reads builder.session directly)
+        self.session = MagicMock()
+
     def get_driver(self):
         return self.mock_driver
 

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -375,7 +375,8 @@ class TestSelectDropdownOption:
     """select_dropdown_option must open the dropdown then select the option (not a no-op)."""
 
     def test_opens_dropdown_then_selects_option(self, action_keyword):
-        with patch.object(action_keyword, "press_element") as mock_press:
+        with patch.object(action_keyword, "press_element") as mock_press, \
+             patch.object(action_keyword.strategy_manager, "get_interactive_elements", return_value=[{"text": "India"}]):
             action_keyword.select_dropdown_option("Country", "India", event_name="evt")
 
         assert mock_press.call_count == 2

--- a/tests/units/api/test_flow_control_all.py
+++ b/tests/units/api/test_flow_control_all.py
@@ -39,6 +39,19 @@ def flow_control():
         'concat': lambda a, b: f"{a}{b}",
     })
 
+# ---- evaluate Tests ----
+def test_evaluate_bare_name_resolves_to_scalar_not_list_repr(flow_control):
+    flow_control.session.elements.add_element("count", "15")
+    result = flow_control.evaluate("${result}", "count")
+    assert result == "15"
+    assert flow_control.session.elements.get_first("result") == "15"
+
+def test_evaluate_ignores_elements_with_empty_value_list(flow_control):
+    flow_control.session.elements.elements["empty"] = []
+    flow_control.session.elements.add_element("a", "5")
+    result = flow_control.evaluate("${result}", "${a}")
+    assert result == 5
+
 # ---- read_data Tests ----
 def test_read_data_csv_relative(tmp_path, flow_control, monkeypatch):
     csv_content = 'a,b\n1,2\n3,4\n5,6'

--- a/tests/units/test_optics.py
+++ b/tests/units/test_optics.py
@@ -30,6 +30,22 @@ def live_servers():
     thread.join()
 
 
+def test_extract_config_data_forwards_save_captures():
+    optics = Optics()
+    config_data = optics._extract_config_data(
+        config={
+            "driver_sources": [],
+            "elements_sources": [],
+            "save_captures": False,
+        },
+        driver_sources=None,
+        elements_sources=None,
+        image_detection=None,
+        text_detection=None,
+        execution_output_path_param=None,
+    )
+    assert config_data["save_captures"] is False
+
 def test_setup_and_elements():
     elements = load_elements(ELEMENTS_CSV_PATH)
     config = load_config(CONTACT_CONFIG_PATH)


### PR DESCRIPTION
A fix for bugged/not implemented keywords documented at: https://github.com/kun-codes/optics-framework/tree/docs/live-keyword-notes


Broken / doesn't work:
~~- [ ] `assert_presence`~~ (false positive)
- [x] `capture_pagesource`
- [x] `capture_screenshot`
- [x] `enter_number`
- [x] `enter_text_using_keyboard`
- [x] `evaluate`
- [ ] `get_app_version` [^1]
- [x] `get_text`
- [ ] `invoke_api`
~~- [ ] `launch_app`~~ (not supposed to be called when after session is started, cannot test since `optics serve` starts a session)


Works but has a bug:
- [x] `clear_element_text`
- [x] `close_and_terminate_app` (possibly wrong documentation about what it does)
- [ ] `date_evaluate` (cannot fix it since it needs `optics live` to work for testing before )
- [x] `enter_text`
- [x] `get_interactive_elements`
- [x] `press_by_coordinates`
- [x] `press_keycode`
- [x] `scroll_until_element_appears`
- [x] `swipe_until_element_appears`

Missing from docs:
- [x] `assert_equality`(not implemented too)
- [x] `get_screen_elements`
- [x] `is_element` (not implemented too)
- [x] `swipe_by_percentage` (wrong keyword mentioned in docs)
- [x] `select_dropdown_option` (has a bug too)


Not yet tested:
- [ ] `condition`
- [ ] `execute_module`
- [ ] `run_loop`

Additional Notes:
- `get_screen_elements` returns a screenshot in base64 through the response json which makes the json too big. It would be more efficient to return a url link through the response json which the client can download if needed
- `get_interactive_elements` without any filter returns all interactive elements which is misleading
- `close_and_terminate_app`'s name seems to be misleading. Refer to what it actually does at commit: 93a101787912a537468417c0159895d869b9344f

Additional Bugs:
- [x] Some keywords' logs are duplicated twice in log files

[^1]: uses `adb` on android. `adb` cannot reach the device since appium won't forward adb in an insecure way without configuring it on the server
