### PR TITLE
fix(serve): wire AI self-heal through optics serve and optics mcp as a service-level setting

### DIFF
--- a/docs/usage/mcp_usage.md
+++ b/docs/usage/mcp_usage.md
@@ -152,6 +152,9 @@ the client at the URL:
 | `text_detection` | list[str] | optional OCR sources (e.g. `["googlevision"]`) |
 | `image_detection` | list[str] | optional template sources (e.g. `["templatematch"]`) |
 | `project_path` | str | optional project folder (loads bundled templates) |
+| `ai_self_heal` | bool | optional per-session override of the server's `OPTICS_AI_SELF_HEAL` default (see below) |
+| `llm_provider` | str | optional per-session override of the server's `OPTICS_LLM_PROVIDER` default (see below) |
+| `llm_model` | str | optional per-session override of the server's `OPTICS_LLM_MODEL` default (see below) |
 
 **Example — local Appium + Android emulator:**
 
@@ -173,6 +176,48 @@ the client at the URL:
 Omit `appPackage`/`appActivity` to attach to whatever is already on screen. For
 a remote/managed hub, set `url` to the hub and include any hub-specific
 capabilities (auth token, device id) just as you would in `config.yaml`.
+
+### AI self-heal
+
+Self-heal has two layers. Whoever starts `optics mcp` (or `optics serve`) can
+set a **server-level default** once via environment variables, so a client
+that's already integrated inherits it with no `start_session` changes:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `OPTICS_AI_SELF_HEAL` | off | `true`/`1`/`yes`/`on` (case-insensitive) enables it |
+| `OPTICS_LLM_PROVIDER` | `gemini` | which `llm_models` entry to enable |
+| `OPTICS_LLM_MODEL` | provider default | optional model name override |
+
+Because a single `serve`/`mcp` process is multi-tenant, each of these is also a
+**per-session override** on `start_session`: `ai_self_heal`, `llm_provider`, and
+`llm_model`. A per-session value always wins over the matching env-var default,
+so a caller can opt in/out and pick its own model without being locked to the
+operator's choice; anything left unset falls back to the env default (and then to
+`gemini`). LLM credentials (e.g. `GOOGLE_API_KEY`/`GEMINI_API_KEY` for Gemini)
+always come from the provider's own environment variables — never through
+`start_session` — so choosing a provider/model per session exposes no secrets.
+
+When self-heal recovers a keyword, the call still succeeds, and the result carries
+the recovery so a client can learn *how* it was fixed:
+
+```json
+{
+  "result": null,
+  "healed": true,
+  "heal_summary": "AI self-heal recovered 'press_element' after 2 steps: scroll down; press_element Login",
+  "suggested_steps": [
+    { "keyword": "scroll", "params": ["down"] },
+    { "keyword": "press_element", "params": ["Login"] }
+  ]
+}
+```
+
+`suggested_steps` is the clean, replayable recovery sequence — only the steps that
+actually worked, curated to the minimal set that reproduces the goal. A platform can
+persist these to replace the failing step, so the next run passes without needing
+self-heal. `optics serve`'s `POST /v1/sessions/{session_id}/action` returns the same
+shape under `data`. Un-healed calls return the bare result, unchanged.
 
 ### Keyword parameters are strings
 

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -313,9 +313,7 @@ class ActionKeyword:
         self._ai_healer: Optional[AISelfHealHandler] = None
         # Breadcrumbs of recently-succeeded keywords, fed to the LLM as context on heal.
         self._recent_steps: "collections.deque[Tuple[str, list]]" = collections.deque(maxlen=10)
-        # The focused subset of keywords the self-healer is allowed to call, bound here
-        # (rather than looked up by name via getattr) so a rename shows up as a static
-        # attribute error instead of a silent "Unknown keyword" at runtime.
+        self._last_heal_info: Optional[Dict[str, Any]] = None
         self._heal_dispatch: Dict[str, Callable] = {
             "press_element": self.press_element,
             "enter_text": self.enter_text,
@@ -359,6 +357,7 @@ class ActionKeyword:
                 self._llm,
                 keyword_executor=self._heal_execute,
                 keyword_catalog=self._heal_catalog,
+                curate=True,
             )
         internal_logger.info("AI self-heal: attempting recovery for '%s' on '%s'", func_name, element)
         result = self._ai_healer.heal(ctx, providers.screenshot, providers.pagesource)
@@ -372,7 +371,13 @@ class ActionKeyword:
         return bool(getattr(self._llm, "instances", None))
 
     def _log_heal_outcome(self, result: Any, func_name: str, element: Any, args: tuple) -> None:
-        """Log the heal result; on success, record the step so the run stays /save-able."""
+        """Log the heal result and, on success, record it for reporting.
+
+        Exposes ``_last_heal_info`` with a human-readable ``summary`` and a structured
+        ``suggested_steps`` list that reporting layers (HTTP/MCP) can persist as
+        replacement steps. ``suggested_steps`` is the clean replayable recovery, falling
+        back to the terminal keyword when the goal was already met with no dispatched steps.
+        """
         if not result.ok:
             internal_logger.info(
                 "AI self-heal: could not recover '%s': %s", func_name, result.message
@@ -382,6 +387,36 @@ class ActionKeyword:
         kw = action.keyword if action else "?"
         internal_logger.info("AI self-heal: recovered '%s' via keyword '%s'", func_name, kw)
         self._record_successful_step(func_name, element, args)
+        steps = result.suggested_steps or ([(action.keyword, list(action.params))] if action and action.keyword else [])
+        rendered = [self._render_heal_step(name, params) for name, params in steps]
+        if rendered:
+            plural = "s" if len(rendered) != 1 else ""
+            summary = (
+                f"AI self-heal recovered '{func_name}' after {len(rendered)} "
+                f"step{plural}: {'; '.join(rendered)}"
+            )
+        else:
+            summary = f"AI self-heal recovered '{func_name}' (goal already satisfied)"
+        self._last_heal_info = {
+            "summary": summary,
+            "suggested_steps": [
+                {"keyword": name, "params": list(params)} for name, params in steps
+            ],
+        }
+
+    @staticmethod
+    def _render_heal_step(keyword: str, params: List[str]) -> str:
+        """Human-readable 'keyword param1 param2' line for the summary string."""
+        return keyword if not params else f"{keyword} {' '.join(str(p) for p in params)}"
+
+    def _pop_last_heal_info(self) -> Optional[Dict[str, Any]]:
+        """Return and clear the heal info for the most recently completed call.
+
+        The sole consumer, ``KeywordExecutor.execute``, must call this after every
+        keyword (healed or not) so one call's heal never leaks onto the next.
+        """
+        info, self._last_heal_info = self._last_heal_info, None
+        return info
 
     # -- Self-heal keyword executor and catalog --------------------------------
 

--- a/optics_framework/common/ai_self_heal.py
+++ b/optics_framework/common/ai_self_heal.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from optics_framework.common.error import OpticsError
 from optics_framework.common.llm_interface import LLMInterface
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.common.step_curation import curate_steps
 
 
 # Provider callables (best-effort; may return None when unavailable).
@@ -92,11 +93,30 @@ class HealAction:
 
 @dataclass
 class HealResult:
-    """Terminal outcome of :meth:`AISelfHealHandler.heal`."""
+    """Terminal outcome of :meth:`AISelfHealHandler.heal`.
+
+    ``steps_taken`` is every attempted keyword line, in order, for the
+    budget-exhausted diagnostic. ``suggested_steps`` is the clean replayable
+    recovery: only the steps that PASSED, curated on success.
+    """
 
     ok: bool
     action: Optional[HealAction] = None
     message: str = ""
+    steps_taken: List[str] = field(default_factory=list)
+    suggested_steps: List[Tuple[str, List[str]]] = field(default_factory=list)
+
+
+@dataclass
+class _DispatchOutcome:
+    """Outcome of dispatching one keyword during a heal.
+
+    ``ok`` is True when the keyword executed successfully; ``done`` is True when it
+    also completes the original keyword's goal.
+    """
+
+    ok: bool
+    done: bool
 
 
 # Structured-output schema. Mirrors the NL agent's schema pattern (flat, no anyOf).
@@ -189,11 +209,16 @@ class AISelfHealHandler:
         keyword_catalog: KeywordCatalog,
         *,
         max_steps: int = 5,
+        curate: bool = False,
     ) -> None:
