### PR TITLE
fix: decide module conditions by result truthiness, not exception-presence

### DIFF
--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -333,37 +333,38 @@ class FlowControl:
         return self.modules.get_module_definition(actual_cond) is not None
 
     def _handle_module_condition(self, cond_str: str, target: str) -> Optional[List[Any]]:
-        """Handles evaluation and execution for module-based conditions."""
-        # Strip "!" prefix if present and determine if we need to invert the result
+        """Handles evaluation and execution for module-based conditions.
+
+        A module condition is true iff the condition module executes without
+        raising *and* returns a non-empty (truthy) result — mirroring the
+        expression path in ``_is_condition_true``. A module that returns an
+        empty result is false, so the target is skipped and the caller falls
+        through to the ``else`` branch. The optional ``!`` prefix inverts.
+        """
+        # Strip "!" prefix if present and determine if we need to invert the result.
         invert = cond_str.startswith("!")
         actual_cond = cond_str[1:].strip() if invert else cond_str
 
         try:
-            self.execute_module(actual_cond)
-            # Module executed successfully
-            if invert:
-                # If inverted, success means we should NOT execute target
-                execution_logger.debug(f"[_EVALUATE_CONDITIONS] Module '{actual_cond}' succeeded, but condition is inverted. Skipping target '{target}'.")
-                return None
-            # If not inverted, success means we should execute target
-            try:
-                return self.execute_module(target)
-            except Exception as e:
-                execution_logger.warning(f"[_EVALUATE_CONDITIONS] Target module '{target}' raised error: {e}.")
-                raise OpticsError(Code.E0401, message=f"Error executing target module '{target}': {e}", cause=e)
+            result = self.execute_module(actual_cond)
+            condition_true = bool(result)
         except Exception as e:
-            # Module execution failed
-            internal_logger.warning(f"[_EVALUATE_CONDITIONS] Module '{actual_cond}' raised error: {e}.")
-            if invert:
-                # If inverted, failure means we SHOULD execute target
-                internal_logger.debug(f"[_EVALUATE_CONDITIONS] Module '{actual_cond}' failed, but condition is inverted. Executing target '{target}'.")
-                try:
-                    return self.execute_module(target)
-                except Exception as target_e:
-                    internal_logger.warning(f"[_EVALUATE_CONDITIONS] Target module '{target}' raised error: {target_e}.")
-                    raise OpticsError(Code.E0401, message=f"Error executing target module '{target}': {target_e}", cause=target_e)
-            # If not inverted, failure means we should NOT execute target
+            # A raising condition module is treated as false (as in _is_condition_true).
+            internal_logger.warning(f"[_EVALUATE_CONDITIONS] Module '{actual_cond}' raised error: {e}. Treating condition as false.")
+            condition_true = False
+
+        if invert:
+            condition_true = not condition_true
+
+        if not condition_true:
+            execution_logger.debug(f"[_EVALUATE_CONDITIONS] Module condition '{cond_str}' is false. Skipping target '{target}'.")
             return None
+
+        try:
+            return self.execute_module(target)
+        except Exception as e:
+            execution_logger.warning(f"[_EVALUATE_CONDITIONS] Target module '{target}' raised error: {e}.")
+            raise OpticsError(Code.E0401, message=f"Error executing target module '{target}': {e}", cause=e)
 
     def _handle_expression_condition(self, cond_str: str, target: str) -> Optional[List[Any]]:
         """Handles evaluation and execution for expression-based conditions."""

--- a/tests/units/api/test_flow_control_all.py
+++ b/tests/units/api/test_flow_control_all.py
@@ -1,12 +1,9 @@
 """Tests for FlowControl keywords: evaluate, read_data, invoke_api, condition,
 run_loop, and date_evaluate.
 
-The condition suite is written against the *documented* module-condition contract
-(a module condition is true iff the module runs and returns a non-empty result).
-The current implementation decides truth by whether the module *raised* instead —
-tracked as a deferred behaviour fix — so the cases that expose it are marked
-``xfail(strict=True)``: they fail today and will flip to XPASS (failing the run,
-prompting removal of the marker) once the fix lands.
+The condition suite is written against the module-condition contract: a module
+condition is true iff the module runs and returns a non-empty (truthy) result
+(mozarkai/optics-framework#385).
 """
 import json
 from unittest.mock import MagicMock
@@ -23,12 +20,6 @@ from optics_framework.common.models import (
     ExpectedResultDefinition,
     RequestDefinition,
 )
-
-_MODULE_CONDITION_BUG = (
-    "Module-condition truth is decided by exception-presence, not bool(result) "
-    "(mozarkai/optics-framework#385). Remove this marker when the fix lands."
-)
-
 
 class _Modules:
     """Minimal stand-in for the session's module registry."""
@@ -265,14 +256,12 @@ class TestModuleCondition:
         assert flow_control.condition("cond", "target", "els") == ["E"]
         assert "target" not in run.calls
 
-    @pytest.mark.xfail(reason=_MODULE_CONDITION_BUG, strict=True)
     def test_falsy_module_skips_target_runs_else(self, flow_control):
         run = _module_runner({"cond": [], "target": ["T"], "els": ["E"]})
         _register(flow_control, run, "cond", "target", "els")
         assert flow_control.condition("cond", "target", "els") == ["E"]
         assert "target" not in run.calls
 
-    @pytest.mark.xfail(reason=_MODULE_CONDITION_BUG, strict=True)
     def test_falsy_module_no_else_returns_none(self, flow_control):
         run = _module_runner({"cond": [], "target": ["T"]})
         _register(flow_control, run, "cond", "target")


### PR DESCRIPTION
Closes #385.

## The bug

`FlowControl._handle_module_condition` decided whether a **module-name condition** was true by whether `execute_module()` *raised*, not by the truthiness of its result. A module that ran successfully but returned an empty result (e.g. `[]`) was treated as **true**, and its target ran anyway.

This contradicts both:
- the `_evaluate_conditions` docstring ("returns the result of executing the module if non-empty"), and
- the sibling expression path `_is_condition_true`, which already uses `bool(result)`.

## The fix

Compute the condition as `bool(result)` (a raising module is false, as in `_is_condition_true`), apply the optional `!` inversion, and run the target only when the condition is true — otherwise return `None` so the caller falls through to the `else` branch. This also collapses the duplicated target-execution / `E0401`-wrapping into one path.

## Tests

`test_flow_control_all.py::TestModuleCondition` already pinned the intended behaviour as `xfail(strict)`; those two tests (`test_falsy_module_skips_target_runs_else`, `test_falsy_module_no_else_returns_none`) now pass and the markers are removed.

## ⚠️ Behaviour change

A suite relying on "an empty-result module condition still runs its target" will now take the `else` branch instead. Worth a changelog note on release.

---
Stacked on #388 (the test overhaul, which adds the tests this flips). Merge after #388.