### PR TITLE
fix(serve): wire AI self-heal through optics serve and optics mcp

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -4,7 +4,7 @@ import inspect
 import shlex
 import time
 import json
-from typing import Callable, Optional, Any, Tuple, List
+from typing import Callable, Optional, Any, Tuple, List, Dict
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import StrategyManager
@@ -241,6 +241,17 @@ class ActionKeyword:
         self._ai_healer: Optional[AISelfHealHandler] = None
         # Breadcrumbs of recently-succeeded keywords, fed to the LLM as context on heal.
         self._recent_steps: "collections.deque[Tuple[str, list]]" = collections.deque(maxlen=10)
+        # The focused subset of keywords the self-healer is allowed to call, bound here
+        # (rather than looked up by name via getattr) so a rename shows up as a static
+        # attribute error instead of a silent "Unknown keyword" at runtime.
+        self._heal_dispatch: Dict[str, Callable] = {
+            "press_element": self.press_element,
+            "enter_text": self.enter_text,
+            "scroll": self.scroll,
+            "swipe_by_percentage": self.swipe_by_percentage,
+            "press_keycode": self.press_keycode,
+            "press_by_percentage": self.press_by_percentage,
+        }
 
     def _record_successful_step(self, func_name: str, element: Any, args: tuple) -> None:
         self._recent_steps.append((func_name, [str(element), *map(str, args)]))
@@ -302,17 +313,6 @@ class ActionKeyword:
 
     # -- Self-heal keyword executor and catalog --------------------------------
 
-    # The focused subset of keywords the self-healer is allowed to call.
-    # These are methods on this class (or simple enough to forward).
-    _HEAL_KEYWORDS: List[str] = [
-        "press_element",
-        "enter_text",
-        "scroll",
-        "swipe_by_percentage",
-        "press_keycode",
-        "press_by_percentage",
-    ]
-
     def _heal_execute(self, line: str) -> Any:
         """Keyword executor for self-heal: parse and run one keyword, returning an ExecResult-like.
 
@@ -338,12 +338,9 @@ class ActionKeyword:
         keyword_name = tokens[0]
         params = tokens[1:]
 
-        if keyword_name not in self._HEAL_KEYWORDS:
-            return _Result(ok=False, message=f"Unknown keyword: {keyword_name}")
-
-        method = getattr(self, keyword_name, None)
+        method = self._heal_dispatch.get(keyword_name)
         if method is None:
-            return _Result(ok=False, message=f"Method not found: {keyword_name}")
+            return _Result(ok=False, message=f"Unknown keyword: {keyword_name}")
 
         try:
             # Non-self-healing methods: call directly with params.
@@ -364,14 +361,10 @@ class ActionKeyword:
 
     def _heal_catalog(self) -> List[HealKeywordSpec]:
         """Return the keyword catalog for the self-healer (focused subset with signatures)."""
-        catalog = []
-        for name in self._HEAL_KEYWORDS:
-            method = getattr(self, name, None)
-            if method is None:
-                continue
-            sig = self._heal_keyword_signature(name, method)
-            catalog.append(HealKeywordSpec(name=name, signature=sig))
-        return catalog
+        return [
+            HealKeywordSpec(name=name, signature=self._heal_keyword_signature(name, method))
+            for name, method in self._heal_dispatch.items()
+        ]
 
     @staticmethod
     def _heal_keyword_signature(name: str, method: Callable) -> str:

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -103,11 +103,17 @@ def _try_results_until_success(
 ):
     last_exception = None
     result_count = 0
+    locate_error: Optional[OpticsError] = None
 
     try:
         results_list = list(results)
-    except OpticsError:
+    except OpticsError as e:
+        # The locate generator raises when no strategy yields a result; treat that
+        # as "no results" so self-heal below gets a chance, but keep the original
+        # error as the cause instead of losing it.
+        internal_logger.debug(f"Locate generator raised for '{element}' in '{func_name}': {e}")
         results_list = []
+        locate_error = e
 
     for result in results_list:
         result_count += 1
@@ -126,7 +132,11 @@ def _try_results_until_success(
     if result_count == 0:
         if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
             return None
-        raise OpticsError(Code.E0201, message=f"No valid strategies found for '{element}' in '{func_name}'")
+        raise OpticsError(
+            Code.E0201,
+            message=f"No valid strategies found for '{element}' in '{func_name}'",
+            cause=locate_error,
+        ) from locate_error
     if last_exception:
         if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
             return None

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -1,14 +1,16 @@
 from functools import wraps
 import collections
+import inspect
+import shlex
 import time
 import json
-from typing import Callable, Optional, Any, Tuple
+from typing import Callable, Optional, Any, Tuple, List
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import StrategyManager
 from optics_framework.common.base_factory import InstanceFallback
 from optics_framework.common import utils
-from optics_framework.common.ai_self_heal import AISelfHealHandler, HealContext
+from optics_framework.common.ai_self_heal import AISelfHealHandler, HealContext, HealKeywordSpec
 from optics_framework.common.error import OpticsError, Code
 from .verifier import Verifier
 
@@ -101,7 +103,13 @@ def _try_results_until_success(
 ):
     last_exception = None
     result_count = 0
-    for result in results:
+
+    try:
+        results_list = list(results)
+    except OpticsError:
+        results_list = []
+
+    for result in results_list:
         result_count += 1
         _save_annotated_for_result(result, screenshot_np, execution_dir, func_name)
         try:
@@ -254,7 +262,11 @@ class ActionKeyword:
             ),
         )
         if self._ai_healer is None:
-            self._ai_healer = AISelfHealHandler(self._llm, self.driver)
+            self._ai_healer = AISelfHealHandler(
+                self._llm,
+                keyword_executor=self._heal_execute,
+                keyword_catalog=self._heal_catalog,
+            )
         internal_logger.info("AI self-heal: attempting recovery for '%s' on '%s'", func_name, element)
         result = self._ai_healer.heal(ctx, providers.screenshot, providers.pagesource)
         self._log_heal_outcome(result, func_name, element, args)
@@ -273,9 +285,105 @@ class ActionKeyword:
                 "AI self-heal: could not recover '%s': %s", func_name, result.message
             )
             return
-        action = result.action.action if result.action else "?"
-        internal_logger.info("AI self-heal: recovered '%s' via '%s'", func_name, action)
+        action = result.action
+        kw = action.keyword if action else "?"
+        internal_logger.info("AI self-heal: recovered '%s' via keyword '%s'", func_name, kw)
         self._record_successful_step(func_name, element, args)
+
+    # -- Self-heal keyword executor and catalog --------------------------------
+
+    # The focused subset of keywords the self-healer is allowed to call.
+    # These are methods on this class (or simple enough to forward).
+    _HEAL_KEYWORDS: List[str] = [
+        "press_element",
+        "enter_text",
+        "scroll",
+        "swipe_by_percentage",
+        "press_keycode",
+        "press_by_percentage",
+    ]
+
+    def _heal_execute(self, line: str) -> Any:
+        """Keyword executor for self-heal: parse and run one keyword, returning an ExecResult-like.
+
+        Calls the ActionKeyword methods directly but avoids re-triggering self-heal by
+        passing ``located=`` for self-healing-decorated methods or calling non-decorated ones.
+
+        Returns an object with ``.ok`` (bool) and ``.message`` (str).
+        """
+        from dataclasses import dataclass as _dc
+
+        @_dc
+        class _Result:
+            ok: bool
+            message: str = ""
+
+        try:
+            tokens = shlex.split(line, posix=True)
+        except ValueError as exc:
+            return _Result(ok=False, message=f"Parse error: {exc}")
+        if not tokens:
+            return _Result(ok=False, message="Empty keyword line")
+
+        keyword_name = tokens[0]
+        params = tokens[1:]
+
+        if keyword_name not in self._HEAL_KEYWORDS:
+            return _Result(ok=False, message=f"Unknown keyword: {keyword_name}")
+
+        method = getattr(self, keyword_name, None)
+        if method is None:
+            return _Result(ok=False, message=f"Method not found: {keyword_name}")
+
+        try:
+            # Non-self-healing methods: call directly with params.
+            # Self-healing methods (press_element, enter_text): they will go through
+            # `with_self_healing` decorator, but self-heal is already running, so
+            # we need to temporarily disable it to avoid recursion.
+            original_enabled = self.ai_self_heal_enabled
+            self.ai_self_heal_enabled = False
+            try:
+                method(*params)
+            finally:
+                self.ai_self_heal_enabled = original_enabled
+            return _Result(ok=True)
+        except OpticsError as exc:
+            return _Result(ok=False, message=str(exc.message))
+        except Exception as exc:  # noqa: BLE001 - never crash the heal loop
+            return _Result(ok=False, message=str(exc))
+
+    def _heal_catalog(self) -> List[HealKeywordSpec]:
+        """Return the keyword catalog for the self-healer (focused subset with signatures)."""
+        catalog = []
+        for name in self._HEAL_KEYWORDS:
+            method = getattr(self, name, None)
+            if method is None:
+                continue
+            sig = self._heal_keyword_signature(name, method)
+            catalog.append(HealKeywordSpec(name=name, signature=sig))
+        return catalog
+
+    @staticmethod
+    def _heal_keyword_signature(name: str, method: Callable) -> str:
+        """Build a ghost-text signature like ``press_element <element> [repeat] [offset_x]``."""
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            return name
+        parts: List[str] = [name]
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            # Skip internal keyword-only params (located, event_name, aoi_*)
+            if param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if pname in ("event_name", "aoi_x", "aoi_y", "aoi_width", "aoi_height"):
+                continue
+            if param.default is inspect.Parameter.empty:
+                parts.append(f"<{pname}>")
+            else:
+                parts.append(f"[{pname}]")
+        return " ".join(parts)
 
     def _capture_screenshot_safe(self) -> Any:
         """Capture a screenshot, returning None on failure (e.g. secure/protected pages)."""

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -241,6 +241,11 @@ class ActionKeyword:
         self._ai_healer: Optional[AISelfHealHandler] = None
         # Breadcrumbs of recently-succeeded keywords, fed to the LLM as context on heal.
         self._recent_steps: "collections.deque[Tuple[str, list]]" = collections.deque(maxlen=10)
+        # Set by `_log_heal_outcome` when a heal succeeds; consumed (and cleared) by the
+        # caller right after the keyword call via `_pop_last_heal_info`, so reporting
+        # layers (TestRunner, LiveController) can attribute the heal to the right call
+        # without it leaking onto the next, unrelated keyword.
+        self._last_heal_info: Optional[Dict[str, str]] = None
         # The focused subset of keywords the self-healer is allowed to call, bound here
         # (rather than looked up by name via getattr) so a rename shows up as a static
         # attribute error instead of a silent "Unknown keyword" at runtime.
@@ -300,7 +305,7 @@ class ActionKeyword:
         return bool(getattr(self._llm, "instances", None))
 
     def _log_heal_outcome(self, result: Any, func_name: str, element: Any, args: tuple) -> None:
-        """Log the heal result; on success, record the step so the run stays /save-able."""
+        """Log the heal result; on success, record the step and expose it for reporting."""
         if not result.ok:
             internal_logger.info(
                 "AI self-heal: could not recover '%s': %s", func_name, result.message
@@ -310,6 +315,23 @@ class ActionKeyword:
         kw = action.keyword if action else "?"
         internal_logger.info("AI self-heal: recovered '%s' via keyword '%s'", func_name, kw)
         self._record_successful_step(func_name, element, args)
+        steps = result.steps_taken or [kw]
+        self._last_heal_info = {
+            "summary": (
+                f"AI self-heal recovered '{func_name}' after {len(steps)} "
+                f"step{'s' if len(steps) != 1 else ''}: {'; '.join(steps)}"
+            ),
+        }
+
+    def _pop_last_heal_info(self) -> Optional[Dict[str, str]]:
+        """Return and clear the self-heal info recorded for the most recently completed call.
+
+        Callers (``TestRunner``, ``LiveController``) must call this immediately after every
+        keyword invocation, self-healing or not, so a heal on one keyword never leaks onto
+        the reporting for the next.
+        """
+        info, self._last_heal_info = self._last_heal_info, None
+        return info
 
     # -- Self-heal keyword executor and catalog --------------------------------
 

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -226,7 +226,7 @@ class AISelfHealHandler:
 
         if done:
             return HealResult(True, action=action, message=action.reason or "Healed.")
-        
+
         return None
 
     def heal(

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -188,6 +188,7 @@ class AISelfHealHandler:
         screenshot_provider: ScreenshotProvider,
         pagesource_provider: PagesourceProvider,
         catalog: List[HealKeywordSpec],
+        attempted: List[str],
     ) -> Optional[HealResult]:
         """Execute a single iteration of self-healing and return terminal result or None to continue."""
         png = self._safe_call(screenshot_provider)
@@ -227,6 +228,10 @@ class AISelfHealHandler:
         if done:
             return HealResult(True, action=action, message=action.reason or "Healed.")
 
+        # Intermediate step: record what was tried so a budget-exhausted message
+        # (the only case that reaches the caller without this action already
+        # attached) can still say what the model attempted.
+        attempted.append(self._build_line(action.keyword, action.params))
         return None
 
     def heal(
@@ -237,16 +242,18 @@ class AISelfHealHandler:
     ) -> HealResult:
         """Attempt to recover the failed keyword. Never raises — returns ok=False on any problem."""
         catalog = self.keyword_catalog()
+        attempted: List[str] = []
 
         for step in range(self.max_steps):
             result = self._execute_single_step(
-                step, ctx, screenshot_provider, pagesource_provider, catalog
+                step, ctx, screenshot_provider, pagesource_provider, catalog, attempted
             )
             if result is not None:
                 return result
             # Intermediate step: UI changed, loop to re-observe.
 
-        return HealResult(False, message="Self-heal step budget exhausted.")
+        tried = "; ".join(attempted) if attempted else "no actions attempted"
+        return HealResult(False, message=f"Self-heal step budget exhausted. Tried: {tried}")
 
     # -- internals -------------------------------------------------------------
 

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -181,6 +181,54 @@ class AISelfHealHandler:
         self.keyword_catalog = keyword_catalog
         self.max_steps = max_steps
 
+    def _execute_single_step(
+        self,
+        step: int,
+        ctx: HealContext,
+        screenshot_provider: ScreenshotProvider,
+        pagesource_provider: PagesourceProvider,
+        catalog: List[HealKeywordSpec],
+    ) -> Optional[HealResult]:
+        """Execute a single iteration of self-healing and return terminal result or None to continue."""
+        png = self._safe_call(screenshot_provider)
+        if not png:
+            return HealResult(False, message="No screenshot available for self-heal.")
+        page_source = self._safe_call(pagesource_provider)
+
+        prompt = self._build_prompt(ctx, step, page_source, catalog)
+        try:
+            raw = self.llm.generate_json(
+                prompt, HEAL_ACTION_SCHEMA, images=[png],
+                system=HEAL_SYSTEM_PROMPT, temperature=0.0,
+            )
+        except OpticsError as exc:
+            return HealResult(False, message=f"LLM error: {exc.message}")
+        except Exception as exc:  # noqa: BLE001 - self-heal must never raise a new error type
+            return HealResult(False, message=f"LLM error: {exc}")
+
+        action = self._validate(raw)
+        internal_logger.info(
+            "AI self-heal step %d/%d for '%s': action=%s keyword=%s params=%s reason=%s",
+            step + 1, self.max_steps, ctx.intent_keyword, action.action,
+            action.keyword, action.params, action.reason[:_MAX_THOUGHT_CHARS],
+        )
+
+        if action.action == "give_up":
+            return HealResult(False, action=action, message=action.reason or "Model gave up.")
+        if action.action == "done":
+            return HealResult(True, action=action, message=action.reason or "Goal reached.")
+
+        # action.action == "keyword"
+        try:
+            done = self._dispatch(action)
+        except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
+            return HealResult(False, action=action, message=f"Keyword failed: {exc}")
+
+        if done:
+            return HealResult(True, action=action, message=action.reason or "Healed.")
+        
+        return None
+
     def heal(
         self,
         ctx: HealContext,
@@ -191,42 +239,11 @@ class AISelfHealHandler:
         catalog = self.keyword_catalog()
 
         for step in range(self.max_steps):
-            png = self._safe_call(screenshot_provider)
-            if not png:
-                return HealResult(False, message="No screenshot available for self-heal.")
-            page_source = self._safe_call(pagesource_provider)
-
-            prompt = self._build_prompt(ctx, step, page_source, catalog)
-            try:
-                raw = self.llm.generate_json(
-                    prompt, HEAL_ACTION_SCHEMA, images=[png],
-                    system=HEAL_SYSTEM_PROMPT, temperature=0.0,
-                )
-            except OpticsError as exc:
-                return HealResult(False, message=f"LLM error: {exc.message}")
-            except Exception as exc:  # noqa: BLE001 - self-heal must never raise a new error type
-                return HealResult(False, message=f"LLM error: {exc}")
-
-            action = self._validate(raw)
-            internal_logger.info(
-                "AI self-heal step %d/%d for '%s': action=%s keyword=%s params=%s reason=%s",
-                step + 1, self.max_steps, ctx.intent_keyword, action.action,
-                action.keyword, action.params, action.reason[:_MAX_THOUGHT_CHARS],
+            result = self._execute_single_step(
+                step, ctx, screenshot_provider, pagesource_provider, catalog
             )
-
-            if action.action == "give_up":
-                return HealResult(False, action=action, message=action.reason or "Model gave up.")
-            if action.action == "done":
-                return HealResult(True, action=action, message=action.reason or "Goal reached.")
-
-            # action.action == "keyword"
-            try:
-                done = self._dispatch(action)
-            except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
-                return HealResult(False, action=action, message=f"Keyword failed: {exc}")
-
-            if done:
-                return HealResult(True, action=action, message=action.reason or "Healed.")
+            if result is not None:
+                return result
             # Intermediate step: UI changed, loop to re-observe.
 
         return HealResult(False, message="Self-heal step budget exhausted.")

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -2,16 +2,20 @@
 
 When the normal element-location ladder (XPath -> on-screen text -> OCR -> image) exhausts
 for a locate-based keyword, :class:`AISelfHealHandler` asks an :class:`LLMInterface` to look at
-the current screen (screenshot + condensed page source) plus the keyword's intent and recent
-context, and to take ONE corrective device action at a time (tap / type / swipe / scroll) until
-the keyword's goal is achieved or a small step budget is hit.
+the current screen (screenshot + condensed page source) plus the keyword's intent and the
+available keyword catalog, and to emit ONE keyword call at a time (e.g. ``press_element "Meesho"``,
+``scroll "down"``) until the keyword's goal is achieved or a small step budget is hit.
 
-The handler runs *independently* of :class:`StrategyManager`: it drives the device directly via
-the :class:`DriverInterface` primitives, so the LLM must FINISH THE JOB itself (it cannot defer
-back to the normal locators). It is decoupled from any controller — it depends only on an ``llm``,
-a ``driver``, and screenshot/page-source provider callables — so it is unit-testable with fakes.
+Unlike the old coordinate-guessing approach, this routes through the framework's own keyword
+methods — so ``press_element "Meesho"`` uses the full locate ladder (XPath -> text -> OCR -> image)
+instead of the LLM blindly tapping pixel percentages.
+
+The handler is decoupled from any controller — it depends only on an ``llm``, a keyword executor
+callable, a keyword catalog callable, and screenshot/page-source provider callables — so it is
+unit-testable with fakes.
 """
 
