### PR TITLE
chore(dependencies): make pytest have the same version range in both dependency groups

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4715,4 +4715,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b84096b9ab4e0a0564c1c407a22f81702b72ec3d19ff5027380b84d75ae89dea"
+content-hash = "495088b58bae6938bbeffa7ce9551c06feb82bb2b98d5dc511e6b87a75af397a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ mcp = ["fastmcp"]
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=4.24.1,<4.31.0"
-pytest = ">=8.3.4,<9.1.0"
+pytest = ">=8.3.5,<10.0.0"
 pytest-cov = ">=6.0,<7.1"
 commitizen = "^4.4.1"
 pre-commit = "^4.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ mkdocs-minify-plugin = "^0.8.0"
 optics = "optics_framework.helper.cli:main"
 
 [tool.pytest.ini_options]
-minversion = "8.3.4"
+minversion = "8.3.5"
 addopts = "-ra -q --cov=optics_framework"
 testpaths = ["tests"]
 


### PR DESCRIPTION
`pytest` is a part of both regular dependencies and dev dependencies. This pr will make the version range for both pytest in both dependency groups the same. 

Note: `pytest` cannot be removed from regular dependencies as it is used in `optics_framework/common/runner/test_runnner.py`