### PR TITLE
chore(dependencies): make `pytest` have the same version range in both dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ mcp = ["fastmcp"]
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=4.24.1,<4.31.0"
-pytest = ">=8.3.4,<9.1.0"
+pytest = ">=8.3.5,<10.0.0"
 pytest-cov = ">=6.0,<7.1"
 commitizen = "^4.4.1"
 pre-commit = "^4.2.0"


### PR DESCRIPTION
`pytest` is a part of both regular dependencies and dev dependencies. This pr will make the version range for both pytest in both dependency groups the same. 

Note: pytest cannot be removed from regular dependencies as it is used in `optics_framework/common/runner/test_runnner.py`