+        """``curate`` is off by default (each curation is an extra LLM call);
+        ActionKeyword enables it to keep the surfaced suggested_steps minimal.
+        """
         self.llm = llm
         self.keyword_executor = keyword_executor
         self.keyword_catalog = keyword_catalog
         self.max_steps = max_steps
+        self.curate = curate
 
     def _execute_single_step(
         self,
@@ -203,8 +228,14 @@ class AISelfHealHandler:
         pagesource_provider: PagesourceProvider,
         catalog: List[HealKeywordSpec],
         attempted: List[str],
+        succeeded: List[Tuple[str, List[str]]],
     ) -> Optional[HealResult]:
-        """Execute a single iteration of self-healing and return terminal result or None to continue."""
+        """Execute one self-heal iteration; return a terminal HealResult or None to continue.
+
+        Each dispatched line is recorded in ``attempted`` for the diagnostic; only the
+        ones that passed are recorded in ``succeeded`` as the clean recovery. Returning
+        None means an intermediate or failed step changed the UI, so the loop re-observes.
+        """
         png = self._safe_call(screenshot_provider)
         if not png:
             return HealResult(False, message="No screenshot available for self-heal.")
@@ -235,17 +266,15 @@ class AISelfHealHandler:
 
         # action.action == "keyword"
         try:
-            done = self._dispatch(action)
+            outcome = self._dispatch(action)
         except Exception as exc:  # noqa: BLE001 - a keyword error ends the heal cleanly
             return HealResult(False, action=action, message=f"Keyword failed: {exc}")
 
-        if done:
-            return HealResult(True, action=action, message=action.reason or "Healed.")
-
-        # Intermediate step: record what was tried so a budget-exhausted message
-        # (the only case that reaches the caller without this action already
-        # attached) can still say what the model attempted.
         attempted.append(self._build_line(action.keyword, action.params))
+        if outcome.ok:
+            succeeded.append((action.keyword, list(action.params)))
+        if outcome.done:
+            return HealResult(True, action=action, message=action.reason or "Healed.")
         return None
 
     def heal(
@@ -257,17 +286,68 @@ class AISelfHealHandler:
         """Attempt to recover the failed keyword. Never raises — returns ok=False on any problem."""
         catalog = self.keyword_catalog()
         attempted: List[str] = []
+        succeeded: List[Tuple[str, List[str]]] = []
 
         for step in range(self.max_steps):
             result = self._execute_single_step(
-                step, ctx, screenshot_provider, pagesource_provider, catalog, attempted
+                step, ctx, screenshot_provider, pagesource_provider, catalog, attempted, succeeded
             )
             if result is not None:
+                result.steps_taken = list(attempted)
+                result.suggested_steps = self._finalize_suggested(ctx, result, succeeded)
                 return result
-            # Intermediate step: UI changed, loop to re-observe.
 
         tried = "; ".join(attempted) if attempted else "no actions attempted"
-        return HealResult(False, message=f"Self-heal step budget exhausted. Tried: {tried}")
+        return HealResult(
+            False,
+            message=f"Self-heal step budget exhausted. Tried: {tried}",
+            steps_taken=list(attempted),
+            suggested_steps=list(succeeded),
+        )
+
+    def _finalize_suggested(
+        self, ctx: HealContext, result: HealResult, succeeded: List[Tuple[str, List[str]]],
+    ) -> List[Tuple[str, List[str]]]:
+        """The clean recovery sequence to report: the passed steps, curated on success.
+
+        On a failed heal we return the raw passed steps (partial progress, no goal to
+        curate against). On success, when curation is enabled and there is more than one
+        step, prune to the minimal reproducing subset; a failed/degenerate curation keeps
+        all steps (``curate_steps`` returns ``None``), so a working recovery is never lost.
+        """
+        if not result.ok or not self.curate or len(succeeded) <= 1:
+            return list(succeeded)
+        prompt = self._build_curation_prompt(ctx, succeeded)
+        indices = curate_steps(self.llm, prompt, len(succeeded))
+        if indices is None:
+            return list(succeeded)
+        return [succeeded[i] for i in indices]
+
+    @staticmethod
+    def _build_curation_prompt(
+        ctx: HealContext, succeeded: List[Tuple[str, List[str]]],
+    ) -> str:
+        """Text-only curation prompt. Candidate steps are the passed heal steps, 1-based.
+
+        The goal is the original keyword the normal locators failed on; only the
+        successful steps are selectable, so no FAILED context section is needed here.
+        """
+        params = " ".join(str(p) for p in ctx.intent_params)
+        goal = f"{ctx.intent_keyword} {params}".rstrip()
+        lines = [
+            f"INSTRUCTION (goal that was achieved by self-heal): {goal}",
+            "",
+            "CANDIDATE STEPS (selectable — put these numbers in `keep`):",
+        ]
+        for idx, (kw, kw_params) in enumerate(succeeded, 1):
+            lines.append(f"  {idx}. {kw} {kw_params}")
+        lines.append("")
+        lines.append(
+            "Return `keep` = the 1-based CANDIDATE numbers to run, in any order, that reproduce "
+            "the goal. Drop dead-ends, backtracks, overshoot-then-correct, and no-op steps. When "
+            "unsure, KEEP."
+        )
+        return "\n".join(lines)
 
     # -- internals -------------------------------------------------------------
 
@@ -281,10 +361,14 @@ class AISelfHealHandler:
             internal_logger.debug("AI self-heal: provider unavailable: %s", exc)
             return None
 
-    def _dispatch(self, action: HealAction) -> bool:
-        """Execute one keyword via the injected executor. Returns True when the goal is complete."""
+    def _dispatch(self, action: HealAction) -> _DispatchOutcome:
+        """Execute one keyword via the injected executor.
+
+        Returns ``_DispatchOutcome(ok, done)``: ``ok`` is whether the keyword executed
+        successfully, ``done`` whether that success also completes the original goal.
+        """
         if not action.keyword:
-            return False
+            return _DispatchOutcome(ok=False, done=False)
 
         line = self._build_line(action.keyword, action.params)
         result = self.keyword_executor(line)
@@ -294,16 +378,16 @@ class AISelfHealHandler:
             # Don't abort the whole heal on a single keyword failure — the LLM can
             # try a different approach on the next step, so let the UI settle first.
             time.sleep(_SETTLE_SECONDS)
-            return False
+            return _DispatchOutcome(ok=False, done=False)
 
         # A completing keyword with completed=True means the goal is done — return
         # immediately without waiting, since there's no next screenshot to settle for.
         if action.keyword not in _NON_COMPLETING_KEYWORDS and action.completed:
-            return True
+            return _DispatchOutcome(ok=True, done=True)
 
         # Intermediate/navigation step: let the UI settle before the next screenshot.
         time.sleep(_SETTLE_SECONDS)
-        return False
+        return _DispatchOutcome(ok=True, done=False)
 
     @staticmethod
     def _validate(raw: Dict[str, Any]) -> HealAction:

--- a/optics_framework/common/execution.py
+++ b/optics_framework/common/execution.py
@@ -168,7 +168,17 @@ class KeywordExecutor(Executor):
         self.params = params
         self.event_manager = event_manager
 
-    async def execute(self, session: Session, runner: Runner) -> None:
+    async def execute(self, session: Session, runner: Runner) -> Any:
+        """Run one keyword and return its result.
+
+        The bound method's ActionKeyword may have recorded an AI self-heal (invisible
+        here — the call returns normally either way), so it is popped read-and-clear
+        after the call. On a heal the return is a dict {result, healed, heal_summary,
+        suggested_steps} instead of the bare result: the event ``extra`` carries only the
+        string summary, while the structured suggested_steps ride on the return value.
+        The ``"result"`` key mirrors ``expose_api.KEY_RESULT``, kept in sync by convention
+        since this lower layer shouldn't import the HTTP module.
+        """
         event_manager = self.event_manager
         method = runner.keyword_map.get("_".join(self.keyword.split()).lower())
         result = None
@@ -187,14 +197,27 @@ class KeywordExecutor(Executor):
                     extra={"session_id": session.session_id}
                 ))
                 raise OpticsError(Code.E0401, message=f"Keyword execution failed: {str(e)}") from e