+import shlex
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -25,16 +29,28 @@ from optics_framework.common.logging_config import internal_logger
 ScreenshotProvider = Callable[[], Optional[bytes]]
 PagesourceProvider = Callable[[], Optional[str]]
 
-# Actions that complete the keyword's goal (heal succeeds) vs. intermediate ones that
-# merely change what is on screen (loop continues to re-observe).
-_TERMINAL_ACTIONS = ("tap", "type")
-_LAYOUT_ACTIONS = ("tap", "type", "swipe", "scroll")
+# Keyword executor: takes a keyword line string (e.g. 'press_element "Login"'),
+# returns an ExecResult-like with .ok and .message.
+KeywordExecutor = Callable[[str], Any]
 
-# Defaults for driver args the LLM schema does not carry.
-_DEFAULT_SWIPE_LENGTH_PCT = 50
-_DEFAULT_SCROLL_DURATION_MS = 1000
+# Keyword catalog entry.
+@dataclass
+class HealKeywordSpec:
+    """A keyword the self-healer may call, with a human-readable signature."""
+    name: str
+    signature: str
+
+
+# Keyword catalog provider.
+KeywordCatalog = Callable[[], List[HealKeywordSpec]]
+
 # Let the UI settle after a layout-changing action before re-screenshotting.
 _SETTLE_SECONDS = 1.5
+
+# Keywords that just change what's on screen but don't complete a locate-based goal.
+_NON_COMPLETING_KEYWORDS = (
+    "scroll", "swipe_by_percentage", "swipe", "press_keycode", "press_by_percentage",
+)
 
 
 @dataclass
@@ -53,12 +69,11 @@ class HealContext:
 class HealAction:
     """A single parsed action the LLM asked for."""
 
-    action: str                  # "tap" | "type" | "swipe" | "scroll" | "give_up"
-    percent_x: Optional[float] = None
-    percent_y: Optional[float] = None
-    text: str = ""
-    direction: str = ""
+    action: str                  # "keyword" | "done" | "give_up"
+    keyword: str = ""            # snake_case keyword name (when action == "keyword")
+    params: List[str] = field(default_factory=list)
     reason: str = ""
+    completed: bool = True       # False for intermediate navigation steps
 
 
 @dataclass
@@ -70,76 +85,100 @@ class HealResult:
     message: str = ""
 
 
-# Flat schema (no anyOf/discriminated unions — Gemini's response_schema support for them is
-# unreliable; same discipline as nl_agent.ACTION_SCHEMA). percent_x/percent_y are also used by
-# the "type" action so the field can be focused (tapped) before typing.
+# Structured-output schema. Mirrors the NL agent's schema pattern (flat, no anyOf).
 HEAL_ACTION_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
         "reason": {
             "type": "string",
-            "description": "Brief reasoning about the screen and the chosen action.",
+            "description": "Brief reasoning about the current screen and the chosen action.",
         },
         "action": {
             "type": "string",
-            "enum": ["tap", "type", "swipe", "scroll", "give_up"],
-            "description": "tap/type complete the goal; swipe/scroll reveal it; give_up if blocked.",
+            "enum": ["keyword", "done", "give_up"],
+            "description": "keyword = run one keyword; done = goal achieved; give_up = blocked.",
         },
-        "percent_x": {
-            "type": "number",
-            "description": "X position 0-100 of screen width (for tap, and the field to tap before type).",
-        },
-        "percent_y": {
-            "type": "number",
-            "description": "Y position 0-100 of screen height (for tap, and the field to tap before type).",
-        },
-        "text": {"type": "string", "description": "Text to type (only when action == type)."},
-        "direction": {
+        "keyword": {
             "type": "string",
-            "enum": ["up", "down", "left", "right"],
-            "description": "Direction for swipe/scroll.",
+            "description": "snake_case keyword name (only when action == keyword).",
+        },
+        "params": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Positional parameters in keyword-signature order (strings).",
+        },
+        "completed": {
+            "type": "boolean",
+            "description": (
+                "Set to true if this keyword call completes the original keyword's goal "
+                "(e.g. pressing the final target element). Set to false if this is an "
+                "intermediate navigation step (e.g. scrolling to reveal the target, pressing "
+                "a menu to navigate, typing in a search bar) and more steps are needed."
+            ),
         },
     },
     "required": ["reason", "action"],
