### PR TITLE
chore/move pytest config to pytest.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,13 +198,13 @@ For an `execute` run, `config.execution_output_path` (default `<project>/executi
 - **`OPTICS_EVENT_DRAIN_TIMEOUT_S`** (`execution.py:266`, default `2.0`) caps shutdown-side event flushing. Truncated JUnit XML on long runs → raise this env before debugging logic.
 - **Robot Framework is optional.** `optics.py:53` provides no-op `keyword` / `library` decorators when `robotframework` isn't installed. Don't hard-import `robot.api`; mirror the try/except.
 - **`element_source.locate` stubs hide strategies.** `LocatorStrategy._is_method_implemented` (`strategies.py:66`) reads source to detect bodies that just `raise NotImplementedError` and excludes that source from the strategy. A poorly-stubbed new element source can silently disappear from the strategy list.
-- **Two test trees.** `tests/units/` and `tests/feature/` both run under one `pytest` invocation (`pyproject.toml:83`, `testpaths = ["tests"]`). Markers (`white_box`, `black_box`, `hybrid`, `generate`) scope: `pytest -m white_box`. `tests/conftest.py` injects shared fixtures.
+- **Two test trees.** `tests/units/` and `tests/feature/` both run under one `pytest` invocation (`pytest.toml`, `testpaths = ["tests"]`). Markers (`white_box`, `black_box`, `hybrid`, `generate`) scope: `pytest -m white_box`. `tests/conftest.py` injects shared fixtures.
 
 ## Commands
 
 ```bash
 poetry install --with dev,test,docs       # full setup
-poetry run pytest                          # tests + coverage (configured in pyproject.toml)
+poetry run pytest                          # tests + coverage (configured in pytest.toml)
 poetry run pytest -m white_box             # unit subset
 poetry run ruff check --fix .              # lint + autofix
 poetry run pre-commit run --files <paths>  # hook chain on touched files

--- a/poetry.lock
+++ b/poetry.lock
@@ -4715,4 +4715,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "495088b58bae6938bbeffa7ce9551c06feb82bb2b98d5dc511e6b87a75af397a"
+content-hash = "edc4dee74b655d846bb1aa1d8fa0d6a467489f7d4e13392d907a05c561f30e1a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,6 @@ mkdocs-minify-plugin = "^0.8.0"
 [tool.poetry.scripts]
 optics = "optics_framework.helper.cli:main"
 
-[tool.pytest.ini_options]
-minversion = "9.0.0"
-addopts = "-ra -q --cov=optics_framework"
-testpaths = ["tests"]
-
 [tool.pylint.main]
 disable = ["C0114", "C0115", "C0116"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ sse-starlette = ">=2.2.1,<4.0.0"
 fastapi = ">=0.115.12,<0.138.0"
 requests = "^2.32.3"
 textual = ">=3,<7"
-pytest = ">=8.3.5,<10.0.0"
+pytest = "^9.0.0"
 pydantic = "^2.11.2"
 scikit-image = "^0.25.2"
 uvicorn = ">=0.35,<0.43"
@@ -56,7 +56,7 @@ mcp = ["fastmcp"]
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=4.24.1,<4.31.0"
-pytest = ">=8.3.5,<10.0.0"
+pytest = "^9.0.0"
 pytest-cov = ">=6.0,<7.1"
 commitizen = "^4.4.1"
 pre-commit = "^4.2.0"
@@ -65,7 +65,7 @@ bandit = "^1.8.3"
 pylint = ">=3.3.7,<5.0.0"
 
 [tool.poetry.group.test.dependencies]
-pytest = ">=8.3.4,<9.1.0"
+pytest = "^9.0.0"
 pytest-cov = ">=6.0,<7.1"
 pytest-mock = ">=3.14,<3.16"
 
@@ -79,7 +79,7 @@ mkdocs-minify-plugin = "^0.8.0"
 optics = "optics_framework.helper.cli:main"
 
 [tool.pytest.ini_options]
-minversion = "8.3.5"
+minversion = "9.0.0"
 addopts = "-ra -q --cov=optics_framework"
 testpaths = ["tests"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-markers =
-    generate: marks tests as generate-related (deselect with '-m "not generate"')
-    white_box: marks tests as white-box unit tests
-    black_box: marks tests as black-box integration tests
-    hybrid: marks tests as hybrid (both unit and integration testing)

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,0 +1,10 @@
+[pytest]
+minversion = "9.0.0"
+addopts = ["-ra", "-q", "--cov=optics_framework"]
+testpaths = ["tests"]
+markers = [
+    "generate: marks tests as generate-related (deselect with '-m \"not generate\"')",
+    "white_box: marks tests as white-box unit tests",
+    "black_box: marks tests as black-box integration tests",
+    "hybrid: marks tests as hybrid (both unit and integration testing)",
+]


### PR DESCRIPTION
- **chore(dependencies): make `pytest` have the same version range in both dependency groups**
- **chore(dependencies): bump `minversion` of `pytest` to `8.3.5` in `pyproject.toml`**
- **chore(dependencies): update `content-hash` in `poetry.lock`**
- **chore(dependencies): bump `pytest` to `^9.0.0` across all dependency groups**