+            heal_owner = getattr(method, "__self__", None)
+            heal_info = heal_owner._pop_last_heal_info() if hasattr(heal_owner, "_pop_last_heal_info") else None
+            extra = {"session_id": session.session_id}
+            if heal_info:
+                extra["healed"] = "true"
+                extra["heal_summary"] = heal_info["summary"]
             await event_manager.publish_event(Event(
                 entity_type="keyword",
                 entity_id=session.session_id,
                 name=self.keyword,
                 status=EventStatus.PASS,
                 message="Keyword executed successfully",
-                extra={"session_id": session.session_id}
+                extra=extra,
             ))
+            if heal_info:
+                return {
+                    "result": result,
+                    "healed": True,
+                    "heal_summary": heal_info["summary"],
+                    "suggested_steps": heal_info.get("suggested_steps", []),
+                }
             return result
         else:
             await event_manager.publish_event(Event(

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -157,6 +157,12 @@ class SessionResponse(BaseModel):
 class ExecutionResponse(BaseModel):
     """
     Response model for execution results.
+
+    ``data`` normally carries ``{"result": <value>}``. When AI self-heal recovered the
+    keyword, it instead carries ``{"result": <value>, "healed": true, "heal_summary":
+    <str>, "suggested_steps": [{"keyword": <str>, "params": [<str>, ...]}, ...]}``.
+    ``suggested_steps`` is the clean, replayable recovery sequence — the steps a caller
+    can persist to reproduce the recovery without relying on self-heal next time.
     """
 
     execution_id: str
@@ -248,11 +254,19 @@ class SessionConfig(BaseModel):
 
     Use `normalize_sources()` to convert entries into a consistent list of
     {name: DependencyConfig} mappings used by the server internals.
+
+    ``ai_self_heal`` / ``llm_provider`` / ``llm_model`` are optional per-session
+    self-heal overrides, kept as flat scalars (not a nested llm_models block) so no LLM
+    credentials ride the request body. See ``_resolve_self_heal_settings`` for their
+    per-field precedence over the service-level env-var defaults.
     """
     driver_sources: List[Union[str, Dict[str, Any]]] = []
     elements_sources: List[Union[str, Dict[str, Any]]] = []
     text_detection: List[Union[str, Dict[str, Any]]] = []
     image_detection: List[Union[str, Dict[str, Any]]] = []
+    ai_self_heal: Optional[bool] = None
+    llm_provider: Optional[str] = None
+    llm_model: Optional[str] = None
     project_path: Optional[str] = None
     appium_url: Optional[str] = None
     appium_config: Optional[Dict[str, Any]] = None
@@ -386,6 +400,51 @@ async def health_check():
     """
     return HealthCheckResponse(status=HEALTH_STATUS_RUNNING, version=VERSION)
 
+_TRUE_STRINGS = frozenset({"1", "true", "yes", "on"})
+ENV_AI_SELF_HEAL = "OPTICS_AI_SELF_HEAL"
+ENV_LLM_PROVIDER = "OPTICS_LLM_PROVIDER"
+ENV_LLM_MODEL = "OPTICS_LLM_MODEL"
+DEFAULT_LLM_PROVIDER = "gemini"
+
+
+def _env_self_heal_defaults() -> Tuple[bool, Optional[str], Optional[str]]:
+    """Service-level self-heal defaults read from the process environment.
+
+    The operator of a running `optics serve`/`optics mcp` process sets these once at
+    start-up so an already-integrated platform (its own session creation, driver
+    credentials, keyword calls) gets self-heal with no per-request changes. They are
+    only defaults, though — a session can override any of them (see
+    _resolve_self_heal_settings). Returns (enabled, provider, model) with unset
+    provider/model as None so the resolver can layer per-session values on top.
+    """
+    enabled = os.getenv(ENV_AI_SELF_HEAL, "").strip().lower() in _TRUE_STRINGS
+    provider = os.getenv(ENV_LLM_PROVIDER, "").strip() or None
+    model = os.getenv(ENV_LLM_MODEL, "").strip() or None
+    return enabled, provider, model
+
+
+def _resolve_self_heal_settings(config: SessionConfig) -> Tuple[bool, List[Dict[str, DependencyConfig]]]:
+    """Resolve a session's effective self-heal enablement and llm_models config.
+
+    Precedence, per field: explicit per-session request value > service-level env-var
+    default > built-in default. A single serve/mcp process is multi-tenant, so a
+    caller can enable/disable self-heal and choose its own LLM provider/model per
+    session rather than being locked to the operator's choice. LLM credentials never
+    flow through here — the provider reads its own environment variables (e.g.
+    GeminiLLM reads GOOGLE_API_KEY/GEMINI_API_KEY) — so exposing provider/model per
+    session adds no credential surface.
+    """
+    env_enabled, env_provider, env_model = _env_self_heal_defaults()
+    enabled = config.ai_self_heal if config.ai_self_heal is not None else env_enabled
+    if not enabled:
+        return False, []
+    provider = config.llm_provider or env_provider or DEFAULT_LLM_PROVIDER
+    model = config.llm_model or env_model
+    capabilities = {"model": model} if model else {}
+    llm_models = [{provider: DependencyConfig(enabled=True, capabilities=capabilities)}]
+    return True, llm_models
+
+
 @app.post(
     "/v1/sessions/start",
     response_model=SessionResponse,
@@ -425,12 +484,15 @@ async def create_session(config: SessionConfig):
         elements_sources = normalized.get(KEY_ELEMENTS_SOURCES, [])
         text_detection = normalized.get(KEY_TEXT_DETECTION, [])
         image_detection = normalized.get(KEY_IMAGE_DETECTION, [])
+        ai_self_heal, llm_models = _resolve_self_heal_settings(config)
 
         session_config = Config(
             driver_sources=driver_sources,
             elements_sources=elements_sources,
             text_detection=text_detection,
             image_detection=image_detection,
+            llm_models=llm_models,
+            ai_self_heal=ai_self_heal,
             project_path=config.project_path,
             log_level=LOG_LEVEL_DEBUG,
             save_captures=False  # do not save screenshots or pagesource when using `optics serve`

--- a/optics_framework/common/nl_agent.py
+++ b/optics_framework/common/nl_agent.py
@@ -17,6 +17,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from optics_framework.common.llm_interface import LLMInterface
 from optics_framework.common.error import OpticsError
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.common.step_curation import (  # noqa: F401 - re-exported for callers/tests
+    CURATION_SCHEMA,
+    CURATION_SYSTEM_PROMPT,
+    curate_steps,
+)
 
 
 @dataclass
@@ -215,43 +220,6 @@ coordinate guessing has already failed).
 """
 
 _MAX_THOUGHT_CHARS = 160
-
-
-# Flat (no anyOf) for the same Gemini-compatibility reasons as ACTION_SCHEMA.
-CURATION_SCHEMA: Dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "keep": {
-            "type": "array",
-            "items": {"type": "integer"},
-            "description": "1-based indices of the CANDIDATE steps to keep, in any order.",
-        },
-        "reason": {
-            "type": "string",
-            "description": "Brief justification for which steps were dropped.",
-        },
-    },
-    "required": ["keep", "reason"],
-    "propertyOrdering": ["keep", "reason"],
-}
-
-
-CURATION_SYSTEM_PROMPT = """\
-You are cleaning up a UI-automation recording. An instruction was just fulfilled by running a \
-sequence of keywords, one at a time. Some of those keywords were dead-ends, backtracks (e.g. \
-navigating somewhere then pressing back), overshoot-then-correct gestures, or no-op actions that \
-did not contribute to the final result.
-
-Your job: return the MINIMAL ordered subset of the CANDIDATE steps that a fresh run must execute, \
-top to bottom, to reproduce the goal deterministically. Drop steps that do not contribute.
-
-RULES:
-- `keep` is a list of the 1-based CANDIDATE step numbers to keep. Only CANDIDATE numbers are valid.
-- Never reference the FAILED context steps — they already failed and are excluded.
-- Order in `keep` does not matter; it will be re-sorted into execution order.
-- When in doubt, KEEP the step. Never drop a step that might be needed — a broken script is far \
-worse than a slightly long one. If every step contributed, keep them all.
-"""
 
 
 class NaturalLanguageAgent:
@@ -527,42 +495,10 @@ class NaturalLanguageAgent:
             return None  # nothing to prune
 
         prompt = self._build_curation_prompt(instruction, state)
-        try:
-            raw = self.llm.generate_json(
-                prompt, CURATION_SCHEMA, images=None,
-                system=CURATION_SYSTEM_PROMPT, temperature=0.0,
-            )
-        except OpticsError as exc:
-            internal_logger.debug("NL curation: LLM error, keeping all steps: %s", exc.message)
-            return None
-        except Exception as exc:  # noqa: BLE001 - curation must never break a working recording
-            internal_logger.debug("NL curation: unexpected error, keeping all steps: %s", exc)
-            return None
-
-        if not isinstance(raw, dict):
-            return None
-        keep_raw = raw.get("keep")
-        if not isinstance(keep_raw, list):
-            return None
-
-        # Coerce to 0-based indices: reject bools/non-ints, range-check, dedup, sort.
-        seen: set[int] = set()
-        indices: List[int] = []
-        for value in keep_raw:
-            if isinstance(value, bool) or not isinstance(value, int):
-                continue
-            zero = value - 1  # prompt uses 1-based candidate numbering
-            if 0 <= zero < n and zero not in seen:
-                seen.add(zero)
-                indices.append(zero)
-        if not indices or len(indices) == n:
-            return None  # dropped everything, or kept everything -> keep all
-        indices.sort()
-        curated = [state.successful[i] for i in indices]
-        internal_logger.debug(
-            "NL curation: kept %d of %d steps (%s)", len(curated), n, raw.get("reason", "")
-        )
-        return curated
+        indices = curate_steps(self.llm, prompt, n)
+        if indices is None:
+            return None  # keep all
+        return [state.successful[i] for i in indices]
 
     def _build_curation_prompt(self, instruction: str, state: "_RunState") -> str:
         """Text-only prompt for the curation pass.

--- a/optics_framework/common/step_curation.py
+++ b/optics_framework/common/step_curation.py
@@ -1,0 +1,116 @@
+"""Shared LLM-driven step curation for the NL agent and AI self-heal.
+
+Both :class:`~optics_framework.common.nl_agent.NaturalLanguageAgent` and
+:class:`~optics_framework.common.ai_self_heal.AISelfHealHandler` drive the UI one
+keyword at a time and finish with an ordered list of *successful* steps that may
+still contain dead-ends, backtracks, overshoot-then-correct gestures, or no-ops.
+This module asks the LLM for the minimal ordered subset that reproduces the goal.
+
+The two loops are documented as siblings that must be kept in sync (see CLAUDE.md);
+sharing the schema, system prompt, and index-coercion here keeps their curation
+identical. Each caller still builds its own user prompt, because the candidate/failed
+step context differs between them.
+
+``CURATION_SCHEMA`` is kept flat (no anyOf) because Gemini's response_schema support
+for anyOf/discriminated unions is unreliable.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from optics_framework.common.error import OpticsError
+from optics_framework.common.llm_interface import LLMInterface
+from optics_framework.common.logging_config import internal_logger
+
+
+CURATION_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keep": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "1-based indices of the CANDIDATE steps to keep, in any order.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Brief justification for which steps were dropped.",
+        },
+    },
+    "required": ["keep", "reason"],
+    "propertyOrdering": ["keep", "reason"],
+}
+
+
+CURATION_SYSTEM_PROMPT = """\
+You are cleaning up a UI-automation recording. An instruction was just fulfilled by running a \
+sequence of keywords, one at a time. Some of those keywords were dead-ends, backtracks (e.g. \
+navigating somewhere then pressing back), overshoot-then-correct gestures, or no-op actions that \
+did not contribute to the final result.
+
+Your job: return the MINIMAL ordered subset of the CANDIDATE steps that a fresh run must execute, \
+top to bottom, to reproduce the goal deterministically. Drop steps that do not contribute.
+
+RULES:
+- `keep` is a list of the 1-based CANDIDATE step numbers to keep. Only CANDIDATE numbers are valid.
+- Never reference the FAILED context steps — they already failed and are excluded.
+- Order in `keep` does not matter; it will be re-sorted into execution order.
+- When in doubt, KEEP the step. Never drop a step that might be needed — a broken script is far \
+worse than a slightly long one. If every step contributed, keep them all.
+"""
+
+
+def curate_steps(llm: LLMInterface, prompt: str, step_count: int) -> Optional[List[int]]:
+    """Ask the LLM which of ``step_count`` candidate steps to keep.
+
+    ``prompt`` is the caller-built user prompt; it must number the selectable candidate
+    steps 1..``step_count`` (see each caller's prompt builder). Returns the kept indices
+    as **0-based, deduplicated, sorted** integers, or ``None`` to mean "keep all".
+
+    Every abnormal outcome returns ``None`` so a working recording is never lost:
+    too few steps to prune, an LLM error, a malformed reply, no valid indices, or the
+    model keeping (or dropping) everything.
+    """
+    if step_count <= 1:
+        return None
+    try:
+        raw = llm.generate_json(
+            prompt, CURATION_SCHEMA, images=None,
+            system=CURATION_SYSTEM_PROMPT, temperature=0.0,
+        )
+    except OpticsError as exc:
+        internal_logger.debug("Step curation: LLM error, keeping all steps: %s", exc.message)
+        return None
+    except Exception as exc:  # noqa: BLE001 - curation must never break a working recording
+        internal_logger.debug("Step curation: unexpected error, keeping all steps: %s", exc)
+        return None
+    return _select_indices(raw, step_count)
+
+
+def _select_indices(raw: Any, step_count: int) -> Optional[List[int]]:
+    """Coerce the model's ``keep`` list to valid 0-based indices, or ``None`` for keep-all.
+
+    Rejects bools/non-ints, converts the prompt's 1-based numbering to 0-based,
+    range-checks, dedups and sorts. Returns ``None`` when the model dropped everything
+    or kept everything, both of which mean "keep all".
+    """
+    if not isinstance(raw, dict):
+        return None
+    keep_raw = raw.get("keep")
+    if not isinstance(keep_raw, list):
+        return None
+
+    seen: set[int] = set()
+    indices: List[int] = []
+    for value in keep_raw:
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        zero = value - 1
+        if 0 <= zero < step_count and zero not in seen:
+            seen.add(zero)
+            indices.append(zero)
+    if not indices or len(indices) == step_count:
+        return None
+    indices.sort()
+    internal_logger.debug(
+        "Step curation: kept %d of %d steps (%s)", len(indices), step_count, raw.get("reason", "")
+    )
+    return indices

--- a/optics_framework/helper/mcp_server.py
+++ b/optics_framework/helper/mcp_server.py
@@ -142,6 +142,9 @@ def _make_keyword_tool(slug: str, params: list[inspect.Parameter]) -> Callable[.
     """
 
     async def wrapper(**kwargs: Any) -> Any:
+        """Run the keyword. On an AI self-heal, return the whole {result, healed, ...}
+        dict so the client sees the recovery; otherwise unwrap to the bare result.
+        """
         session_id = kwargs.pop("session_id")
         request = expose_api.ExecuteRequest(
             mode=expose_api.MODE_KEYWORD,
@@ -155,6 +158,8 @@ def _make_keyword_tool(slug: str, params: list[inspect.Parameter]) -> Callable[.
         except OpticsError as exc:  # pragma: no cover - defensive
             raise ToolError(str(exc)) from exc
         data = getattr(response, "data", None) or {}
+        if "healed" in data:
+            return data
         return data.get(_RESULT_KEY, data)
 
     synth: list[inspect.Parameter] = [
@@ -246,6 +251,9 @@ def build_server() -> "FastMCP":
         text_detection: Optional[list[str]] = None,
         image_detection: Optional[list[str]] = None,
         project_path: Optional[str] = None,
+        ai_self_heal: Optional[bool] = None,
+        llm_provider: Optional[str] = None,
+        llm_model: Optional[str] = None,
     ) -> dict[str, Any]:
         """Start a new optics session and launch the target app.
 
@@ -253,6 +261,16 @@ def build_server() -> "FastMCP":
         keyword tool and state resource. The app is auto-launched on start.
         Sessions are NOT shared with `optics serve`/`optics live` (separate
         process); start one here before using any keyword tool.
+
+        ai_self_heal / llm_provider / llm_model: per-session overrides for AI self-heal.
+        Each falls back to the matching service-level env var the operator set at
+        start-up (OPTICS_AI_SELF_HEAL / OPTICS_LLM_PROVIDER / OPTICS_LLM_MODEL) when left
+        unset, so an already-configured server needs none of them. Because the process
+        is multi-tenant, pass them to opt in/out or pick your own model for just this
+        session instead of being locked to the operator's choice. Note that
+        ai_self_heal=True with no provider configured anywhere still degrades to inert
+        (no LLM to drive it); LLM credentials always come from the provider's own env
+        vars (e.g. GOOGLE_API_KEY), never this tool.
         """
         if url or capabilities:
             driver_sources: list[Any] = [
@@ -266,6 +284,9 @@ def build_server() -> "FastMCP":
             text_detection=text_detection or [],
             image_detection=image_detection or [],
             project_path=project_path,
+            ai_self_heal=ai_self_heal,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
         )
         try:
             response = await expose_api.create_session(config)

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -20,6 +20,7 @@ from optics_framework.common.ai_self_heal import (
     HEAL_ACTION_SCHEMA,
 )
 from optics_framework.common.error import OpticsError, Code
+from optics_framework.common.step_curation import CURATION_SCHEMA
 
 pytestmark = pytest.mark.white_box
 
@@ -227,6 +228,146 @@ class TestHandlerActions:
         res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=2).heal(_ctx(), _shots, _no_ps)
         assert res.ok is False
         assert executor.calls == ['swipe_by_percentage 50 80 up 30']
+
+
+class _FailByParamExecutor:
+    """Executor that fails when a substring appears in the keyword line."""
+
+    def __init__(self, fail_substring: str):
+        self.calls = []
+        self._fail_substring = fail_substring
+
+    def __call__(self, line: str) -> ExecResult:
+        self.calls.append(line)
+        if self._fail_substring in line:
+            return ExecResult(ok=False, message="not found")
+        return ExecResult(ok=True)
+
+
+class CuratingFakeLLM:
+    """FakeLLM that also serves the post-heal curation turn.
+
+    HEAL_ACTION_SCHEMA turns come from ``scripted``; the single CURATION_SCHEMA turn
+    returns ``curation_reply``. Curation is text-only, so ``images`` must be None.
+    """
+
+    def __init__(self, scripted, curation_reply):
+        self.scripted = list(scripted)
+        self.curation_reply = curation_reply
+        self.calls = 0
+        self.curation_calls = 0
+        self.last_curation_prompt = None
+
+    def generate(self, *a, **k):  # pragma: no cover - handler uses generate_json
+        raise RuntimeError("unexpected generate() call")
+
+    def generate_json(self, prompt, response_schema, images=None, system=None, temperature=None):
+        if response_schema is CURATION_SCHEMA:
+            self.curation_calls += 1
+            self.last_curation_prompt = prompt
+            assert images is None
+            return self.curation_reply
+        self.calls += 1
+        assert response_schema is HEAL_ACTION_SCHEMA
+        return self.scripted.pop(0)
+
+
+class TestSuggestedSteps:
+    def test_suggested_steps_are_the_passing_steps(self):
+        """A navigation step then a completing step: both passed -> both suggested."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press"},
+        ])
+        res = AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog(), max_steps=2).heal(
+            _ctx(), _shots, _no_ps
+        )
+        assert res.ok is True
+        assert res.suggested_steps == [("scroll", ["down"]), ("press_element", ["Login"])]
+
+    def test_failed_attempts_excluded_from_suggested_but_kept_in_steps_taken(self):
+        """A failed intermediate attempt pollutes steps_taken but not suggested_steps."""
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Wrong"],
+             "completed": True, "reason": "try"},
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press"},
+        ])
+        executor = _FailByParamExecutor("Wrong")
+        res = AISelfHealHandler(llm, executor, lambda: _catalog(), max_steps=3).heal(
+            _ctx(), _shots, _no_ps
+        )
+        assert res.ok is True
+        assert res.suggested_steps == [("scroll", ["down"]), ("press_element", ["Login"])]
+        # steps_taken keeps the noisy full history, including the failed attempt.
+        assert res.steps_taken == ["press_element Wrong", "scroll down", "press_element Login"]
+
+    def test_curation_off_by_default_makes_no_extra_llm_call(self):
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"],
+             "completed": False, "reason": "reveal"},
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press"},
+        ])
+        res = AISelfHealHandler(llm, FakeExecutor(), lambda: _catalog(), max_steps=2).heal(
+            _ctx(), _shots, _no_ps
+        )
+        assert res.ok is True
+        assert llm.calls == 2  # no curation round-trip
+        assert res.suggested_steps == [("scroll", ["down"]), ("press_element", ["Login"])]
+
+    def test_curation_prunes_suggested_steps(self):
+        """With curate=True, the curation pass drops the overshoot/backtrack steps."""
+        llm = CuratingFakeLLM(
+            [
+                {"action": "keyword", "keyword": "scroll", "params": ["down"],
+                 "completed": False, "reason": "overshoot"},
+                {"action": "keyword", "keyword": "scroll", "params": ["up"],
+                 "completed": False, "reason": "backtrack"},
+                {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+                 "completed": True, "reason": "press"},
+            ],
+            curation_reply={"keep": [3], "reason": "only the final press contributed"},
+        )
+        res = AISelfHealHandler(
+            llm, FakeExecutor(), lambda: _catalog(), max_steps=3, curate=True
+        ).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert llm.curation_calls == 1
+        assert res.suggested_steps == [("press_element", ["Login"])]
+        # The goal (the original failed keyword) is named in the curation prompt.
+        assert "press_element Login" in llm.last_curation_prompt
+
+    def test_curation_keeps_all_on_degenerate_reply(self):
+        """A curation reply that keeps everything leaves suggested_steps unpruned."""
+        llm = CuratingFakeLLM(
+            [
+                {"action": "keyword", "keyword": "scroll", "params": ["down"],
+                 "completed": False, "reason": "reveal"},
+                {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+                 "completed": True, "reason": "press"},
+            ],
+            curation_reply={"keep": [1, 2], "reason": "both needed"},
+        )
+        res = AISelfHealHandler(
+            llm, FakeExecutor(), lambda: _catalog(), max_steps=2, curate=True
+        ).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is True
+        assert res.suggested_steps == [("scroll", ["down"]), ("press_element", ["Login"])]
+
+    def test_budget_exhausted_reports_passed_steps_uncurated(self):
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "scroll", "params": ["down"], "reason": "x"}
+        ] * 2)
+        res = AISelfHealHandler(
+            llm, FakeExecutor(), lambda: _catalog(), max_steps=2, curate=True
+        ).heal(_ctx(), _shots, _no_ps)
+        assert res.ok is False
+        assert res.suggested_steps == [("scroll", ["down"]), ("scroll", ["down"])]
 
 
 class TestHandlerErrorHandling:
@@ -464,3 +605,31 @@ class TestHealExecute:
         assert "device offline" in result.message
         assert seen_enabled == [False]
         assert ak.ai_self_heal_enabled is True
+
+
+class TestSuggestedStepsWiring:
+    def test_pop_last_heal_info_exposes_structured_suggested_steps(self, monkeypatch):
+        monkeypatch.setattr(ash.time, "sleep", lambda *_a, **_k: None)
+        # Single completing step: curation short-circuits (<=1 step), so no extra LLM turn.
+        llm = FakeLLM([
+            {"action": "keyword", "keyword": "press_element", "params": ["Login"],
+             "completed": True, "reason": "press it"},
+        ])
+        llm.instances = [object()]
+        ak = _make_action_keyword(ai_self_heal=True, llm=llm)
+        shot = np.zeros((10, 10, 3), dtype=np.uint8)
+        ak.strategy_manager.capture_screenshot = MagicMock(return_value=shot)
+        ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
+        mock_result = MagicMock()
+        mock_result.is_coordinates = False
+        mock_result.value = MagicMock()
+        mock_result.strategy = MagicMock()
+        ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
+
+        assert ak._ai_self_heal("Login", "press_element", (), {}, shot) is True
+        info = ak._pop_last_heal_info()
+        assert info is not None
+        assert info["suggested_steps"] == [{"keyword": "press_element", "params": ["Login"]}]
+        assert "press_element Login" in info["summary"]
+        # Read-and-clear: a second pop returns nothing so a heal never leaks onto the next call.
+        assert ak._pop_last_heal_info() is None

--- a/tests/units/common/test_execution_self_heal.py
+++ b/tests/units/common/test_execution_self_heal.py
@@ -1,0 +1,68 @@
+"""Unit tests for KeywordExecutor surfacing AI self-heal recoveries.
+
+KeywordExecutor.execute is the ``optics serve`` / ``optics mcp`` keyword path. When the
+bound ActionKeyword method recorded a self-heal (via the ``_pop_last_heal_info`` side
+channel), the executor folds ``healed`` / ``heal_summary`` / ``suggested_steps`` into the
+returned dict so the synchronous HTTP/MCP payload carries them. An un-healed call returns
+the bare result unchanged.
+"""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from optics_framework.common.execution import KeywordExecutor
+
+pytestmark = pytest.mark.white_box
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _Session:
+    session_id = "sess-1"
+
+
+class _Runner:
+    def __init__(self, keyword_map):
+        self.keyword_map = keyword_map
+
+
+class _HealingKeyword:
+    """Stand-in ActionKeyword: press_element passes, with a heal recorded on the side."""
+
+    def __init__(self, heal_info):
+        self._heal_info = heal_info
+
+    def press_element(self, element):
+        return None
+
+    def _pop_last_heal_info(self):
+        info, self._heal_info = self._heal_info, None
+        return info
+
+
+def _execute(keyword_obj, keyword="press_element", params=("Login",)):
+    executor = KeywordExecutor(keyword, list(params), event_manager=AsyncMock())
+    runner = _Runner({keyword: getattr(keyword_obj, keyword)})
+    return _run(executor.execute(_Session(), runner))
+
+
+def test_healed_keyword_returns_suggested_steps():
+    heal_info = {
+        "summary": "AI self-heal recovered 'press_element' after 1 step: press_element Login",
+        "suggested_steps": [{"keyword": "press_element", "params": ["Login"]}],
+    }
+    result = _execute(_HealingKeyword(heal_info))
+    assert result == {
+        "result": None,
+        "healed": True,
+        "heal_summary": heal_info["summary"],
+        "suggested_steps": [{"keyword": "press_element", "params": ["Login"]}],
+    }
+
+
+def test_unhealed_keyword_returns_bare_result():
+    result = _execute(_HealingKeyword(None))
+    assert result is None

--- a/tests/units/common/test_expose_api_self_heal.py
+++ b/tests/units/common/test_expose_api_self_heal.py
@@ -1,0 +1,134 @@
+"""Tests for AI self-heal resolution in expose_api.
+
+Enablement and LLM provider/model are per-session settings that fall back to
+service-level env-var defaults. These cover the env-only defaults and the
+per-session-overrides-service-default precedence, per field.
+"""
+from optics_framework.common.config_handler import DependencyConfig
+from optics_framework.common.expose_api import (
+    ENV_AI_SELF_HEAL,
+    ENV_LLM_MODEL,
+    ENV_LLM_PROVIDER,
+    SessionConfig,
+    _env_self_heal_defaults,
+    _resolve_self_heal_settings,
+)
+
+
+def _clear_env(monkeypatch):
+    for name in (ENV_AI_SELF_HEAL, ENV_LLM_PROVIDER, ENV_LLM_MODEL):
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- Service-level env defaults ------------------------------------------------
+
+def test_disabled_by_default(monkeypatch):
+    _clear_env(monkeypatch)
+    assert _env_self_heal_defaults() == (False, None, None)
+
+
+def test_env_defaults_carry_provider_and_model(monkeypatch):
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    monkeypatch.setenv(ENV_LLM_PROVIDER, "custom_llm")
+    monkeypatch.setenv(ENV_LLM_MODEL, "custom-model-v1")
+    assert _env_self_heal_defaults() == (True, "custom_llm", "custom-model-v1")
+
+
+def test_truthy_variants_all_enable(monkeypatch):
+    _clear_env(monkeypatch)
+    for value in ("1", "TRUE", "Yes", "on"):
+        monkeypatch.setenv(ENV_AI_SELF_HEAL, value)
+        enabled, _, _ = _env_self_heal_defaults()
+        assert enabled is True, f"{value!r} should enable self-heal"
+
+
+def test_falsy_or_garbage_values_stay_disabled(monkeypatch):
+    _clear_env(monkeypatch)
+    for value in ("false", "0", "no", "", "nonsense"):
+        monkeypatch.setenv(ENV_AI_SELF_HEAL, value)
+        enabled, _, _ = _env_self_heal_defaults()
+        assert enabled is False
+
+
+# --- Resolution: env default with no per-session override ----------------------
+
+def test_env_enabled_defaults_to_gemini(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    enabled, llm_models = _resolve_self_heal_settings(SessionConfig())
+    assert enabled is True
+    assert llm_models == [{"gemini": DependencyConfig(enabled=True, capabilities={})}]
+
+
+def test_env_provider_and_model_flow_through(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    monkeypatch.setenv(ENV_LLM_PROVIDER, "custom_llm")
+    monkeypatch.setenv(ENV_LLM_MODEL, "custom-model-v1")
+    enabled, llm_models = _resolve_self_heal_settings(SessionConfig())
+    assert enabled is True
+    assert llm_models == [
+        {"custom_llm": DependencyConfig(enabled=True, capabilities={"model": "custom-model-v1"})}
+    ]
+
+
+def test_disabled_returns_no_llm_models(monkeypatch):
+    _clear_env(monkeypatch)
+    assert _resolve_self_heal_settings(SessionConfig()) == (False, [])
+
+
+# --- Resolution: per-session overrides -----------------------------------------
+
+def test_explicit_request_false_overrides_enabled_service_default(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    assert _resolve_self_heal_settings(SessionConfig(ai_self_heal=False)) == (False, [])
+
+
+def test_explicit_request_true_overrides_disabled_service_default(monkeypatch):
+    _clear_env(monkeypatch)
+    enabled, llm_models = _resolve_self_heal_settings(SessionConfig(ai_self_heal=True))
+    assert enabled is True
+    assert llm_models == [{"gemini": DependencyConfig(enabled=True, capabilities={})}]
+
+
+def test_unset_request_field_inherits_service_default(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    assert _resolve_self_heal_settings(SessionConfig())[0] is True
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "false")
+    assert _resolve_self_heal_settings(SessionConfig())[0] is False
+
+
+def test_session_provider_and_model_override_env(monkeypatch):
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    monkeypatch.setenv(ENV_LLM_PROVIDER, "env_provider")
+    monkeypatch.setenv(ENV_LLM_MODEL, "env-model")
+    config = SessionConfig(llm_provider="session_provider", llm_model="session-model")
+    enabled, llm_models = _resolve_self_heal_settings(config)
+    assert enabled is True
+    assert llm_models == [
+        {"session_provider": DependencyConfig(enabled=True, capabilities={"model": "session-model"})}
+    ]
+
+
+def test_session_provider_falls_back_to_env_model(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(ENV_AI_SELF_HEAL, "true")
+    monkeypatch.setenv(ENV_LLM_MODEL, "env-model")
+    config = SessionConfig(llm_provider="session_provider")
+    _, llm_models = _resolve_self_heal_settings(config)
+    assert llm_models == [
+        {"session_provider": DependencyConfig(enabled=True, capabilities={"model": "env-model"})}
+    ]
+
+
+def test_session_can_enable_and_pick_provider_with_no_env(monkeypatch):
+    """A caller opts in entirely on its own — nothing set by the operator."""
+    _clear_env(monkeypatch)
+    config = SessionConfig(ai_self_heal=True, llm_provider="session_provider", llm_model="m1")
+    enabled, llm_models = _resolve_self_heal_settings(config)
+    assert enabled is True
+    assert llm_models == [
+        {"session_provider": DependencyConfig(enabled=True, capabilities={"model": "m1"})}
+    ]

--- a/tests/units/common/test_step_curation.py
+++ b/tests/units/common/test_step_curation.py
@@ -1,0 +1,79 @@
+"""Unit tests for the shared LLM step-curation helper.
+
+``curate_steps`` is reused by the NL agent and AI self-heal; it must never lose a working
+recording, so every abnormal outcome (too few steps, LLM error, malformed reply, all/none
+kept) returns None ("keep all").
+"""
+import pytest
+
+from optics_framework.common.error import OpticsError, Code
+from optics_framework.common.step_curation import (
+    CURATION_SCHEMA,
+    curate_steps,
+)
+
+pytestmark = pytest.mark.white_box
+
+
+class _LLM:
+    def __init__(self, reply):
+        self._reply = reply
+        self.calls = 0
+
+    def generate_json(self, prompt, response_schema, images=None, system=None, temperature=None):
+        self.calls += 1
+        assert response_schema is CURATION_SCHEMA
+        assert images is None
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return self._reply
+
+
+def test_no_anyof_in_schema():
+    import json
+    assert "anyOf" not in json.dumps(CURATION_SCHEMA)
+
+
+def test_single_step_skips_llm():
+    llm = _LLM({"keep": [1], "reason": "r"})
+    assert curate_steps(llm, "p", 1) is None
+    assert llm.calls == 0
+
+
+def test_prunes_to_kept_indices_zero_based_sorted():
+    llm = _LLM({"keep": [3, 1], "reason": "drop 2"})
+    assert curate_steps(llm, "p", 3) == [0, 2]
+
+
+def test_dedups_and_range_checks():
+    llm = _LLM({"keep": [3, 1, 1, 99, 0], "reason": "dup/out-of-range"})
+    # 0 and 99 are out of the 1..3 range; 1 is deduped -> {1,3} -> 0-based [0, 2].
+    assert curate_steps(llm, "p", 3) == [0, 2]
+
+
+def test_keep_all_returns_none():
+    llm = _LLM({"keep": [1, 2, 3], "reason": "all needed"})
+    assert curate_steps(llm, "p", 3) is None
+
+
+def test_drop_all_returns_none():
+    llm = _LLM({"keep": [], "reason": "none"})
+    assert curate_steps(llm, "p", 3) is None
+
+
+@pytest.mark.parametrize("reply", [
+    "not a dict",
+    {"reason": "no keep key"},
+    {"keep": "not a list", "reason": "r"},
+    {"keep": [True, False], "reason": "bools are not indices"},
+])
+def test_malformed_replies_keep_all(reply):
+    assert curate_steps(_LLM(reply), "p", 3) is None
+
+
+def test_llm_error_keeps_all():
+    assert curate_steps(_LLM(OpticsError(Code.E0801, message="boom")), "p", 3) is None
+
+
+def test_unexpected_error_keeps_all():
+    assert curate_steps(_LLM(RuntimeError("kaboom")), "p", 3) is None


### PR DESCRIPTION
Closes #375.
Depends on #303 

## Design

Self-heal is now a **service-level** setting for a running `optics serve`/`optics mcp` process, configured once via environment variables when it starts — not a per-request field requiring the platform to change any of its existing integration code:

- `OPTICS_AI_SELF_HEAL` — enables it (`true`/`1`/`yes`/`on`, case-insensitive)
- `OPTICS_LLM_PROVIDER` — which `llm_models` entry to use (default `gemini`, the only implemented provider today)
- `OPTICS_LLM_MODEL` — optional model override

The operator running the service for a platform sets these once; every session that platform creates inherits self-heal automatically. `SessionConfig.ai_self_heal: Optional[bool] = None` remains as a per-session override (explicit request value always wins over the service default) — there's no `llm_models` field on the request body at all, since provider/model selection is a deployment decision, not a per-request one. LLM credentials continue to come entirely from the provider's own environment variables (e.g. `GeminiLLM` already reads `GOOGLE_API_KEY`/`GEMINI_API_KEY` itself) and never flow through this config.

This removes the CodeQL-flagged code rather than patching it — there's no longer any server-side file read driven by request data.

## Changes

- `optics_framework/common/ai_self_heal.py` / `optics_framework/api/action_keyword.py` — `HealResult.steps_taken` + `ActionKeyword._pop_last_heal_info()`, unchanged from #376 (pure reporting plumbing, independent of enablement).
- `optics_framework/common/execution.py` — `KeywordExecutor.execute` surfaces a heal via the Event and the returned result, unchanged from #376.
- `optics_framework/common/expose_api.py` — `_service_self_heal_settings()` replaces the old project_path-based resolution entirely.
- `optics_framework/helper/mcp_server.py` — `start_session`'s `ai_self_heal` param and the `_make_keyword_tool` result-unwrap fix are unchanged; only the docstring now describes the env vars.
- `docs/usage/mcp_usage.md` — documents the three env vars and the per-session override.
- `tests/units/common/test_expose_api_self_heal.py` — new: env-var resolution (default off, truthy/falsy variants, custom provider/model) and explicit-override-wins-over-service-default semantics.