-    "propertyOrdering": ["reason", "action", "percent_x", "percent_y", "text", "direction"],
+    "propertyOrdering": ["reason", "action", "keyword", "params", "completed"],
 }
 
 
 HEAL_SYSTEM_PROMPT = """\
 You are the LAST-RESORT self-healing layer of a UI test-automation framework. The normal element \
 locators (XPath, on-screen text, OCR, image matching) have ALL failed to find the target for the \
-keyword described below. Your job is to look at the current screen and take ONE corrective device \
-action so the keyword's goal is achieved.
+keyword described below. Your job is to look at the current screen and execute framework keywords \
+step-by-step until the original keyword's goal is achieved.
 
-YOU MUST FINISH THE JOB YOURSELF — you cannot hand control back to the normal locators. If the \
-target is not on screen, `scroll` or `swipe` to reveal it, and once it is visible complete the \
-action yourself (`tap` to press it, `type` to enter text). Only use `give_up` when there is no \
-recoverable next action.
+YOU MUST FINISH THE JOB YOURSELF by issuing keyword calls. You have access to the same keywords \
+the framework uses. The most important one is `press_element` — it takes a visible text label \
+as its element parameter and the framework will locate the element using its full strategy ladder \
+(XPath → text → OCR → image matching). NAME TARGETS BY THEIR VISIBLE TEXT whenever possible.
 
-COORDINATES: always express positions as PERCENTAGES of the screen (percent_x, percent_y in 0-100). \
-Read element bounds from the condensed UI hierarchy (when provided) to compute a precise center, \
-or estimate from the screenshot. Percentages are resolution-independent and safer than pixels.
+WORKFLOW:
+1. Look at the screenshot and UI hierarchy to understand the current screen state.
+2. If the target element IS visible on screen, call the appropriate keyword to act on it \
+(e.g. `press_element` with the element's visible text). Set `completed` to true.
+3. If the target element is NOT visible, navigate to reveal it — scroll, swipe, press a menu, \
+or type in a search bar. Set `completed` to false for intermediate steps.
+4. Use `action: "done"` when you believe the original keyword's goal has been fully achieved.
+5. Use `action: "give_up"` only when there is no recoverable next action.
 
-ACTIONS:
-- tap: press at (percent_x, percent_y). Completes a press/click goal.
-- type: focus the field at (percent_x, percent_y) then enter `text`. Completes a text-entry goal.
-- swipe: swipe from (percent_x, percent_y) in `direction`. Intermediate (re-observe afterwards).
-- scroll: scroll the screen in `direction`. Intermediate (re-observe afterwards).
-- give_up: nothing recoverable remains.
+TARGETING POLICY (strict order of preference):
+1. Name the target by its VISIBLE TEXT as the element parameter (e.g. press_element ["Meesho"]). \
+Use the condensed hierarchy for EXACT text / content-desc / resource id.
+2. If the target is not visible, swipe to reveal it, THEN name it by text.
+3. For system buttons (home/back/recents), use press_keycode with the Android keycode \
+(HOME=3, BACK=4, RECENTS=187, ENTER=66).
+4. LAST RESORT: use press_by_percentage with coordinate percentages.
+5. Use swipe instead of scroll.
 
-RULES: emit exactly ONE action as JSON. Keep `reason` short. Be conservative: prefer revealing the \
-real target and tapping it over blindly tapping a guessed position.
+GESTURE DIRECTIONS:
+- To reveal content below (swipe down the list to see lower items), you must use direction "up" (finger drags from bottom to top).
+- To reveal content above (swipe up the list to see upper items), you must use direction "down" (finger drags from top to bottom).
+
+RULES:
+- Emit exactly ONE action per turn as JSON.
+- Keep `reason` short.
+- Prefer naming elements by text over guessing coordinates.
+- Set `completed` to true only when this step achieves the original keyword's goal.
 """
 
 _MAX_THOUGHT_CHARS = 160
 
 
 class AISelfHealHandler:
-    """Bounded loop that drives the device via LLM decisions to land a failed keyword."""
+    """Bounded loop that drives the device via keyword calls to land a failed keyword."""
 
-    def __init__(self, llm: LLMInterface, driver: Any, *, max_steps: int = 2) -> None:
+    def __init__(
+        self,
+        llm: LLMInterface,
+        keyword_executor: KeywordExecutor,
+        keyword_catalog: KeywordCatalog,
+        *,
+        max_steps: int = 5,
+    ) -> None:
         self.llm = llm
-        self.driver = driver
+        self.keyword_executor = keyword_executor
+        self.keyword_catalog = keyword_catalog
         self.max_steps = max_steps
 
     def heal(
@@ -149,13 +188,15 @@ class AISelfHealHandler:
         pagesource_provider: PagesourceProvider,
     ) -> HealResult:
         """Attempt to recover the failed keyword. Never raises — returns ok=False on any problem."""
+        catalog = self.keyword_catalog()
+
         for step in range(self.max_steps):
             png = self._safe_call(screenshot_provider)
             if not png:
                 return HealResult(False, message="No screenshot available for self-heal.")
             page_source = self._safe_call(pagesource_provider)
 
