### PR TITLE
fix/fix keywords on ios

### DIFF
--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -617,7 +617,10 @@ def _build_named_param_context(
 ) -> _NamedParamsContext:
     """Normalize named params and build context for fallback combos."""
     sig = inspect.signature(method)
-    all_param_names = [p.name for p in sig.parameters.values() if p.name != "self"]
+    all_param_names = [
+        p.name for p in sig.parameters.values()
+        if p.name != "self" and p.kind != inspect.Parameter.KEYWORD_ONLY
+    ]
     normalized_param_lists: List[List[str]] = []
     provided_param_names: List[str] = []
     param_defaults: Dict[str, Any] = {}

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -4,6 +4,7 @@ from appium import webdriver
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.client_config import AppiumClientConfig
 from selenium.common import WebDriverException, NoSuchElementException
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.command import Command  # type: ignore
 from appium.options.android.uiautomator2.base import UiAutomator2Options
 from appium.options.ios import XCUITestOptions # type: ignore
@@ -77,6 +78,21 @@ class Appium(DriverInterface):
         SpecialKey.POWER: 26,
         SpecialKey.CAMERA: 27,
         SpecialKey.SEARCH: 84,
+    }
+    # ios fallback for the "Basic keys" subset of KEYCODE_MAP press_keycode is a
+    # uiautomator2 only android command with no XCUITest equivalent, so these keys
+    # are sent as W3C Keys codepoints to the focused element instead. The
+    # Mobile/System keys above are Android hardware buttons with no ios equivalent
+    #
+    # We can't use XCUITest's own `mobile: keys` execute method here either -
+    # per its docs it only works on iPad; calling it on iPhone has no effect:
+    # https://appium.github.io/appium-xcuitest-driver/11.17/reference/execute-methods/#mobile-keys
+    SELENIUM_KEY_MAP = {
+        SpecialKey.ENTER: Keys.ENTER,
+        SpecialKey.TAB: Keys.TAB,
+        SpecialKey.BACKSPACE: Keys.BACK_SPACE,
+        SpecialKey.SPACE: Keys.SPACE,
+        SpecialKey.ESCAPE: Keys.ESCAPE,
     }
 
 
@@ -982,6 +998,31 @@ class Appium(DriverInterface):
                     "No element currently has keyboard focus; cannot enter text directly."
                 )
 
+    def _press_special_key(self, driver: Any, key: SpecialKey, keycode: int) -> None:
+        # `press_keycode` is a UiAutomator2-only Android keyevent command; XCUITest has
+        # no equivalent, so fall back to sending the matching W3C Keys codepoint
+        # (https://appium.readthedocs.io/en/stable/en/commands/element/actions/send-keys/)
+        # to whichever element currently has keyboard focus.
+        try:
+            driver.press_keycode(keycode)
+        except WebDriverException:
+            selenium_key = self.SELENIUM_KEY_MAP.get(key)
+            if selenium_key is None:
+                raise OpticsError(
+                    Code.E0401,
+                    message=f"Special key '{key.value}' is not supported on this platform.",
+                )
+            try:
+                driver.switch_to.active_element.send_keys(selenium_key)
+            except NoSuchElementException:
+                internal_logger.error(
+                    "No element currently has keyboard focus; cannot send special key."
+                )
+                raise OpticsError(
+                    Code.E0401,
+                    message="No element currently has keyboard focus.",
+                )
+
     def enter_text(self, text: Union[str, SpecialKey], event_name: Optional[str] = None) -> None:
         driver = self._require_driver()
         if event_name:
@@ -994,7 +1035,7 @@ class Appium(DriverInterface):
                     f"Pressing Detected SpecialKey: {text}. Keycode: {keycode}"
                 )
                 internal_logger.debug(f"Pressing SpecialKey: {text}")
-                driver.press_keycode(keycode)
+                self._press_special_key(driver, text, keycode)
             else:
                 internal_logger.warning(f"Unknown special key: {text}")
                 internal_logger.debug(f"Unknown special key, treating as text: {text}")
@@ -1025,7 +1066,7 @@ class Appium(DriverInterface):
         if keycode is not None:
             internal_logger.debug(f"Pressing Detected SpecialKey: {text}. Keycode: {keycode}")
             internal_logger.debug(f"Pressing SpecialKey: {text}")
-            driver.press_keycode(keycode)
+            self._press_special_key(driver, text, keycode)
             return
         internal_logger.warning(f"Unknown special key: {text}")
         internal_logger.debug(f"Unknown special key, treating as text: {text}")

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -1118,12 +1118,18 @@ class Appium(DriverInterface):
         return mapping.get(char.lower())
 
     def get_text_element(self, element: Any) -> str:
-        text = element.get_attribute("text")
-        if text is None:
+        text: Optional[str] = None
+        # "value", "label" and "name" are for ios. Found at
+        # https://appium.github.io/appium-xcuitest-driver/11.17/reference/element-attributes/
+        # "text" is enough for android. Found at
+        # https://github.com/appium/appium-uiautomator2-driver/blob/5e7f19e70caa31851f620b1381509d442c4854ac/README.md#element-attributes
+        for attr in ("text", "value", "label", "name"):
             try:
-                text = element.get_attribute("value")
+                text = element.get_attribute(attr)
             except WebDriverException:
-                text = None
+                continue
+            if text is not None:
+                break
         internal_logger.info(f"Text of element: {text}")
         if text is None:
             raise OpticsError(Code.E0401, message="Element text is None")

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 from appium import webdriver
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.client_config import AppiumClientConfig
-from selenium.common import WebDriverException
+from selenium.common import WebDriverException, NoSuchElementException
 from selenium.webdriver.remote.command import Command  # type: ignore
 from appium.options.android.uiautomator2.base import UiAutomator2Options
 from appium.options.ios import XCUITestOptions # type: ignore
@@ -972,9 +972,15 @@ class Appium(DriverInterface):
         try:
             # path for android
             driver.execute_script(self.MOBILE_TYPE_COMMAND, {"text": text})
-        except WebDriverException as e:
+        except WebDriverException:
             # path for ios because MOBILE_TYPE_COMMAND doesn't exist for ios which uses XCUITest
-            driver.switch_to.active_element.send_keys(text)
+            try:
+                driver.switch_to.active_element.send_keys(text)
+            except NoSuchElementException:
+                # this executes when no element is focussed on the ios device
+                internal_logger.error(
+                    "No element currently has keyboard focus; cannot enter text directly."
+                )
 
     def enter_text(self, text: Union[str, SpecialKey], event_name: Optional[str] = None) -> None:
         driver = self._require_driver()

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -964,6 +964,18 @@ class Appium(DriverInterface):
         internal_logger.debug(f"Clearing text in element: {element}")
         element.clear()
 
+    def _type_into_focused_element(self, driver: Any, text: str) -> None:
+        # "mobile: type" is a UiAutomator2-only command with no XCUITest equivalent
+        # (https://github.com/appium/appium/issues/16419). On ios, fall back to the
+        # standard "active element" endpoint to resolve the keyboard-focused element
+        # and send keys to it directly.
+        try:
+            # path for android
+            driver.execute_script(self.MOBILE_TYPE_COMMAND, {"text": text})
+        except WebDriverException as e:
+            # path for ios because MOBILE_TYPE_COMMAND doesn't exist for ios which uses XCUITest
+            driver.switch_to.active_element.send_keys(text)
+
     def enter_text(self, text: Union[str, SpecialKey], event_name: Optional[str] = None) -> None:
         driver = self._require_driver()
         if event_name:
@@ -981,11 +993,11 @@ class Appium(DriverInterface):
                 internal_logger.warning(f"Unknown special key: {text}")
                 internal_logger.debug(f"Unknown special key, treating as text: {text}")
                 text_to_send = utils.strip_sensitive_prefix(str(text))
-                driver.execute_script(self.MOBILE_TYPE_COMMAND, {"text": text_to_send})
+                self._type_into_focused_element(driver, text_to_send)
         else:
             internal_logger.debug(f"Entering text: {text}")
             text_to_send = utils.strip_sensitive_prefix(str(text))
-            driver.execute_script(self.MOBILE_TYPE_COMMAND, {"text": text_to_send})
+            self._type_into_focused_element(driver, text_to_send)
 
     def clear_text(self, event_name: Optional[str] = None) -> None:
         driver = self._require_driver()


### PR DESCRIPTION
- **chore(dependencies): make `pytest` have the same version range in both dependency groups**
- **chore(dependencies): bump `minversion` of `pytest` to `8.3.5` in `pyproject.toml`**
- **chore(dependencies): update `content-hash` in `poetry.lock`**
- **fix(server): exclude keyword-only params from named-param keyword execution**
- **fix(driver): ensure `get_text_element` retrieves text across multiple attributes**
- **fix(drivers): fall back to active element for `enter_text` on iOS**
- **fix(driver): log when `enter_text`'s iOS fallback finds no focused element**