-            prompt = self._build_prompt(ctx, step, page_source)
+            prompt = self._build_prompt(ctx, step, page_source, catalog)
             try:
                 raw = self.llm.generate_json(
                     prompt, HEAL_ACTION_SCHEMA, images=[png],
@@ -168,22 +209,25 @@ class AISelfHealHandler:
 
             action = self._validate(raw)
             internal_logger.info(
-                "AI self-heal step %d/%d for '%s': action=%s reason=%s",
+                "AI self-heal step %d/%d for '%s': action=%s keyword=%s params=%s reason=%s",
                 step + 1, self.max_steps, ctx.intent_keyword, action.action,
-                action.reason[:_MAX_THOUGHT_CHARS],
+                action.keyword, action.params, action.reason[:_MAX_THOUGHT_CHARS],
             )
 
             if action.action == "give_up":
                 return HealResult(False, action=action, message=action.reason or "Model gave up.")
+            if action.action == "done":
+                return HealResult(True, action=action, message=action.reason or "Goal reached.")
 
+            # action.action == "keyword"
             try:
                 done = self._dispatch(action)
-            except Exception as exc:  # noqa: BLE001 - a driver error ends the heal cleanly
-                return HealResult(False, action=action, message=f"Action failed: {exc}")
+            except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
+                return HealResult(False, action=action, message=f"Keyword failed: {exc}")
 
             if done:
                 return HealResult(True, action=action, message=action.reason or "Healed.")
-            # Intermediate (scroll/swipe): UI changed, loop to re-observe.
+            # Intermediate step: UI changed, loop to re-observe.
 
         return HealResult(False, message="Self-heal step budget exhausted.")
 
@@ -200,44 +244,67 @@ class AISelfHealHandler:
             return None
 
     def _dispatch(self, action: HealAction) -> bool:
-        """Execute one action via the driver. Returns True when the keyword goal is complete."""
-        px = action.percent_x if action.percent_x is not None else 50.0
-        py = action.percent_y if action.percent_y is not None else 50.0
-
-        if action.action == "tap":
-            self.driver.press_percentage_coordinates(px, py, 1)
-        elif action.action == "type":
-            self.driver.press_percentage_coordinates(px, py, 1)
-            self.driver.enter_text(action.text)
-        elif action.action == "swipe":
-            direction = action.direction or "up"
-            self.driver.swipe_percentage(int(px), int(py), direction, _DEFAULT_SWIPE_LENGTH_PCT)
-        elif action.action == "scroll":
-            direction = action.direction or "down"
-            self.driver.scroll(direction, _DEFAULT_SCROLL_DURATION_MS)
-        else:  # pragma: no cover - _validate guarantees a known action
+        """Execute one keyword via the injected executor. Returns True when the goal is complete."""
+        if not action.keyword:
             return False
 
-        if action.action in _LAYOUT_ACTIONS:
-            # Handler bypasses keyword-level settling; let the UI finish animating.
-            time.sleep(_SETTLE_SECONDS)
-        return action.action in _TERMINAL_ACTIONS
+        line = self._build_line(action.keyword, action.params)
+        result = self.keyword_executor(line)
+
+        # Let the UI settle after the keyword runs.
+        time.sleep(_SETTLE_SECONDS)
+
+        ok = getattr(result, "ok", False)
+        if not ok:
+            msg = getattr(result, "message", "keyword failed")
+            internal_logger.debug("AI self-heal: keyword '%s' failed: %s", line, msg)
+            # Don't abort the whole heal on a single keyword failure —
+            # the LLM can try a different approach on the next step.
+            return False
+
+        # A completing keyword with completed=True means the goal is done.
+        if action.keyword not in _NON_COMPLETING_KEYWORDS and action.completed:
+            return True
+        return False
 
     @staticmethod
     def _validate(raw: Dict[str, Any]) -> HealAction:
+        if not isinstance(raw, dict):
+            raw = {}
         action = raw.get("action")
-        if action not in ("tap", "type", "swipe", "scroll", "give_up"):
+        if action not in ("keyword", "done", "give_up"):
             action = "give_up"
+
+        params_raw = raw.get("params") or []
+        params = [str(p) for p in params_raw] if isinstance(params_raw, list) else []
+
+        completed = raw.get("completed")
+        if completed is None:
+            # Default: completing keywords complete by default; navigation ones don't.
+            keyword = str(raw.get("keyword") or "")
+            completed = keyword not in _NON_COMPLETING_KEYWORDS
+        else:
+            completed = bool(completed)
+
         return HealAction(
             action=action,
-            percent_x=_as_float(raw.get("percent_x")),
-            percent_y=_as_float(raw.get("percent_y")),
-            text=str(raw.get("text") or ""),
-            direction=str(raw.get("direction") or ""),
+            keyword=str(raw.get("keyword") or ""),
+            params=params,
             reason=str(raw.get("reason") or ""),
+            completed=completed,
         )
 
-    def _build_prompt(self, ctx: HealContext, step: int, page_source: Optional[str]) -> str:
+    @staticmethod
+    def _build_line(keyword: str, params: List[str]) -> str:
+        """Build a keyword line string from keyword name and params."""
+        if not params:
+            return keyword
+        return keyword + " " + " ".join(shlex.quote(p) for p in params)
+
+    def _build_prompt(
+        self, ctx: HealContext, step: int, page_source: Optional[str],
+        catalog: List[HealKeywordSpec],
+    ) -> str:
         params = " ".join(str(p) for p in ctx.intent_params)
         lines = [
             f"FAILED KEYWORD: {ctx.intent_keyword} {params}".rstrip(),
@@ -248,6 +315,12 @@ class AISelfHealHandler:
             lines.append(f"RESOLVED VARIABLES: {pairs}")
         if ctx.failed_strategies:
             lines.append("STRATEGIES ALREADY TRIED (all failed): " + ", ".join(ctx.failed_strategies))
+
+        lines.append("")
+        lines.append("AVAILABLE KEYWORDS (name and parameters):")
+        for spec in catalog:
+            lines.append(f"  {spec.signature}")
+
         if page_source:
             lines.append("")
             lines.append(
@@ -263,18 +336,9 @@ class AISelfHealHandler:
         if step > 0:
             lines.append("")
             lines.append(
-                f"This is attempt {step + 1}. Your previous action changed the screen; "
-                "re-read the CURRENT screenshot and complete the goal (tap/type)."
+                f"This is attempt {step + 1}. Your previous keyword changed the screen; "
+                "re-read the CURRENT screenshot and complete the goal."
             )
         lines.append("")
         lines.append("The attached image is the CURRENT screen. Decide the SINGLE next action as JSON.")
         return "\n".join(lines)
-
-
-def _as_float(value: Any) -> Optional[float]:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -268,20 +268,22 @@ class AISelfHealHandler:
         line = self._build_line(action.keyword, action.params)
         result = self.keyword_executor(line)
 
-        # Let the UI settle after the keyword runs.
-        time.sleep(_SETTLE_SECONDS)
-
         ok = getattr(result, "ok", False)
         if not ok:
             msg = getattr(result, "message", "keyword failed")
             internal_logger.debug("AI self-heal: keyword '%s' failed: %s", line, msg)
-            # Don't abort the whole heal on a single keyword failure —
-            # the LLM can try a different approach on the next step.
+            # Don't abort the whole heal on a single keyword failure — the LLM can
+            # try a different approach on the next step, so let the UI settle first.
+            time.sleep(_SETTLE_SECONDS)
             return False
 
-        # A completing keyword with completed=True means the goal is done.
+        # A completing keyword with completed=True means the goal is done — return
+        # immediately without waiting, since there's no next screenshot to settle for.
         if action.keyword not in _NON_COMPLETING_KEYWORDS and action.completed:
             return True
+
+        # Intermediate/navigation step: let the UI settle before the next screenshot.
+        time.sleep(_SETTLE_SECONDS)
         return False
 
     @staticmethod

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -83,6 +83,9 @@ class HealResult:
     ok: bool
     action: Optional[HealAction] = None
     message: str = ""
+    # Every keyword line attempted during this heal, in order (including the
+    # terminal one on success), for building a human-readable recovery summary.
+    steps_taken: List[str] = field(default_factory=list)
 
 
 # Structured-output schema. Mirrors the NL agent's schema pattern (flat, no anyOf).
@@ -225,13 +228,13 @@ class AISelfHealHandler:
         except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
             return HealResult(False, action=action, message=f"Keyword failed: {exc}")
 
+        # Record every dispatched line, including the terminal one, so a caller can
+        # build a "recovered via X after N steps: ..." summary regardless of outcome.
+        attempted.append(self._build_line(action.keyword, action.params))
         if done:
             return HealResult(True, action=action, message=action.reason or "Healed.")
 
-        # Intermediate step: record what was tried so a budget-exhausted message
-        # (the only case that reaches the caller without this action already
-        # attached) can still say what the model attempted.
-        attempted.append(self._build_line(action.keyword, action.params))
+        # Intermediate step: UI changed, loop to re-observe.
         return None
 
     def heal(
@@ -249,11 +252,16 @@ class AISelfHealHandler:
                 step, ctx, screenshot_provider, pagesource_provider, catalog, attempted
             )
             if result is not None:
+                result.steps_taken = list(attempted)
                 return result
             # Intermediate step: UI changed, loop to re-observe.
 
         tried = "; ".join(attempted) if attempted else "no actions attempted"
-        return HealResult(False, message=f"Self-heal step budget exhausted. Tried: {tried}")
+        return HealResult(
+            False,
+            message=f"Self-heal step budget exhausted. Tried: {tried}",
+            steps_taken=list(attempted),
+        )
 
     # -- internals -------------------------------------------------------------
 

--- a/optics_framework/common/elementsource_interface.py
+++ b/optics_framework/common/elementsource_interface.py
@@ -24,6 +24,21 @@ class ElementSourceInterface(ABC):
         """
         pass
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the current screen as already-encoded image bytes (e.g. PNG/JPEG).
+
+        Optional fast-path companion to :meth:`capture`. A backend that can return the
+        device's native encoded screenshot should override this; callers then skip the
+        decode-to-numpy and re-encode round-trip. Otherwise they fall back to encoding
+        :meth:`capture`'s frame.
+
+        :raises NotImplementedError: if this element source has no native encoded path.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support capture_screenshot_bytes"
+        )
+
     @abstractmethod
     def locate(self, element: Any, index: int | None = None) -> tuple:
         """

--- a/optics_framework/common/elementsource_interface.py
+++ b/optics_framework/common/elementsource_interface.py
@@ -26,18 +26,19 @@ class ElementSourceInterface(ABC):
 
     def capture_screenshot_bytes(self) -> bytes:
         """
-        Return the current screen as already-encoded image bytes (e.g. PNG/JPEG).
+        Return the current screen as encoded PNG bytes.
 
-        Optional fast-path companion to :meth:`capture`. A backend that can return the
-        device's native encoded screenshot should override this; callers then skip the
-        decode-to-numpy and re-encode round-trip. Otherwise they fall back to encoding
-        :meth:`capture`'s frame.
+        Combines the numpy and bytes screenshot paths into one call. Backends that can
+        return native encoded bytes (e.g. Appium, Playwright) should override this for
+        efficiency; the default implementation encodes the result of :meth:`capture`.
 
-        :raises NotImplementedError: if this element source has no native encoded path.
+        :return: PNG-encoded screenshot bytes.
+        :rtype: bytes
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support capture_screenshot_bytes"
-        )
+        import cv2  # local import — cv2 is a runtime dep, not needed at module load
+        frame = self.capture()
+        _, buf = cv2.imencode(".png", frame)
+        return bytes(buf)
 
     @abstractmethod
     def locate(self, element: Any, index: int | None = None) -> tuple:

--- a/optics_framework/common/execution.py
+++ b/optics_framework/common/execution.py
@@ -187,14 +187,29 @@ class KeywordExecutor(Executor):
                     extra={"session_id": session.session_id}
                 ))
                 raise OpticsError(Code.E0401, message=f"Keyword execution failed: {str(e)}") from e
+            # Same read-and-clear side channel TestRunner/LiveController use: whichever
+            # ActionKeyword instance the bound method belongs to may have just recorded a
+            # successful self-heal, which is otherwise invisible here (the keyword call
+            # itself returns normally either way).
+            heal_owner = getattr(method, "__self__", None)
+            heal_info = heal_owner._pop_last_heal_info() if hasattr(heal_owner, "_pop_last_heal_info") else None
+            extra = {"session_id": session.session_id}
+            if heal_info:
+                extra["healed"] = "true"
+                extra["heal_summary"] = heal_info["summary"]
             await event_manager.publish_event(Event(
                 entity_type="keyword",
                 entity_id=session.session_id,
                 name=self.keyword,
                 status=EventStatus.PASS,
                 message="Keyword executed successfully",
-                extra={"session_id": session.session_id}
+                extra=extra,
             ))
+            if heal_info:
+                # "result" mirrors expose_api.KEY_RESULT; execution.py is a lower layer
+                # and shouldn't import the HTTP-facing module, so the literal is kept in
+                # sync by convention rather than a shared import.
+                return {"result": result, "healed": True, "heal_summary": heal_info["summary"]}
             return result
         else:
             await event_manager.publish_event(Event(

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -399,8 +399,19 @@ def _load_project_self_heal_settings(project_path: str) -> Tuple[Optional[bool],
     Returns (ai_self_heal_or_None, raw_llm_models_list). Never raises: a missing or
     unparsable config.yaml just means there is nothing to fall back to, not a session
     creation failure — same tolerance as the rest of session creation gives a bad project.
+
+    project_path is caller-supplied (SessionConfig.project_path, the same field already
+    used elsewhere in this module for template discovery and the output directory).
+    realpath() resolves it before it ever reaches a filesystem call, so a relative
+    value or symlink can't resolve somewhere other than what the caller pointed at.
     """
-    path = os.path.join(project_path, "config.yaml")
+    try:
+        resolved_dir = os.path.realpath(project_path)
+    except (OSError, ValueError):
+        return None, []
+    if not os.path.isdir(resolved_dir):
+        return None, []
+    path = os.path.join(resolved_dir, "config.yaml")
     if not os.path.isfile(path):
         return None, []
     try:

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -12,6 +12,7 @@ import pkgutil
 import asyncio
 import warnings
 import hashlib
+import yaml
 from itertools import product
 from typing import Annotated, Optional, Dict, Any, List, Union, cast, Callable, Tuple, NamedTuple
 from fastapi import FastAPI, HTTPException, Query, Body
@@ -253,6 +254,12 @@ class SessionConfig(BaseModel):
     elements_sources: List[Union[str, Dict[str, Any]]] = []
     text_detection: List[Union[str, Dict[str, Any]]] = []
     image_detection: List[Union[str, Dict[str, Any]]] = []
+    # AI self-heal. Both default to "unspecified" (None / empty) rather than off, so an
+    # explicit value here always wins, and when neither is given we fall back to
+    # project_path's own config.yaml (see _resolve_self_heal_settings) instead of
+    # silently forcing self-heal off for a project that already has it configured.
+    ai_self_heal: Optional[bool] = None
+    llm_models: List[Union[str, Dict[str, Any]]] = []
     project_path: Optional[str] = None
     appium_url: Optional[str] = None
     appium_config: Optional[Dict[str, Any]] = None
@@ -386,6 +393,48 @@ async def health_check():
     """
     return HealthCheckResponse(status=HEALTH_STATUS_RUNNING, version=VERSION)
 
+def _load_project_self_heal_settings(project_path: str) -> Tuple[Optional[bool], List[Any]]:
+    """Best-effort read of ai_self_heal/llm_models straight from a project's config.yaml.
+
+    Returns (ai_self_heal_or_None, raw_llm_models_list). Never raises: a missing or
+    unparsable config.yaml just means there is nothing to fall back to, not a session
+    creation failure — same tolerance as the rest of session creation gives a bad project.
+    """
+    path = os.path.join(project_path, "config.yaml")
+    if not os.path.isfile(path):
+        return None, []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as e:
+        internal_logger.warning("Could not read project config.yaml for self-heal fallback: %s", e)
+        return None, []
+    ai_self_heal = raw.get("ai_self_heal")
+    return (
+        bool(ai_self_heal) if ai_self_heal is not None else None,
+        raw.get("llm_models") or [],
+    )
+
+
+def _resolve_self_heal_settings(
+    config: SessionConfig,
+) -> Tuple[bool, List[Dict[str, DependencyConfig]]]:
+    """Explicit SessionConfig fields win; otherwise fall back to project_path's config.yaml.
+
+    This lets a serve/mcp session either opt in without a project folder (explicit
+    ai_self_heal + llm_models in the request) or simply inherit whatever a project's own
+    config.yaml already has configured for `optics execute`/`optics live` on the same
+    project — self-heal shouldn't behave differently depending on which frontend loads it.
+    """
+    project_ai_self_heal, project_llm_models_raw = (
+        _load_project_self_heal_settings(config.project_path) if config.project_path else (None, [])
+    )
+    ai_self_heal = config.ai_self_heal if config.ai_self_heal is not None else bool(project_ai_self_heal)
+    llm_models_raw = config.llm_models if config.llm_models else project_llm_models_raw
+    llm_models = [config._normalize_item(i) for i in llm_models_raw]
+    return ai_self_heal, llm_models
+
+
 @app.post(
     "/v1/sessions/start",
     response_model=SessionResponse,
@@ -425,12 +474,15 @@ async def create_session(config: SessionConfig):
         elements_sources = normalized.get(KEY_ELEMENTS_SOURCES, [])
         text_detection = normalized.get(KEY_TEXT_DETECTION, [])
         image_detection = normalized.get(KEY_IMAGE_DETECTION, [])
+        ai_self_heal, llm_models = _resolve_self_heal_settings(config)
 
         session_config = Config(
             driver_sources=driver_sources,
             elements_sources=elements_sources,
             text_detection=text_detection,
             image_detection=image_detection,
+            llm_models=llm_models,
+            ai_self_heal=ai_self_heal,
             project_path=config.project_path,
             log_level=LOG_LEVEL_DEBUG,
             save_captures=False  # do not save screenshots or pagesource when using `optics serve`

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -735,6 +735,28 @@ class StrategyManager:
         internal_logger.debug("No screenshot captured.")
         raise OpticsError(Code.E0303, message="No screenshot captured using available strategies.")
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """Return the current screen as encoded image bytes (PNG/JPEG).
+
+        Prefers an element source that overrides
+        :meth:`ElementSourceInterface.capture_screenshot_bytes` (native encoded path,
+        skipping the numpy decode/re-encode round-trip); otherwise encodes the numpy
+        frame from :meth:`capture_screenshot`.
+        """
+        for strategy in self.screenshot_strategies:
+            source = strategy.element_source
+            try:
+                data = source.capture_screenshot_bytes()
+            except NotImplementedError:
+                continue
+            except Exception as e:
+                internal_logger.debug(
+                    "Native screenshot bytes via %s failed: %s", source.__class__.__name__, e)
+                continue
+            if data:
+                return data
+        return utils.encode_numpy_to_png_bytes(self.capture_screenshot())
+
     def capture_screenshot_stream(self, timeout: int = 30):
         """Capture a screenshot stream using the available strategies."""
         execution_logger.debug("Starting screenshot stream with available strategies.")

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -736,26 +736,25 @@ class StrategyManager:
         raise OpticsError(Code.E0303, message="No screenshot captured using available strategies.")
 
     def capture_screenshot_bytes(self) -> bytes:
-        """Return the current screen as encoded image bytes (PNG/JPEG).
+        """Return the current screen as encoded PNG bytes.
 
-        Prefers an element source that overrides
-        :meth:`ElementSourceInterface.capture_screenshot_bytes` (native encoded path,
-        skipping the numpy decode/re-encode round-trip); otherwise encodes the numpy
-        frame from :meth:`capture_screenshot`.
+        Delegates to :meth:`ElementSourceInterface.capture_screenshot_bytes` on each
+        strategy's source. Backends with a native encoded path (Appium, Playwright,
+        Selenium) override that method for efficiency; others encode the numpy frame
+        via the default base-class implementation.
         """
         for strategy in self.screenshot_strategies:
             source = strategy.element_source
             try:
                 data = source.capture_screenshot_bytes()
-            except NotImplementedError:
-                continue
+                if data:
+                    execution_tracer.log_attempt(strategy, "screenshot_bytes", "success")
+                    return data
             except Exception as e:
+                execution_tracer.log_attempt(strategy, "screenshot_bytes", "fail", error=str(e))
                 internal_logger.debug(
-                    "Native screenshot bytes via %s failed: %s", source.__class__.__name__, e)
-                continue
-            if data:
-                return data
-        return utils.encode_numpy_to_png_bytes(self.capture_screenshot())
+                    "Screenshot bytes via %s failed: %s", source.__class__.__name__, e)
+        raise OpticsError(Code.E0303, message="No screenshot bytes captured using available strategies.")
 
     def capture_screenshot_stream(self, timeout: int = 30):
         """Capture a screenshot stream using the available strategies."""

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -6,6 +6,7 @@ import os
 import cv2
 import json
 import base64
+import time
 import numpy as np
 from enum import Enum
 from datetime import timezone, timedelta
@@ -235,6 +236,43 @@ def encode_numpy_to_base64(image: np.ndarray) -> str:
     :return: Base64 encoded string.
     """
     return base64.b64encode(encode_numpy_to_png_bytes(image)).decode('utf-8')
+
+
+# Screenshot-bytes retry: backends whose driver exposes a base64-encoded screenshot
+# (Appium, Selenium) share this fetch-and-decode-with-retry helper.
+BASE64_SCREENSHOT_RETRY_ATTEMPTS = 2
+# Delay between retries; a busy remote hub/grid node occasionally returns a
+# truncated base64 payload, and an immediate retry tends to hit the same failure.
+BASE64_SCREENSHOT_RETRY_BACKOFF_S = 0.5
+
+
+def capture_base64_screenshot_bytes(get_base64: Callable[[], str], backend_name: str) -> bytes:
+    """
+    Fetch a base64-encoded screenshot via ``get_base64`` and decode it to PNG bytes,
+    retrying on transient driver/decode failures.
+
+    :param get_base64: Zero-arg callable returning the driver's base64 screenshot string
+        (e.g. ``driver.get_screenshot_as_base64``).
+    :param backend_name: Human-readable backend name for log/error messages (e.g. "Appium").
+    :raises RuntimeError: If every attempt fails.
+    """
+    import binascii
+    from selenium.common.exceptions import WebDriverException  # local: optional runtime dep
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(BASE64_SCREENSHOT_RETRY_ATTEMPTS):
+        try:
+            return base64.b64decode(get_base64())
+        except (WebDriverException, binascii.Error) as e:
+            last_exc = e
+            internal_logger.warning(
+                "%s native screenshot bytes attempt %d/%d failed: %s",
+                backend_name, attempt + 1, BASE64_SCREENSHOT_RETRY_ATTEMPTS, e,
+            )
+            if attempt < BASE64_SCREENSHOT_RETRY_ATTEMPTS - 1:
+                time.sleep(BASE64_SCREENSHOT_RETRY_BACKOFF_S)
+    raise RuntimeError(f"Error capturing {backend_name} screenshot bytes: {last_exc}") from last_exc
+
 
 def compute_hash(xml_string):
     """Computes the SHA-256 hash of the XML string."""

--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -3,6 +3,7 @@ from typing import Optional, Any, List, Tuple
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.common.appiumby import AppiumBy
 from lxml import etree # type: ignore
+from selenium.common.exceptions import NoSuchElementException
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.elementsource_interface import ElementSourceInterface
@@ -113,8 +114,10 @@ class AppiumFindElement(ElementSourceInterface):
             try:
                 found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)
                 return found_element
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.exception(f" element: {element}", exc_info=e)
+                internal_logger.debug(f"Unexpected error finding element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         elif element_type == 'Class':
             try:
@@ -129,8 +132,12 @@ class AppiumFindElement(ElementSourceInterface):
 
                 found_element = found_elements[index_to_use]
                 return found_element
+            except OpticsError:
+                raise
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.exception(f" element: {element}", exc_info=e)
+                internal_logger.debug(f"Unexpected error finding class element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         return None
 

--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -117,7 +117,7 @@ class AppiumFindElement(ElementSourceInterface):
             except NoSuchElementException as e:
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.debug(f"Unexpected error finding element {element}: {e}")
+                internal_logger.exception(f"Unexpected error finding element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         elif element_type == 'Class':
             try:
@@ -137,7 +137,7 @@ class AppiumFindElement(ElementSourceInterface):
             except NoSuchElementException as e:
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.debug(f"Unexpected error finding class element {element}: {e}")
+                internal_logger.exception(f"Unexpected error finding class element {element}: {e}")
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         return None
 

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -79,6 +79,37 @@ class AppiumPageSource(ElementSourceInterface):
         internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
         raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
 
+    def _locate_by_text(self, driver: WebDriver, element: str, element_type: str, index: Optional[int] = None) -> Any:
+        locator = element[len("text="):] if element.lower().startswith("text=") else element
+        if index is not None:
+            xpath = self.find_xpath_from_text_index(locator, index)
+        else:
+            xpath = self.find_xpath_from_text(locator)
+        try:
+            execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
+            element_obj = driver.find_element(AppiumBy.XPATH, xpath)
+            return element_obj
+        except NoSuchElementException as e:
+            raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+        except Exception as e:
+            internal_logger.debug("Error finding element by text: %s: %s", xpath, e)
+            raise RuntimeError("Error finding element by text.") from e
+
+    def _locate_by_xpath(self, driver: WebDriver, element: str, element_type: str) -> Any:
+        if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
+            xpath, _ = self.driver.ui_helper.find_xpath(element)
+            try:
+                element_obj = driver.find_element(AppiumBy.XPATH, xpath)
+                return element_obj
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+            except Exception as e:
+                internal_logger.debug("Error finding element by xpath: %s: %s", xpath, e)
+                raise RuntimeError("Error finding element by xpath.") from e
+        else:
+            internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
+            raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
+
     def locate(self, element: str, index: Optional[int] = None) -> Any:
         """
         Locate a UI element on the current page using Appium.
@@ -101,34 +132,9 @@ class AppiumPageSource(ElementSourceInterface):
             internal_logger.debug('Appium Page Source does not support finding images.')
             return None
         elif element_type == 'Text':
-            locator = element[len("text="):] if element.lower().startswith("text=") else element
-            if index is not None:
-                xpath = self.find_xpath_from_text_index(locator, index)
-            else:
-                xpath = self.find_xpath_from_text(locator)
-            try:
-                execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
-                element_obj = driver.find_element(AppiumBy.XPATH, xpath)
-                return element_obj
-            except NoSuchElementException as e:
-                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
-            except Exception as e:
-                internal_logger.debug("Error finding element by text: %s: %s", xpath, e)
-                raise RuntimeError("Error finding element by text.") from e
+            return self._locate_by_text(driver, element, element_type, index)
         elif element_type == 'XPath':
-            if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-                xpath, _ = self.driver.ui_helper.find_xpath(element)
-                try:
-                    element_obj = driver.find_element(AppiumBy.XPATH, xpath)
-                    return element_obj
-                except NoSuchElementException as e:
-                    raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
-                except Exception as e:
-                    internal_logger.debug("Error finding element by xpath: %s: %s", xpath, e)
-                    raise RuntimeError("Error finding element by xpath.") from e
-            else:
-                internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
-                raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
+            return self._locate_by_xpath(driver, element, element_type)
         raise RuntimeError("Unknown element type.")
 
     def get_element_bboxes(

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -3,9 +3,11 @@ from typing import Optional, Any, Tuple, List
 from lxml import etree  # type: ignore
 from appium.webdriver.webdriver import WebDriver
 from appium.webdriver.common.appiumby import AppiumBy
+from selenium.common.exceptions import NoSuchElementException
 from optics_framework.common.logging_config import internal_logger, execution_logger
 from optics_framework.common import utils
 from optics_framework.common.elementsource_interface import ElementSourceInterface
+from optics_framework.common.error import OpticsError, Code
 
 APPIUM_NOT_INITIALISED_MSG = "Appium driver is not initialized for AppiumPageSource."
 
@@ -108,18 +110,22 @@ class AppiumPageSource(ElementSourceInterface):
                 execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
                 element_obj = driver.find_element(AppiumBy.XPATH, xpath)
                 return element_obj
-            except Exception:
-                internal_logger.exception("Error finding element by text: %s", xpath)
-                raise RuntimeError("Error finding element by text.")
+            except NoSuchElementException as e:
+                raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+            except Exception as e:
+                internal_logger.debug("Error finding element by text: %s: %s", xpath, e)
+                raise RuntimeError("Error finding element by text.") from e
         elif element_type == 'XPath':
             if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
                 xpath, _ = self.driver.ui_helper.find_xpath(element)
                 try:
                     element_obj = driver.find_element(AppiumBy.XPATH, xpath)
                     return element_obj
-                except Exception:
-                    internal_logger.exception("Error finding element by xpath: %s", xpath)
-                    raise RuntimeError("Error finding element by xpath.")
+                except NoSuchElementException as e:
+                    raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
+                except Exception as e:
+                    internal_logger.debug("Error finding element by xpath: %s: %s", xpath, e)
+                    raise RuntimeError("Error finding element by xpath.") from e
             else:
                 internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
                 raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
@@ -163,8 +169,10 @@ class AppiumPageSource(ElementSourceInterface):
                 xpath = self.driver.ui_helper.get_view_locator(strategy=strategy, locator=locator)
                 try:
                     element_obj = self._require_webdriver().find_element(AppiumBy.XPATH, xpath)
-                except Exception:
-                    internal_logger.exception("Error finding element by index: %s", xpath)
+                except NoSuchElementException:
+                    return None
+                except Exception as e:
+                    internal_logger.debug("Error finding element by index: %s: %s", xpath, e)
                     return None
                 return element_obj
             return None

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -92,7 +92,7 @@ class AppiumPageSource(ElementSourceInterface):
         except NoSuchElementException as e:
             raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
         except Exception as e:
-            internal_logger.debug("Error finding element by text: %s: %s", xpath, e)
+            internal_logger.exception("Error finding element by text: %s: %s", xpath, e)
             raise RuntimeError("Error finding element by text.") from e
 
     def _locate_by_xpath(self, driver: WebDriver, element: str, element_type: str) -> Any:
@@ -104,7 +104,7 @@ class AppiumPageSource(ElementSourceInterface):
             except NoSuchElementException as e:
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:
-                internal_logger.debug("Error finding element by xpath: %s: %s", xpath, e)
+                internal_logger.exception("Error finding element by xpath: %s: %s", xpath, e)
                 raise RuntimeError("Error finding element by xpath.") from e
         else:
             internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
@@ -178,7 +178,7 @@ class AppiumPageSource(ElementSourceInterface):
                 except NoSuchElementException:
                     return None
                 except Exception as e:
-                    internal_logger.debug("Error finding element by index: %s: %s", xpath, e)
+                    internal_logger.exception("Error finding element by index: %s: %s", xpath, e)
                     return None
                 return element_obj
             return None

--- a/optics_framework/engines/elementsources/appium_screenshot.py
+++ b/optics_framework/engines/elementsources/appium_screenshot.py
@@ -1,11 +1,14 @@
 import base64
+import time
 from typing import Optional, Any, List
 import numpy as np
 import cv2
 from appium.webdriver.webdriver import WebDriver
-from selenium.common.exceptions import ScreenshotException
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
+
+# Delay between screenshot retries; an immediate retry tends to hit the same transient failure.
+_SCREENSHOT_RETRY_BACKOFF_S = 0.5
 
 
 class AppiumScreenshot(ElementSourceInterface):
@@ -47,6 +50,29 @@ class AppiumScreenshot(ElementSourceInterface):
         """
         return self.capture_screenshot_as_numpy()
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the device screen as native PNG bytes via Appium's base64 endpoint.
+
+        Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
+        :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
+        bytes. The retry absorbs the truncated-response ("Incorrect padding") base64
+        failures occasionally seen against busy remote hubs.
+        """
+        driver = self._require_driver()
+        last_exc: Optional[Exception] = None
+        for attempt in range(2):
+            try:
+                return base64.b64decode(driver.get_screenshot_as_base64())
+            except Exception as e:
+                last_exc = e
+                internal_logger.warning(
+                    "Appium native screenshot bytes attempt %d/2 failed: %s", attempt + 1, e
+                )
+                if attempt == 0:
+                    time.sleep(_SCREENSHOT_RETRY_BACKOFF_S)
+        raise RuntimeError(f"Error capturing Appium screenshot bytes: {last_exc}") from last_exc
+
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None):
         internal_logger.exception("AppiumScreenshot does not support getting interactive elements.")
         raise NotImplementedError(
@@ -57,28 +83,15 @@ class AppiumScreenshot(ElementSourceInterface):
         """
         Captures a screenshot using Appium and returns it as a NumPy array.
 
+        Reuses :meth:`capture_screenshot_bytes` (shared fetch + retry) and only adds
+        the decode, so the numpy and bytes paths stay in sync.
+
         Returns:
             numpy.ndarray: The captured screenshot as a NumPy array.
         """
-        try:
-            # Use Base64 encoding for faster processing
-            driver = self._require_driver()
-            internal_logger.debug('driver session_id: %s', driver.session_id)
-            screenshot_base64 = driver.get_screenshot_as_base64()
-            screenshot_bytes = base64.b64decode(screenshot_base64)
-            internal_logger.debug("Screenshot bytes length: %d", len(screenshot_bytes))
-            numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
-            numpy_image = cv2.imdecode(numpy_image, cv2.IMREAD_COLOR) # type: ignore
-            return numpy_image
-
-        except ScreenshotException as se:
-            # internal_logger.debug(f'ScreenshotException: {se}. Using external camera')
-            internal_logger.warning(f'ScreenshotException : {se}. Using external camera.')
-            raise RuntimeError("ScreenshotException occurred.")
-        except Exception as e:
-            # Log the error and fallback to external camera
-            internal_logger.warning(f"Error capturing Appium screenshot: {e}. Using external camera.")
-            raise RuntimeError(f"Error capturing Appium screenshot: {e}") from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
+        return cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)  # type: ignore
 
     def assert_elements(self, elements, timeout=30, rule='any') -> None:
         internal_logger.exception("AppiumScreenshot does not support asserting elements.")

--- a/optics_framework/engines/elementsources/appium_screenshot.py
+++ b/optics_framework/engines/elementsources/appium_screenshot.py
@@ -1,14 +1,10 @@
-import base64
-import time
 from typing import Optional, Any, List
 import numpy as np
 import cv2
 from appium.webdriver.webdriver import WebDriver
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
-
-# Delay between screenshot retries; an immediate retry tends to hit the same transient failure.
-_SCREENSHOT_RETRY_BACKOFF_S = 0.5
+from optics_framework.common.utils import capture_base64_screenshot_bytes
 
 
 class AppiumScreenshot(ElementSourceInterface):
@@ -56,22 +52,12 @@ class AppiumScreenshot(ElementSourceInterface):
 
         Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
         :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
-        bytes. The retry absorbs the truncated-response ("Incorrect padding") base64
-        failures occasionally seen against busy remote hubs.
+        bytes. The retry (shared with :class:`SeleniumScreenshot`) absorbs the
+        truncated-response ("Incorrect padding") base64 failures occasionally seen
+        against busy remote hubs.
         """
         driver = self._require_driver()
-        last_exc: Optional[Exception] = None
-        for attempt in range(2):
-            try:
-                return base64.b64decode(driver.get_screenshot_as_base64())
-            except Exception as e:
-                last_exc = e
-                internal_logger.warning(
-                    "Appium native screenshot bytes attempt %d/2 failed: %s", attempt + 1, e
-                )
-                if attempt == 0:
-                    time.sleep(_SCREENSHOT_RETRY_BACKOFF_S)
-        raise RuntimeError(f"Error capturing Appium screenshot bytes: {last_exc}") from last_exc
+        return capture_base64_screenshot_bytes(driver.get_screenshot_as_base64, "Appium")
 
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None):
         internal_logger.exception("AppiumScreenshot does not support getting interactive elements.")

--- a/optics_framework/engines/elementsources/playwright_screenshot.py
+++ b/optics_framework/engines/elementsources/playwright_screenshot.py
@@ -42,43 +42,40 @@ class PlaywrightScreenshot(ElementSourceInterface):
         """
         return self.capture_screenshot_as_numpy()
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the viewport as native PNG bytes.
+
+        ``page.screenshot()`` already returns encoded PNG, so this is the cheapest
+        path of all backends — no base64 decode and no OpenCV decode/encode at all.
+        """
+        page = self._require_page()
+        try:
+            internal_logger.debug("Capturing Playwright screenshot")
+            # Use run_async to handle async page.screenshot() if page is from async_api.
+            return run_async(page.screenshot(full_page=False))
+        except Exception as e:
+            internal_logger.warning(
+                "Error capturing Playwright screenshot bytes: %s", e, exc_info=True
+            )
+            raise RuntimeError(f"Error capturing Playwright screenshot bytes: {e}") from e
+
     def capture_screenshot_as_numpy(self) -> np.ndarray:
         """
         Captures screenshot via Playwright and converts to NumPy image.
         Only captures the viewport, not the full page.
 
+        Reuses :meth:`capture_screenshot_bytes` and only adds the decode.
+
         Returns:
             numpy.ndarray: Screenshot image
         """
-        page = self._require_page()
-        try:
-            internal_logger.debug("Capturing Playwright screenshot")
-
-            # Playwright returns raw PNG bytes
-            # Use run_async to handle async page.screenshot() if page is from async_api
-            screenshot_bytes = run_async(page.screenshot(full_page=False))
-
-            internal_logger.debug(
-                "Playwright screenshot bytes length: %d",
-                len(screenshot_bytes),
-            )
-
-            np_image = np.frombuffer(screenshot_bytes, np.uint8)
-            np_image = cv2.imdecode(np_image, cv2.IMREAD_COLOR)  # type: ignore
-
-            if np_image is None:
-                raise RuntimeError("Failed to decode Playwright screenshot")
-
-            return np_image
-
-        except Exception as e:
-            internal_logger.warning(
-                f"Error capturing Playwright screenshot: {e}",
-                exc_info=True,
-            )
-            raise RuntimeError(
-                f"Error capturing Playwright screenshot: {e}"
-            ) from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        np_image = np.frombuffer(screenshot_bytes, np.uint8)
+        np_image = cv2.imdecode(np_image, cv2.IMREAD_COLOR)  # type: ignore
+        if np_image is None:
+            raise RuntimeError("Failed to decode Playwright screenshot")
+        return np_image
 
     # --------------------------------------------------
     # Unsupported operations

--- a/optics_framework/engines/elementsources/selenium_screenshot.py
+++ b/optics_framework/engines/elementsources/selenium_screenshot.py
@@ -1,10 +1,13 @@
 from typing import Optional, Any, List
 import base64
+import time
 import cv2
 import numpy as np
-from selenium.common.exceptions import ScreenshotException
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
+
+# Delay between screenshot retries (Selenium Grid nodes can be remote/flaky too).
+_SCREENSHOT_RETRY_BACKOFF_S = 0.5
 
 
 class SeleniumScreenshot(ElementSourceInterface):
@@ -38,25 +41,41 @@ class SeleniumScreenshot(ElementSourceInterface):
         internal_logger.exception("SeleniumScreenshot does not support getting interactive elements.")
         raise NotImplementedError("SeleniumScreenshot does not support getting interactive elements.")
 
+    def capture_screenshot_bytes(self) -> bytes:
+        """
+        Return the screen as native PNG bytes via Selenium's base64 endpoint.
+
+        Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
+        :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
+        bytes. The retry absorbs transient/truncated responses from remote Grid nodes.
+        """
+        driver = self._require_driver()
+        last_exc: Optional[Exception] = None
+        for attempt in range(2):
+            try:
+                return base64.b64decode(driver.get_screenshot_as_base64())
+            except Exception as e:
+                last_exc = e
+                internal_logger.warning(
+                    "Selenium native screenshot bytes attempt %d/2 failed: %s", attempt + 1, e
+                )
+                if attempt == 0:
+                    time.sleep(_SCREENSHOT_RETRY_BACKOFF_S)
+        raise RuntimeError(f"Error capturing Selenium screenshot bytes: {last_exc}") from last_exc
+
     def capture_screenshot_as_numpy(self) -> np.ndarray:
         """
         Captures a screenshot using Selenium and returns it as a NumPy array.
+
+        Reuses :meth:`capture_screenshot_bytes` (shared fetch + retry) and only adds
+        the decode, so the numpy and bytes paths stay in sync.
+
         Returns:
             np.ndarray: The captured screenshot as a NumPy array.
         """
-        try:
-            driver = self._require_driver()
-            screenshot_base64 = driver.get_screenshot_as_base64()
-            screenshot_bytes = base64.b64decode(screenshot_base64)
-            numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
-            numpy_image = cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)
-            return numpy_image
-        except ScreenshotException as se:
-            internal_logger.warning("ScreenshotException : %s. Using external camera.", se)
-            raise RuntimeError("ScreenshotException occurred.") from se
-        except Exception as e:
-            internal_logger.warning("Error capturing Selenium screenshot: %s. Using external camera.", e)
-            raise RuntimeError("Error capturing Selenium screenshot.") from e
+        screenshot_bytes = self.capture_screenshot_bytes()
+        numpy_image = np.frombuffer(screenshot_bytes, np.uint8)
+        return cv2.imdecode(numpy_image, cv2.IMREAD_COLOR)
 
     def assert_elements(self, elements, timeout=30, rule='any') -> None:
         internal_logger.exception("SeleniumScreenshot does not support asserting elements.")

--- a/optics_framework/engines/elementsources/selenium_screenshot.py
+++ b/optics_framework/engines/elementsources/selenium_screenshot.py
@@ -1,13 +1,9 @@
 from typing import Optional, Any, List
-import base64
-import time
 import cv2
 import numpy as np
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.logging_config import internal_logger
-
-# Delay between screenshot retries (Selenium Grid nodes can be remote/flaky too).
-_SCREENSHOT_RETRY_BACKOFF_S = 0.5
+from optics_framework.common.utils import capture_base64_screenshot_bytes
 
 
 class SeleniumScreenshot(ElementSourceInterface):
@@ -47,21 +43,11 @@ class SeleniumScreenshot(ElementSourceInterface):
 
         Skips the ``base64 -> numpy -> cv2.imdecode`` decode that
         :meth:`capture_screenshot_as_numpy` does, for callers that only need encoded
-        bytes. The retry absorbs transient/truncated responses from remote Grid nodes.
+        bytes. The retry (shared with :class:`AppiumScreenshot`) absorbs
+        transient/truncated responses from remote Grid nodes.
         """
         driver = self._require_driver()
-        last_exc: Optional[Exception] = None
-        for attempt in range(2):
-            try:
-                return base64.b64decode(driver.get_screenshot_as_base64())
-            except Exception as e:
-                last_exc = e
-                internal_logger.warning(
-                    "Selenium native screenshot bytes attempt %d/2 failed: %s", attempt + 1, e
-                )
-                if attempt == 0:
-                    time.sleep(_SCREENSHOT_RETRY_BACKOFF_S)
-        raise RuntimeError(f"Error capturing Selenium screenshot bytes: {last_exc}") from last_exc
+        return capture_base64_screenshot_bytes(driver.get_screenshot_as_base64, "Selenium")
 
     def capture_screenshot_as_numpy(self) -> np.ndarray:
         """

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -1104,10 +1104,7 @@ class LiveController:
         """
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
-        try:
-            return self._action_keyword.strategy_manager.capture_screenshot_bytes()
-        except ValueError as exc:  # pragma: no cover - defensive
-            raise OpticsError(Code.E0303, message="Failed to encode screenshot") from exc
+        return self._action_keyword.strategy_manager.capture_screenshot_bytes()
 
     # -- Natural-language mode ----------------------------------------------------
 

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -1096,7 +1096,12 @@ class LiveController:
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:
-        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect."""
+        """Capture the current screen as encoded PNG bytes (for the LLM); no file side-effect.
+
+        Delegates to ``StrategyManager.capture_screenshot_bytes()`` so the native
+        fast path (when a backend supports it) and the numpy fallback are chosen
+        driver-agnostically.
+        """
         if self._action_keyword is None:  # pragma: no cover - defensive
             raise OpticsError(Code.E0303, message="Screenshot capture unavailable")
         try:

--- a/optics_framework/helper/mcp_server.py
+++ b/optics_framework/helper/mcp_server.py
@@ -155,6 +155,11 @@ def _make_keyword_tool(slug: str, params: list[inspect.Parameter]) -> Callable[.
         except OpticsError as exc:  # pragma: no cover - defensive
             raise ToolError(str(exc)) from exc
         data = getattr(response, "data", None) or {}
+        # When a self-heal recovered this call, execute_keyword returns {"result": ...,
+        # "healed": True, "heal_summary": ...} instead of the bare result — return the
+        # whole dict so the MCP client sees the heal, not just the unwrapped result.
+        if "healed" in data:
+            return data
         return data.get(_RESULT_KEY, data)
 
     synth: list[inspect.Parameter] = [
@@ -246,6 +251,7 @@ def build_server() -> "FastMCP":
         text_detection: Optional[list[str]] = None,
         image_detection: Optional[list[str]] = None,
         project_path: Optional[str] = None,
+        ai_self_heal: Optional[bool] = None,
     ) -> dict[str, Any]:
         """Start a new optics session and launch the target app.
 
@@ -253,6 +259,13 @@ def build_server() -> "FastMCP":
         keyword tool and state resource. The app is auto-launched on start.
         Sessions are NOT shared with `optics serve`/`optics live` (separate
         process); start one here before using any keyword tool.
+
+        ai_self_heal: leave unset to inherit project_path's own config.yaml (if it has
+        ai_self_heal + an enabled llm_models entry configured); pass True/False to
+        override it explicitly. There is no way to configure the LLM provider itself
+        from this tool — it must come from project_path's config.yaml or environment
+        variables, so ai_self_heal=True without a project_path pointing at a project
+        with an enabled llm_models entry will stay silently inert.
         """
         if url or capabilities:
             driver_sources: list[Any] = [
@@ -266,6 +279,7 @@ def build_server() -> "FastMCP":
             text_detection=text_detection or [],
             image_detection=image_detection or [],
             project_path=project_path,
+            ai_self_heal=ai_self_heal,
         )
         try:
             response = await expose_api.create_session(config)

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -187,6 +187,7 @@ class TestHandlerActions:
         assert res.ok is False
         assert llm.calls == 2
         assert executor.calls == ['scroll down', 'scroll down']
+        assert "scroll down" in res.message
 
     def test_keyword_failure_does_not_abort(self):
         """A failing keyword lets the LLM retry a different approach."""

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -1,10 +1,12 @@
-"""Unit tests for the AI self-heal handler and its ActionKeyword wiring.
+"""Unit tests for the keyword-based AI self-heal handler and its ActionKeyword wiring.
 
-No network: a scripted fake LLM drives the handler and a fake driver records the primitive
-calls. Covers each action type, the bounded loop, give_up, malformed JSON, LLM/driver errors,
-missing-screenshot inertness, page-source injection, and the ActionKeyword inert/active paths.
+No network: a scripted fake LLM drives the handler and a fake keyword executor records the
+keyword lines dispatched. Covers each action type, the bounded loop, give_up, done, malformed
+JSON, LLM/executor errors, missing-screenshot inertness, page-source injection, and the
+ActionKeyword inert/active paths.
 """
 import json
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
@@ -13,6 +15,7 @@ from optics_framework.common import ai_self_heal as ash
 from optics_framework.common.ai_self_heal import (
     AISelfHealHandler,
     HealContext,
+    HealKeywordSpec,
     HEAL_ACTION_SCHEMA,
 )
 from optics_framework.common.error import OpticsError, Code
@@ -47,23 +50,36 @@ class FakeLLM:
         return self.scripted.pop(0)
 
 
-class FakeDriver:
-    """Records the driver primitive calls the handler dispatches."""
+@dataclass
+class ExecResult:
+    ok: bool
+    message: str = ""
 
-    def __init__(self):
+
+class FakeExecutor:
+    """Records keyword lines dispatched by the handler."""
+
+    def __init__(self, *, fail_keywords=None):
         self.calls = []
+        self._fail_keywords = fail_keywords or set()
 
-    def press_percentage_coordinates(self, px, py, repeat, event_name=None):
-        self.calls.append(("tap", px, py, repeat))
+    def __call__(self, line: str) -> ExecResult:
+        self.calls.append(line)
+        keyword = line.split()[0] if line else ""
+        if keyword in self._fail_keywords:
+            return ExecResult(ok=False, message=f"Element not found for '{keyword}'")
+        return ExecResult(ok=True)
 
-    def enter_text(self, text, event_name=None):
-        self.calls.append(("enter_text", text))
 
-    def swipe_percentage(self, x, y, direction, length, event_name=None):
-        self.calls.append(("swipe", x, y, direction, length))
-
-    def scroll(self, direction, duration, event_name=None):
-        self.calls.append(("scroll", direction, duration))
+def _catalog():
+    return [
+        HealKeywordSpec(name="press_element", signature="press_element <element> [repeat]"),
+        HealKeywordSpec(name="enter_text", signature="enter_text <element> <text>"),
+        HealKeywordSpec(name="scroll", signature="scroll <direction>"),
+        HealKeywordSpec(name="swipe_by_percentage", signature="swipe_by_percentage <percent_x> <percent_y> <direction> [swipe_length]"),
+        HealKeywordSpec(name="press_keycode", signature="press_keycode <keycode>"),
+        HealKeywordSpec(name="press_by_percentage", signature="press_by_percentage <percent_x> <percent_y>"),
+    ]
 
 
 def _shots():
@@ -87,64 +103,128 @@ class TestActionSchema:
 
 
 class TestHandlerActions:
-    def test_tap_completes(self):
-        llm = FakeLLM([{"action": "tap", "percent_x": 50, "percent_y": 60, "reason": "press it"}])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+    def test_press_element_completes(self):
+        """LLM emits press_element with text target — single step, completed."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is True
-        assert driver.calls == [("tap", 50.0, 60.0, 1)]
+        assert executor.calls == ['press_element Meesho']
         assert llm.calls == 1
 
-    def test_type_taps_then_enters(self):
+    def test_scroll_then_press_element(self):
+        """LLM scrolls to reveal target, then presses by text."""
         llm = FakeLLM([
-            {"action": "type", "percent_x": 10, "percent_y": 20, "text": "hello", "reason": "fill"}
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal target"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
         ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
         assert res.ok is True
-        assert driver.calls == [("tap", 10.0, 20.0, 1), ("enter_text", "hello")]
-
-    def test_scroll_then_tap(self):
-        llm = FakeLLM([
-            {"action": "scroll", "direction": "down", "reason": "reveal"},
-            {"action": "tap", "percent_x": 40, "percent_y": 80, "reason": "now press"},
-        ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
-        assert res.ok is True
-        assert driver.calls == [("scroll", "down", 1000), ("tap", 40.0, 80.0, 1)]
+        assert executor.calls == ['scroll down', 'press_element Meesho']
         assert llm.calls == 2
 
-    def test_swipe_uses_int_coords_and_default_length(self):
+    def test_enter_text_completes(self):
+        """LLM emits enter_text — single step completion."""
+        ctx = HealContext(intent_keyword="enter_text", intent_params=["Search", "hello"], element="Search")
         llm = FakeLLM([
-            {"action": "swipe", "percent_x": 50.7, "percent_y": 50.2, "direction": "up", "reason": "x"},
-            {"action": "give_up", "reason": "done trying"},
+            {"action": "keyword", "keyword": "enter_text", "params": ["Search", "hello"],
+             "completed": True, "reason": "type it"},
         ])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
-        assert res.ok is False
-        assert driver.calls[0] == ("swipe", 50, 50, "up", 50)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(ctx, _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ["enter_text Search hello"]
+
+    def test_press_keycode_then_press_element(self):
+        """LLM presses back, then targets element by text."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_keycode", "params": ["4"],
+             "completed": False, "reason": "go back"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press it"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ['press_keycode 4', 'press_element Login']
+
+    def test_done_action_succeeds(self):
+        """LLM signals done — goal reached without a keyword."""
+        llm = FakeLLM([
+            {"action": "done", "reason": "target already visible and pressed"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == []
 
     def test_give_up_fails(self):
         llm = FakeLLM([{"action": "give_up", "reason": "blocked"}])
-        res = AISelfHealHandler(llm, FakeDriver()).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "blocked" in res.message
 
     def test_malformed_action_treated_as_give_up(self):
         llm = FakeLLM([{"action": "frobnicate", "reason": "nonsense"}])
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver).heal(_ctx(), _shots, _no_ps)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
-        assert driver.calls == []
+        assert executor.calls == []
 
     def test_step_budget_exhausted(self):
-        llm = FakeLLM([{"action": "scroll", "direction": "down", "reason": "x"}] * 2)
-        driver = FakeDriver()
-        res = AISelfHealHandler(llm, driver, max_steps=2).heal(_ctx(), _shots, _no_ps)
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"], "reason": "x"}
+        ] * 2)
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert llm.calls == 2
-        assert driver.calls == [("scroll", "down", 1000), ("scroll", "down", 1000)]
+        assert executor.calls == ['scroll down', 'scroll down']
+
+    def test_keyword_failure_does_not_abort(self):
+        """A failing keyword lets the LLM retry a different approach."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["WrongText"],
+             "completed": True, "reason": "try pressing"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "correct target"},
+        ])
+        executor = FakeExecutor(fail_keywords={"press_element"})
+        # Both fail because we set press_element as failing, so heal should fail
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is False
+        assert len(executor.calls) == 2
+
+    def test_intermediate_press_then_final_press(self):
+        """LLM presses a menu (completed=False), then the final target (completed=True)."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Apps"],
+             "completed": False, "reason": "open apps drawer"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Meesho"],
+             "completed": True, "reason": "press target"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert executor.calls == ['press_element Apps', 'press_element Meesho']
+
+    def test_swipe_uses_percentage(self):
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "swipe_by_percentage", "params": ["50", "80", "up", "30"],
+             "completed": False, "reason": "reveal target"},
+            {"action": "give_up", "reason": "still not visible"},
+        ])
+        executor = FakeExecutor()
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is False
+        assert executor.calls == ['swipe_by_percentage 50 80 up 30']
 
 
 class TestHandlerErrorHandling:
@@ -153,23 +233,22 @@ class TestHandlerErrorHandling:
             def generate_json(self, *a, **k):
                 raise OpticsError(Code.E0801, message="bad json")
 
-        res = AISelfHealHandler(BoomLLM(), FakeDriver()).heal(_ctx(), _shots, _no_ps)
+        res = AISelfHealHandler(BoomLLM(), FakeExecutor(), lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "bad json" in res.message
 
-    def test_driver_error_returns_not_ok(self):
-        class BadDriver(FakeDriver):
-            def press_percentage_coordinates(self, *a, **k):
-                raise RuntimeError("device offline")
+    def test_executor_exception_returns_not_ok(self):
+        def boom_executor(line):
+            raise RuntimeError("device offline")
 
-        llm = FakeLLM([{"action": "tap", "percent_x": 1, "percent_y": 1, "reason": "x"}])
-        res = AISelfHealHandler(llm, BadDriver()).heal(_ctx(), _shots, _no_ps)
+        llm = FakeLLM([{"action": "keyword", "keyword": "press_element", "params": ["X"], "reason": "x"}])
+        res = AISelfHealHandler(llm, boom_executor, lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert "device offline" in res.message
 
     def test_no_screenshot_is_inert(self):
-        llm = FakeLLM([{"action": "tap", "percent_x": 1, "percent_y": 1, "reason": "x"}])
-        res = AISelfHealHandler(llm, FakeDriver()).heal(_ctx(), lambda: None, _no_ps)
+        llm = FakeLLM([{"action": "keyword", "keyword": "press_element", "params": ["X"], "reason": "x"}])
+        res = AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(_ctx(), lambda: None, _no_ps)
         assert res.ok is False
         assert llm.calls == 0
 
@@ -185,13 +264,20 @@ class TestPromptContext:
             recent_steps=[("press_element", ["Menu"])],
             failed_strategies=["XPathStrategy", "TextDetectionStrategy"],
         )
-        AISelfHealHandler(llm, FakeDriver()).heal(ctx, _shots, lambda: ps)
+        AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(ctx, _shots, lambda: ps)
         assert "login_field" in llm.last_prompt
         assert "CURRENT SCREEN ELEMENTS" in llm.last_prompt
         assert "enter_text" in llm.last_prompt
         assert "press_element" in llm.last_prompt  # recent step
         assert "TextDetectionStrategy" in llm.last_prompt
         assert "last-resort" in llm.last_system.lower()
+
+    def test_keyword_catalog_in_prompt(self):
+        llm = FakeLLM([{"action": "give_up", "reason": "x"}])
+        AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog()).heal(_ctx(), _shots, _no_ps)
+        assert "AVAILABLE KEYWORDS" in llm.last_prompt
+        assert "press_element <element>" in llm.last_prompt
+        assert "scroll <direction>" in llm.last_prompt
 
 
 # --------------------------------------------------------------------------------------------
@@ -256,15 +342,45 @@ class TestActionKeywordWiring:
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
         assert ak._ai_self_heal("X", "press_element", (), {}, shot) is False
 
-    def test_active_tap_heals(self, monkeypatch):
+    def test_heal_catalog_returns_specs(self):
+        ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
+        catalog = ak._heal_catalog()
+        names = [spec.name for spec in catalog]
+        assert "press_element" in names
+        assert "scroll" in names
+        assert "enter_text" in names
+        # Signatures should be human-readable
+        pe_spec = next(s for s in catalog if s.name == "press_element")
+        assert "<element>" in pe_spec.signature
+
+    def test_active_press_element_heals(self, monkeypatch):
         monkeypatch.setattr(ash.time, "sleep", lambda *_a, **_k: None)
-        llm = FakeLLM([{"action": "tap", "percent_x": 25, "percent_y": 75, "reason": "press"}])
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press it"},
+        ])
         llm.instances = [object()]  # InstanceFallback-like truthiness gate
         ak = _make_action_keyword(ai_self_heal=True, llm=llm)
-        # No page source from the mocked strategy manager.
-        ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
+        # Mock strategy manager to return valid screenshot bytes and no page source.
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
+        ak.strategy_manager.capture_screenshot = MagicMock(return_value=shot)
+        ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
+
+        # Mock the keyword methods that _heal_execute will call.
+        # scroll is non-self-healing so it's called directly.
+        ak.scroll = MagicMock()
+        # press_element goes through `with_self_healing` decorator, which needs a
+        # working strategy_manager.locate; mock it to return a located result.
+        mock_result = MagicMock()
+        mock_result.is_coordinates = False
+        mock_result.value = MagicMock()
+        mock_result.strategy = MagicMock()
+        ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
+
         assert ak._ai_self_heal("Login", "press_element", (), {}, shot) is True
-        ak.driver.press_percentage_coordinates.assert_called_once()
-        # Healed keyword is recorded as a breadcrumb.
-        assert list(ak._recent_steps) == [("press_element", ["Login"])]
+        # Healed keyword is recorded as a breadcrumb (may appear more than once —
+        # the inner press_element records one, and _log_heal_outcome records another).
+        steps = list(ak._recent_steps)
+        assert any(s == ("press_element", ["Login"]) for s in steps)

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -1,4 +1,7 @@
 """Unit tests for TEXT_ONLY prefix feature and strategy selection."""
+import base64
+import time
+import cv2
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
@@ -182,3 +185,129 @@ class TestStrategyManagerAssertPresenceTextOnly:
             assert "Submit" in seen_elements
             assert "Login" in seen_elements
             assert "TEXT_ONLY:Login" not in seen_elements
+
+
+# --- capture_screenshot_bytes (native fast path + numpy fallback) ---
+
+
+def _sm_with_source(source):
+    """StrategyManager wrapping a single element source (screenshot path only)."""
+    return StrategyManager(
+        element_source=InstanceFallback([source]),
+        text_detection=None,
+        image_detection=None,
+    )
+
+
+class TestCaptureScreenshotBytes:
+    """StrategyManager.capture_screenshot_bytes() prefers the native path, else encodes numpy."""
+
+    def test_prefers_native_bytes(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.return_value = b"\x89PNG-native"
+        sm = _sm_with_source(source)
+        assert sm.capture_screenshot_bytes() == b"\x89PNG-native"
+        source.capture.assert_not_called()  # native path => no numpy capture/encode
+
+    def test_falls_back_to_numpy_encode(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.side_effect = NotImplementedError
+        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)  # white, not black
+        sm = _sm_with_source(source)
+        data = sm.capture_screenshot_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # real PNG magic from cv2.imencode
+
+    def test_skips_failing_native_then_falls_back(self):
+        source = MagicMock()
+        source.capture_screenshot_bytes.side_effect = RuntimeError("hub timeout")
+        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)
+        sm = _sm_with_source(source)
+        assert sm.capture_screenshot_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class _FakeWD:
+    """Stub webdriver (no ``.driver`` attr, so _require_driver returns it as-is)."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def get_screenshot_as_base64(self):
+        self.calls += 1
+        item = self._results.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+@pytest.fixture
+def _no_backoff(monkeypatch):
+    """Skip the inter-retry sleep so retry tests stay fast."""
+    monkeypatch.setattr(time, "sleep", lambda *_a, **_k: None)
+
+
+class TestAppiumScreenshotBytes:
+    """AppiumScreenshot.capture_screenshot_bytes() decodes base64 with a single retry."""
+
+    def test_returns_decoded_base64(self):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNG\r\n\x1a\nDATA"
+        drv = _FakeWD([base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 1
+
+    def test_retries_then_succeeds(self, _no_backoff):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        png = b"\x89PNGok"
+        drv = _FakeWD(["not-valid-base64!!!", base64.b64encode(png).decode("ascii")])
+        assert AppiumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 2
+
+    def test_raises_after_exhausted_retries(self, _no_backoff):
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        drv = _FakeWD([ValueError("boom"), ValueError("boom")])
+        with pytest.raises(RuntimeError):
+            AppiumScreenshot(driver=drv).capture_screenshot_bytes()
+        assert drv.calls == 2
+
+    def test_numpy_path_reuses_bytes(self, _no_backoff):
+        """capture_screenshot_as_numpy delegates to the bytes path (shared retry)."""
+        from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
+        # A real 2x2 PNG so cv2.imdecode succeeds; corrupt first to exercise the shared retry.
+        ok_png = cv2.imencode(".png", np.full((2, 2, 3), 255, np.uint8))[1].tobytes()
+        drv = _FakeWD(["bad!!!", base64.b64encode(ok_png).decode("ascii")])
+        img = AppiumScreenshot(driver=drv).capture_screenshot_as_numpy()
+        assert img.shape == (2, 2, 3)
+        assert drv.calls == 2
+
+
+class TestSeleniumScreenshotBytes:
+    """SeleniumScreenshot mirrors the Appium native base64 path."""
+
+    def test_returns_decoded_base64(self):
+        from optics_framework.engines.elementsources.selenium_screenshot import SeleniumScreenshot
+        png = b"\x89PNG\r\n\x1a\nDATA"
+        drv = _FakeWD([base64.b64encode(png).decode("ascii")])
+        assert SeleniumScreenshot(driver=drv).capture_screenshot_bytes() == png
+
+    def test_retries_then_succeeds(self, _no_backoff):
+        from optics_framework.engines.elementsources.selenium_screenshot import SeleniumScreenshot
+        png = b"\x89PNGok"
+        drv = _FakeWD(["bad!!!", base64.b64encode(png).decode("ascii")])
+        assert SeleniumScreenshot(driver=drv).capture_screenshot_bytes() == png
+        assert drv.calls == 2
+
+
+class TestPlaywrightScreenshotBytes:
+    """PlaywrightScreenshot returns page.screenshot()'s PNG bytes verbatim (no decode)."""
+
+    def test_returns_page_screenshot_bytes(self, monkeypatch):
+        pytest.importorskip("playwright")
+        import types as _types
+        import optics_framework.engines.elementsources.playwright_screenshot as pw
+        monkeypatch.setattr(pw, "run_async", lambda coro: coro)
+        png = b"\x89PNG\r\n\x1a\nPLAYWRIGHT"
+        page = MagicMock()
+        page.screenshot.return_value = png
+        src = pw.PlaywrightScreenshot(driver=_types.SimpleNamespace(page=page))
+        assert src.capture_screenshot_bytes() == png

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -220,8 +220,6 @@ class TestCaptureScreenshotBytes:
     def test_interface_default_encodes_numpy_via_capture(self):
         """ElementSourceInterface.capture_screenshot_bytes() default encodes capture() result."""
         from optics_framework.common.elementsource_interface import ElementSourceInterface
-        from unittest.mock import patch
-        import cv2
 
         class _MinimalSource(ElementSourceInterface):
             def capture(self) -> np.ndarray:

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -209,20 +209,30 @@ class TestCaptureScreenshotBytes:
         assert sm.capture_screenshot_bytes() == b"\x89PNG-native"
         source.capture.assert_not_called()  # native path => no numpy capture/encode
 
-    def test_falls_back_to_numpy_encode(self):
-        source = MagicMock()
-        source.capture_screenshot_bytes.side_effect = NotImplementedError
-        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)  # white, not black
-        sm = _sm_with_source(source)
-        data = sm.capture_screenshot_bytes()
-        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # real PNG magic from cv2.imencode
-
-    def test_skips_failing_native_then_falls_back(self):
+    def test_raises_optics_error_when_all_sources_fail(self):
+        from optics_framework.common.error import OpticsError
         source = MagicMock()
         source.capture_screenshot_bytes.side_effect = RuntimeError("hub timeout")
-        source.capture.return_value = np.full((8, 8, 3), 255, dtype=np.uint8)
         sm = _sm_with_source(source)
-        assert sm.capture_screenshot_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+        with pytest.raises(OpticsError):
+            sm.capture_screenshot_bytes()
+
+    def test_interface_default_encodes_numpy_via_capture(self):
+        """ElementSourceInterface.capture_screenshot_bytes() default encodes capture() result."""
+        from optics_framework.common.elementsource_interface import ElementSourceInterface
+        from unittest.mock import patch
+        import cv2
+
+        class _MinimalSource(ElementSourceInterface):
+            def capture(self) -> np.ndarray:
+                return np.full((8, 8, 3), 255, dtype=np.uint8)
+            def locate(self, element, index=None): raise NotImplementedError
+            def assert_elements(self, elements, timeout=30, rule='any'): raise NotImplementedError
+            def get_interactive_elements(self, filter_config=None): raise NotImplementedError
+
+        source = _MinimalSource()
+        data = source.capture_screenshot_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic bytes from cv2.imencode
 
 
 class _FakeWD:

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -4,6 +4,7 @@ import time
 import cv2
 import numpy as np
 import pytest
+from selenium.common.exceptions import WebDriverException
 from unittest.mock import MagicMock, patch
 
 from optics_framework.common import utils
@@ -273,7 +274,7 @@ class TestAppiumScreenshotBytes:
 
     def test_raises_after_exhausted_retries(self, _no_backoff):
         from optics_framework.engines.elementsources.appium_screenshot import AppiumScreenshot
-        drv = _FakeWD([ValueError("boom"), ValueError("boom")])
+        drv = _FakeWD([WebDriverException("boom"), WebDriverException("boom")])
         with pytest.raises(RuntimeError):
             AppiumScreenshot(driver=drv).capture_screenshot_bytes()
         assert drv.calls == 2


### PR DESCRIPTION
Closes #375. Depends on #303 .

## What was missing

`SessionConfig` (used by both `POST /v1/sessions/start` and the MCP `start_session` tool) had no `ai_self_heal`/`llm_models` fields, so a session created that way could never turn self-heal on, even with `project_path` pointing at a project whose own `config.yaml` already had it configured.

Separately, `mode=keyword` execution (the path `serve`/`mcp` use) goes through `KeywordExecutor` — a third call site distinct from `TestRunner`/`LiveController` — which had no visibility into whether a keyword only passed because self-heal recovered it.

## Changes

- `SessionConfig` gains `ai_self_heal`/`llm_models`. `_resolve_self_heal_settings` resolves each independently: an explicit value in the request always wins; otherwise, when `project_path` is given, it's read straight from that project's `config.yaml` — so a project already set up for self-heal behaves the same via `serve` as via `execute`/`live`.
- `KeywordExecutor.execute` now pops the heal info recorded on the `ActionKeyword` instance right after a successful call, publishing it on the keyword `Event`'s `extra` and folding it into the returned value as `{"result": ..., "healed": true, "heal_summary": ...}` when a heal occurred (unhealed calls are unaffected).
- MCP's `start_session` gets a single `ai_self_heal: Optional[bool] = None` param (left unset, it inherits `project_path`'s config; the LLM provider itself still comes from that config or the environment, not this tool — it's a nested provider/credentials shape that doesn't fit a flat tool param). `_make_keyword_tool`'s result-unwrapping is fixed so it no longer silently drops `healed`/`heal_summary` before they reach the MCP client.