### PR TITLE
fix(init,config,completion): valid scaffold, stop dep-list corruption, refresh completions

### DIFF
--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -6,7 +6,7 @@ _optics_completions() {
 
   local subcommands="list config dry_run init execute live generate setup serve mcp completion"
 
-  local template_options="contact clock calendar youtube gmail_web playwright"
+  local template_options="calendar clock contact gmail_web playwright youtube"
   local runner_options="test_runner pytest"
   # Only the two-space-indented lines are engine keys; category headers are not
   # indented, so this needs no per-header filter.

--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -1,27 +1,37 @@
 #!/bin/bash
 
 _optics_completions() {
-  local cur prev
+  local cur prev words cword
   _init_completion || return
 
-  local subcommands="list config dry_run init execute version generate setup serve completion"
+  local subcommands="list config dry_run init execute live generate setup serve mcp completion"
 
-  local template_options="calender contact gmail_web youtube"
+  local template_options="contact clock calendar youtube gmail_web playwright"
   local runner_options="test_runner pytest"
-  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Drivers:|Text)$')
+  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')
 
   case ${COMP_CWORD} in
     1)
       COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
       return 0
       ;;
-    *)
-      ;;
   esac
 
   case ${COMP_WORDS[1]} in
-    list|config|version|completion)
+    list|config|completion)
       COMPREPLY=( $(compgen -W "--help -h" -- "$cur") )
+      ;;
+
+    live)
+      COMPREPLY=( $(compgen -d -- "$cur") )
+      ;;
+
+    mcp)
+      if [[ $prev == "--transport" ]]; then
+        COMPREPLY=( $(compgen -W "stdio http" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -W "--transport --host --port -h --help" -- "$cur") )
+      fi
       ;;
 
     dry_run|execute)
@@ -45,13 +55,13 @@ _optics_completions() {
 
     generate)
       COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-      if [[ $prev == "--framework" ]]; then
-        COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
-      elif [[ $prev == "--output" ]]; then
-        COMPREPLY=( $(compgen -f -- "$cur") )
-      elif [[ $prev == "--project_path" ]]; then
-        COMPREPLY=( $(compgen -d -- "$cur") )
-      fi
+        if [[ $prev == "--framework" ]]; then
+            COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
+        elif [[ $prev == "--output" ]]; then
+            COMPREPLY=( $(compgen -f -- "$cur") )
+        elif [[ $prev == "--project_path" ]]; then
+            COMPREPLY=( $(compgen -d -- "$cur") )
+        fi
       ;;
 
     setup)
@@ -67,10 +77,6 @@ _optics_completions() {
 
     serve)
       COMPREPLY=( $(compgen -W "--host --port -h --help" -- "$cur") )
-      ;;
-
-    *)
-      COMPREPLY=()
       ;;
   esac
 }

--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -15,6 +15,9 @@ _optics_completions() {
       COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
       return 0
       ;;
+    *)
+      # Beyond the subcommand: handled per-subcommand below.
+      ;;
   esac
 
   case ${COMP_WORDS[1]} in
@@ -61,6 +64,8 @@ _optics_completions() {
             COMPREPLY=( $(compgen -f -- "$cur") )
         elif [[ $prev == "--project_path" ]]; then
             COMPREPLY=( $(compgen -d -- "$cur") )
+        else
+            : # keep the default --help completion set above
         fi
       ;;
 
@@ -77,6 +82,11 @@ _optics_completions() {
 
     serve)
       COMPREPLY=( $(compgen -W "--host --port -h --help" -- "$cur") )
+      ;;
+
+    *)
+      # Unknown subcommand: offer only --help.
+      COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
       ;;
   esac
 }

--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -8,7 +8,9 @@ _optics_completions() {
 
   local template_options="contact clock calendar youtube gmail_web playwright"
   local runner_options="test_runner pytest"
-  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')
+  # Only the two-space-indented lines are engine keys; category headers are not
+  # indented, so this needs no per-header filter.
+  local engine_options=$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')
 
   case ${COMP_CWORD} in
     1)
@@ -72,7 +74,7 @@ _optics_completions() {
     setup)
       case $prev in
         --install)
-          COMPREPLY=( $(compgen -W "$driver_options" -- "$cur") )
+          COMPREPLY=( $(compgen -W "$engine_options" -- "$cur") )
           ;;
         *)
           COMPREPLY=( $(compgen -W "--install --list -h --help" -- "$cur") )

--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -60,15 +60,15 @@ _optics_completions() {
 
     generate)
       COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-        if [[ $prev == "--framework" ]]; then
-            COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
-        elif [[ $prev == "--output" ]]; then
-            COMPREPLY=( $(compgen -f -- "$cur") )
-        elif [[ $prev == "--project_path" ]]; then
-            COMPREPLY=( $(compgen -d -- "$cur") )
-        else
-            : # keep the default --help completion set above
-        fi
+      if [[ $prev == "--framework" ]]; then
+        COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
+      elif [[ $prev == "--output" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+      elif [[ $prev == "--project_path" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+      else
+        : # keep the default --help completion set above
+      fi
       ;;
 
     setup)

--- a/autocompletion/optics_completion.sh
+++ b/autocompletion/optics_completion.sh
@@ -14,7 +14,7 @@ _optics_completions() {
 
   case ${COMP_CWORD} in
     1)
-      COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+      COMPREPLY=( $(compgen -W "$subcommands --version --help -h" -- "$cur") )
       return 0
       ;;
     *)

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -62,7 +62,16 @@ _optics_completions() {
                 serve)
                     _arguments                         '--host=[Host address]'                         '--port=[Port number]'                         '--help[-h]'
                     ;;
+
+                *)
+                    # Unknown subcommand: offer only --help.
+                    _arguments '--help[-h]'
+                    ;;
             esac
+            ;;
+
+        *)
+            # Unexpected state: nothing to complete.
             ;;
     esac
 }

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -14,7 +14,7 @@ local -a _optics_subcommands=(
 )
 
 # Static or dynamic values
-local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwright")
+local -a templates=("calendar" "clock" "contact" "gmail_web" "playwright" "youtube")
 local -a runners=("test_runner" "pytest")
 local -a frameworks=("pytest" "robot")
 local -a transports=("stdio" "http")

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -18,7 +18,10 @@ local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwrig
 local -a runners=("test_runner" "pytest")
 local -a frameworks=("pytest" "robot")
 local -a transports=("stdio" "http")
-local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')}")
+# `optics setup --list` indents each installable engine key by two spaces under a
+# category header; take only those indented lines so this stays correct no matter
+# what the category headers are named.
+local -a engines=("${(f)$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')}")
 
 _optics_completions() {
     local state
@@ -56,7 +59,7 @@ _optics_completions() {
                     ;;
 
                 setup)
-                    _arguments                         "--install=[Drivers]:drivers:(${drivers[@]})"                         '--list[List all drivers]'                         '--help[-h]'
+                    _arguments                         "--install=[Engines]:engines:(${engines[@]})"                         '--list[List all engines]'                         '--help[-h]'
                     ;;
 
                 serve)

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -1,82 +1,70 @@
 # Description: Zsh completion script for the Optics CLI tool
 local -a _optics_subcommands=(
-  'list: List available API methods'
-  'config: Manage configuration'
-  'dry_run: Run tests in dry-run mode'
-  'init: Initialize a new project'
-  'execute: Execute tests'
-  'version: Show version'
-  'generate: Generate framework code'
-  'setup: Install drivers'
-  'serve: Start a server'
-  'completion: Enable shell completion'
+    'list: List available API methods'
+    'config: Manage configuration'
+    'dry_run: Run tests in dry-run mode'
+    'init: Initialize a new project'
+    'execute: Execute tests'
+    'live: Interactive session against a live target'
+    'generate: Generate framework code'
+    'setup: Install optional engine backends'
+    'serve: Start the optics REST server'
+    'mcp: Start the MCP server'
+    'completion: Enable shell completion'
 )
 
 # Static or dynamic values
-local -a templates=("calender" "contact" "gmail_web" "youtube")
+local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwright")
 local -a runners=("test_runner" "pytest")
-local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Drivers:|Text)$')}")
 local -a frameworks=("pytest" "robot")
+local -a transports=("stdio" "http")
+local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')}")
 
 _optics_completions() {
-  local state
+    local state
 
-  _arguments -C \
-    '1:command:->cmds' \
-    '*::arg:->args'
+    _arguments -C         '1:command:->cmds'         '*::arg:->args'
 
-  case $state in
-    cmds)
-      _describe 'command' _optics_subcommands
-      ;;
-    args)
-      case $words[2] in
-        list|config|version|completion)
-          _arguments '--help[-h]'
-          ;;
+    case $state in
+        cmds)
+            _describe 'command' _optics_subcommands
+            ;;
+        args)
+            case $words[2] in
+                list|config|completion)
+                    _arguments '--help[-h]'
+                    ;;
 
-        dry_run|execute)
-          _arguments \
-            '--runner=[Runner]:runner:(${runners[@]})' \
-            '--use-printer[Enable printer]' \
-            '--no-use-printer[Disable printer]' \
-            '--help[-h]'
-          ;;
+                live)
+                    _arguments                         '*:project_path:_files -/'                         '--help[-h]'
+                    ;;
 
-        init)
-          _arguments \
-            '--name=[Project name]' \
-            '--path=[Project path]' \
-            '--force[Override existing]' \
-            "--template=[Template name]:template:(${templates[@]})" \
-            '--git-init[Initialize Git]' \
-            '--help[-h]'
-          ;;
+                mcp)
+                    _arguments                         '--transport=[Transport]:transport:(${transports[@]})'                         '--host=[Host address]'                         '--port=[Port number]'                         '--help[-h]'
+                    ;;
 
-        generate)
-          _arguments \
-            '*:project_path:_files' \
-            '*:output_file:_files' \
-            '--framework=[Framework]:framework:(${frameworks[@]})' \
-            '--help[-h]'
-          ;;
+                dry_run|execute)
+                    _arguments                         '--runner=[Runner]:runner:(${runners[@]})'                         '--use-printer[Enable printer]'                         '--no-use-printer[Disable printer]'                         '--help[-h]'
+                    ;;
 
-        setup)
-          _arguments \
-            "--install=[Drivers]:drivers:(${drivers[@]})" \
-            '--list[List all drivers]' \
-            '--help[-h]'
-          ;;
+                init)
+                    _arguments                         '--name=[Project name]'                         '--path=[Project path]'                         '--force[Override existing]'                         "--template=[Template name]:template:(${templates[@]})"                         '--git-init[Initialize Git]'                         '--help[-h]'
+                    ;;
 
-        serve)
-          _arguments \
-            '--host=[Host address]' \
-            '--port=[Port number]' \
-            '--help[-h]'
-          ;;
-      esac
-      ;;
-  esac
+                generate)
+                    _arguments                         '*:project_path:_files'                         '*:output:_files'                         '--framework=[Framework]:framework:(${frameworks[@]})'                         '--help[-h]'
+                    ;;
+
+                setup)
+                    _arguments                         "--install=[Drivers]:drivers:(${drivers[@]})"                         '--list[List all drivers]'                         '--help[-h]'
+                    ;;
+
+                serve)
+                    _arguments                         '--host=[Host address]'                         '--port=[Port number]'                         '--help[-h]'
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 compdef _optics_completions optics

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -1,16 +1,16 @@
 # Description: Zsh completion script for the Optics CLI tool
 local -a _optics_subcommands=(
-    'list: List available API methods'
-    'config: Manage configuration'
-    'dry_run: Run tests in dry-run mode'
-    'init: Initialize a new project'
-    'execute: Execute tests'
-    'live: Interactive session against a live target'
-    'generate: Generate framework code'
-    'setup: Install optional engine backends'
-    'serve: Start the optics REST server'
-    'mcp: Start the MCP server'
-    'completion: Enable shell completion'
+  'list: List available API methods'
+  'config: Manage configuration'
+  'dry_run: Run tests in dry-run mode'
+  'init: Initialize a new project'
+  'execute: Execute tests'
+  'live: Interactive session against a live target'
+  'generate: Generate framework code'
+  'setup: Install optional engine backends'
+  'serve: Start the optics REST server'
+  'mcp: Start the MCP server'
+  'completion: Enable shell completion'
 )
 
 # Static or dynamic values
@@ -24,59 +24,87 @@ local -a transports=("stdio" "http")
 local -a engines=("${(f)$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')}")
 
 _optics_completions() {
-    local state
+  local state
 
-    _arguments -C         '1:command:->cmds'         '*::arg:->args'
+  _arguments -C \
+    '1:command:->cmds' \
+    '*::arg:->args'
 
-    case $state in
-        cmds)
-            _describe 'command' _optics_subcommands
-            ;;
-        args)
-            case $words[2] in
-                list|config|completion)
-                    _arguments '--help[-h]'
-                    ;;
+  case $state in
+    cmds)
+      _describe 'command' _optics_subcommands
+      ;;
+    args)
+      case $words[2] in
+        list|config|completion)
+          _arguments '--help[-h]'
+          ;;
 
-                live)
-                    _arguments                         '*:project_path:_files -/'                         '--help[-h]'
-                    ;;
+        live)
+          _arguments \
+            '*:project_path:_files -/' \
+            '--help[-h]'
+          ;;
 
-                mcp)
-                    _arguments                         '--transport=[Transport]:transport:(${transports[@]})'                         '--host=[Host address]'                         '--port=[Port number]'                         '--help[-h]'
-                    ;;
+        mcp)
+          _arguments \
+            '--transport=[Transport]:transport:(${transports[@]})' \
+            '--host=[Host address]' \
+            '--port=[Port number]' \
+            '--help[-h]'
+          ;;
 
-                dry_run|execute)
-                    _arguments                         '--runner=[Runner]:runner:(${runners[@]})'                         '--use-printer[Enable printer]'                         '--no-use-printer[Disable printer]'                         '--help[-h]'
-                    ;;
+        dry_run|execute)
+          _arguments \
+            '--runner=[Runner]:runner:(${runners[@]})' \
+            '--use-printer[Enable printer]' \
+            '--no-use-printer[Disable printer]' \
+            '--help[-h]'
+          ;;
 
-                init)
-                    _arguments                         '--name=[Project name]'                         '--path=[Project path]'                         '--force[Override existing]'                         "--template=[Template name]:template:(${templates[@]})"                         '--git-init[Initialize Git]'                         '--help[-h]'
-                    ;;
+        init)
+          _arguments \
+            '--name=[Project name]' \
+            '--path=[Project path]' \
+            '--force[Override existing]' \
+            "--template=[Template name]:template:(${templates[@]})" \
+            '--git-init[Initialize Git]' \
+            '--help[-h]'
+          ;;
 
-                generate)
-                    _arguments                         '*:project_path:_files'                         '*:output:_files'                         '--framework=[Framework]:framework:(${frameworks[@]})'                         '--help[-h]'
-                    ;;
+        generate)
+          _arguments \
+            '*:project_path:_files' \
+            '*:output_file:_files' \
+            '--framework=[Framework]:framework:(${frameworks[@]})' \
+            '--help[-h]'
+          ;;
 
-                setup)
-                    _arguments                         "--install=[Engines]:engines:(${engines[@]})"                         '--list[List all engines]'                         '--help[-h]'
-                    ;;
+        setup)
+          _arguments \
+            "--install=[Engines]:engines:(${engines[@]})" \
+            '--list[List all engines]' \
+            '--help[-h]'
+          ;;
 
-                serve)
-                    _arguments                         '--host=[Host address]'                         '--port=[Port number]'                         '--help[-h]'
-                    ;;
-
-                *)
-                    # Unknown subcommand: offer only --help.
-                    _arguments '--help[-h]'
-                    ;;
-            esac
-            ;;
+        serve)
+          _arguments \
+            '--host=[Host address]' \
+            '--port=[Port number]' \
+            '--help[-h]'
+          ;;
 
         *)
-            # Unexpected state: nothing to complete.
-            ;;
-    esac
+          # Unknown subcommand: offer only --help.
+          _arguments '--help[-h]'
+          ;;
+      esac
+      ;;
+
+    *)
+      # Unexpected state: nothing to complete.
+      ;;
+  esac
 }
 
 compdef _optics_completions optics

--- a/autocompletion/optics_completion.zsh
+++ b/autocompletion/optics_completion.zsh
@@ -27,6 +27,8 @@ _optics_completions() {
   local state
 
   _arguments -C \
+    '(-)--version[Show the Optics Framework version]' \
+    '(-)--help[-h]' \
     '1:command:->cmds' \
     '*::arg:->args'
 

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -94,7 +94,16 @@ _optics_completions() {
                         '--port=[Port number]' \
                         '--help[-h]'
                     ;;
+
+                *)
+                    # Unknown subcommand: offer only --help.
+                    _arguments '--help[-h]'
+                    ;;
             esac
+            ;;
+
+        *)
+            # Unexpected state: nothing to complete.
             ;;
     esac
 }
@@ -118,6 +127,9 @@ _optics_completions() {
     1)
       COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
       return 0
+      ;;
+    *)
+      # Beyond the subcommand: handled per-subcommand below.
       ;;
   esac
 
@@ -165,6 +177,8 @@ _optics_completions() {
             COMPREPLY=( $(compgen -f -- "$cur") )
         elif [[ $prev == "--project_path" ]]; then
             COMPREPLY=( $(compgen -d -- "$cur") )
+        else
+            : # keep the default --help completion set above
         fi
       ;;
 
@@ -181,6 +195,11 @@ _optics_completions() {
 
     serve)
       COMPREPLY=( $(compgen -W "--host --port -h --help" -- "$cur") )
+      ;;
+
+    *)
+      # Unknown subcommand: offer only --help.
+      COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
       ;;
   esac
 }

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -9,18 +9,20 @@ local -a _optics_subcommands=(
     'dry_run: Run tests in dry-run mode'
     'init: Initialize a new project'
     'execute: Execute tests'
-    'version: Show version'
+    'live: Interactive session against a live target'
     'generate: Generate framework code'
-    'setup: Install drivers'
-    'serve: Start the optics server'
+    'setup: Install optional engine backends'
+    'serve: Start the optics REST server'
+    'mcp: Start the MCP server'
     'completion: Enable shell completion'
 )
 
 # Static or dynamic values
-local -a templates=("calendar" "clock" "contact" "gmail_web" "youtube")
+local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwright")
 local -a runners=("test_runner" "pytest")
 local -a frameworks=("pytest" "robot")
-local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Drivers:|Text)$')}")
+local -a transports=("stdio" "http")
+local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')}")
 
 _optics_completions() {
     local state
@@ -35,8 +37,22 @@ _optics_completions() {
             ;;
         args)
             case $words[2] in
-                list|config|version|completion)
+                list|config|completion)
                     _arguments '--help[-h]'
+                    ;;
+
+                live)
+                    _arguments \
+                        '*:project_path:_files -/' \
+                        '--help[-h]'
+                    ;;
+
+                mcp)
+                    _arguments \
+                        '--transport=[Transport]:transport:(${transports[@]})' \
+                        '--host=[Host address]' \
+                        '--port=[Port number]' \
+                        '--help[-h]'
                     ;;
 
                 dry_run|execute)
@@ -92,11 +108,11 @@ _optics_completions() {
   local cur prev words cword
   _init_completion || return
 
-  local subcommands="list config dry_run init execute version generate setup serve completion"
+  local subcommands="list config dry_run init execute live generate setup serve mcp completion"
 
-  local template_options="calendar clock contact gmail_web youtube"
+  local template_options="contact clock calendar youtube gmail_web playwright"
   local runner_options="test_runner pytest"
-  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Drivers:|Text)$')
+  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')
 
   case ${COMP_CWORD} in
     1)
@@ -106,8 +122,20 @@ _optics_completions() {
   esac
 
   case ${COMP_WORDS[1]} in
-    list|config|version|completion)
+    list|config|completion)
       COMPREPLY=( $(compgen -W "--help -h" -- "$cur") )
+      ;;
+
+    live)
+      COMPREPLY=( $(compgen -d -- "$cur") )
+      ;;
+
+    mcp)
+      if [[ $prev == "--transport" ]]; then
+        COMPREPLY=( $(compgen -W "stdio http" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -W "--transport --host --port -h --help" -- "$cur") )
+      fi
       ;;
 
     dry_run|execute)

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -22,7 +22,10 @@ local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwrig
 local -a runners=("test_runner" "pytest")
 local -a frameworks=("pytest" "robot")
 local -a transports=("stdio" "http")
-local -a drivers=("${(f)$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')}")
+# `optics setup --list` indents each installable engine key by two spaces under a
+# category header; take only those indented lines so this stays correct no matter
+# what the category headers are named.
+local -a engines=("${(f)$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')}")
 
 _optics_completions() {
     local state
@@ -83,8 +86,8 @@ _optics_completions() {
 
                 setup)
                     _arguments \
-                        "--install=[Drivers]:drivers:(${drivers[@]})" \
-                        '--list[List all drivers]' \
+                        "--install=[Engines]:engines:(${engines[@]})" \
+                        '--list[List all engines]' \
                         '--help[-h]'
                     ;;
 
@@ -121,7 +124,9 @@ _optics_completions() {
 
   local template_options="contact clock calendar youtube gmail_web playwright"
   local runner_options="test_runner pytest"
-  local driver_options=$(optics setup --list 2>/dev/null | awk '{print $1}' | grep -vE '^(Action|Available|Text|LLM)$')
+  # Only the two-space-indented lines are engine keys; category headers are not
+  # indented, so this needs no per-header filter.
+  local engine_options=$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')
 
   case ${COMP_CWORD} in
     1)
@@ -185,7 +190,7 @@ _optics_completions() {
     setup)
       case $prev in
         --install)
-          COMPREPLY=( $(compgen -W "$driver_options" -- "$cur") )
+          COMPREPLY=( $(compgen -W "$engine_options" -- "$cur") )
           ;;
         *)
           COMPREPLY=( $(compgen -W "--install --list -h --help" -- "$cur") )

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from optics_framework.helper.initialize import available_templates
+
 ZSH_COMPLETION_CONTENT = """# Description: Zsh completion script for the Optics CLI tool
 local -a _optics_subcommands=(
     'list: List available API methods'
@@ -18,7 +20,7 @@ local -a _optics_subcommands=(
 )
 
 # Static or dynamic values
-local -a templates=("contact" "clock" "calendar" "youtube" "gmail_web" "playwright")
+local -a templates=(__OPTICS_TEMPLATES_ZSH__)
 local -a runners=("test_runner" "pytest")
 local -a frameworks=("pytest" "robot")
 local -a transports=("stdio" "http")
@@ -122,7 +124,7 @@ _optics_completions() {
 
   local subcommands="list config dry_run init execute live generate setup serve mcp completion"
 
-  local template_options="contact clock calendar youtube gmail_web playwright"
+  local template_options="__OPTICS_TEMPLATES_BASH__"
   local runner_options="test_runner pytest"
   # Only the two-space-indented lines are engine keys; category headers are not
   # indented, so this needs no per-header filter.
@@ -212,13 +214,25 @@ _optics_completions() {
 complete -F _optics_completions optics
 """
 
+def _render(content: str) -> str:
+    """Fill the sample-template placeholders from the single source of truth in
+    ``initialize.available_templates()`` so the completion candidates never drift
+    from the templates that actually ship."""
+    templates = available_templates()
+    zsh_arr = " ".join(f'"{t}"' for t in templates)
+    bash_list = " ".join(templates)
+    return (content
+            .replace("__OPTICS_TEMPLATES_ZSH__", zsh_arr)
+            .replace("__OPTICS_TEMPLATES_BASH__", bash_list))
+
+
 def write_completion_scripts():
     optics_dir = Path.home() / ".optics"
     optics_dir.mkdir(exist_ok=True)
     zsh_path = optics_dir / "optics_completion.zsh"
     bash_path = optics_dir / "optics_completion.sh"
-    zsh_path.write_text(ZSH_COMPLETION_CONTENT)
-    bash_path.write_text(BASH_COMPLETION_CONTENT)
+    zsh_path.write_text(_render(ZSH_COMPLETION_CONTENT))
+    bash_path.write_text(_render(BASH_COMPLETION_CONTENT))
     return zsh_path, bash_path
 
 def update_shell_rc(shell: Optional[str] = None):

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -4,19 +4,22 @@ from typing import Optional
 
 from optics_framework.helper.initialize import available_templates
 
-ZSH_COMPLETION_CONTENT = """# Description: Zsh completion script for the Optics CLI tool
+# Raw string: the `\` line-continuations below must reach the generated script
+# verbatim. A normal string would let Python collapse each `\`+newline, emitting
+# the `_arguments` calls as one unreadable line.
+ZSH_COMPLETION_CONTENT = r"""# Description: Zsh completion script for the Optics CLI tool
 local -a _optics_subcommands=(
-    'list: List available API methods'
-    'config: Manage configuration'
-    'dry_run: Run tests in dry-run mode'
-    'init: Initialize a new project'
-    'execute: Execute tests'
-    'live: Interactive session against a live target'
-    'generate: Generate framework code'
-    'setup: Install optional engine backends'
-    'serve: Start the optics REST server'
-    'mcp: Start the MCP server'
-    'completion: Enable shell completion'
+  'list: List available API methods'
+  'config: Manage configuration'
+  'dry_run: Run tests in dry-run mode'
+  'init: Initialize a new project'
+  'execute: Execute tests'
+  'live: Interactive session against a live target'
+  'generate: Generate framework code'
+  'setup: Install optional engine backends'
+  'serve: Start the optics REST server'
+  'mcp: Start the MCP server'
+  'completion: Enable shell completion'
 )
 
 # Static or dynamic values
@@ -30,87 +33,87 @@ local -a transports=("stdio" "http")
 local -a engines=("${(f)$(optics setup --list 2>/dev/null | awk '/^  / {print $1}')}")
 
 _optics_completions() {
-    local state
+  local state
 
-    _arguments -C \
-        '1:command:->cmds' \
-        '*::arg:->args'
+  _arguments -C \
+    '1:command:->cmds' \
+    '*::arg:->args'
 
-    case $state in
-        cmds)
-            _describe 'command' _optics_subcommands
-            ;;
-        args)
-            case $words[2] in
-                list|config|completion)
-                    _arguments '--help[-h]'
-                    ;;
+  case $state in
+    cmds)
+      _describe 'command' _optics_subcommands
+      ;;
+    args)
+      case $words[2] in
+        list|config|completion)
+          _arguments '--help[-h]'
+          ;;
 
-                live)
-                    _arguments \
-                        '*:project_path:_files -/' \
-                        '--help[-h]'
-                    ;;
+        live)
+          _arguments \
+            '*:project_path:_files -/' \
+            '--help[-h]'
+          ;;
 
-                mcp)
-                    _arguments \
-                        '--transport=[Transport]:transport:(${transports[@]})' \
-                        '--host=[Host address]' \
-                        '--port=[Port number]' \
-                        '--help[-h]'
-                    ;;
+        mcp)
+          _arguments \
+            '--transport=[Transport]:transport:(${transports[@]})' \
+            '--host=[Host address]' \
+            '--port=[Port number]' \
+            '--help[-h]'
+          ;;
 
-                dry_run|execute)
-                    _arguments \
-                        '--runner=[Runner]:runner:(${runners[@]})' \
-                        '--use-printer[Enable printer]' \
-                        '--no-use-printer[Disable printer]' \
-                        '--help[-h]'
-                    ;;
+        dry_run|execute)
+          _arguments \
+            '--runner=[Runner]:runner:(${runners[@]})' \
+            '--use-printer[Enable printer]' \
+            '--no-use-printer[Disable printer]' \
+            '--help[-h]'
+          ;;
 
-                init)
-                    _arguments \
-                        '--name=[Project name]' \
-                        '--path=[Project path]' \
-                        '--force[Override existing]' \
-                        "--template=[Template name]:template:(${templates[@]})" \
-                        '--git-init[Initialize Git]' \
-                        '--help[-h]'
-                    ;;
+        init)
+          _arguments \
+            '--name=[Project name]' \
+            '--path=[Project path]' \
+            '--force[Override existing]' \
+            "--template=[Template name]:template:(${templates[@]})" \
+            '--git-init[Initialize Git]' \
+            '--help[-h]'
+          ;;
 
-                generate)
-                    _arguments \
-                        '*:project_path:_files' \
-                        '*:output:_files' \
-                        '--framework=[Framework]:framework:(${frameworks[@]})' \
-                        '--help[-h]'
-                    ;;
+        generate)
+          _arguments \
+            '*:project_path:_files' \
+            '*:output_file:_files' \
+            '--framework=[Framework]:framework:(${frameworks[@]})' \
+            '--help[-h]'
+          ;;
 
-                setup)
-                    _arguments \
-                        "--install=[Engines]:engines:(${engines[@]})" \
-                        '--list[List all engines]' \
-                        '--help[-h]'
-                    ;;
+        setup)
+          _arguments \
+            "--install=[Engines]:engines:(${engines[@]})" \
+            '--list[List all engines]' \
+            '--help[-h]'
+          ;;
 
-                serve)
-                    _arguments \
-                        '--host=[Host address]' \
-                        '--port=[Port number]' \
-                        '--help[-h]'
-                    ;;
-
-                *)
-                    # Unknown subcommand: offer only --help.
-                    _arguments '--help[-h]'
-                    ;;
-            esac
-            ;;
+        serve)
+          _arguments \
+            '--host=[Host address]' \
+            '--port=[Port number]' \
+            '--help[-h]'
+          ;;
 
         *)
-            # Unexpected state: nothing to complete.
-            ;;
-    esac
+          # Unknown subcommand: offer only --help.
+          _arguments '--help[-h]'
+          ;;
+      esac
+      ;;
+
+    *)
+      # Unexpected state: nothing to complete.
+      ;;
+  esac
 }
 
 compdef _optics_completions optics
@@ -178,15 +181,15 @@ _optics_completions() {
 
     generate)
       COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-        if [[ $prev == "--framework" ]]; then
-            COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
-        elif [[ $prev == "--output" ]]; then
-            COMPREPLY=( $(compgen -f -- "$cur") )
-        elif [[ $prev == "--project_path" ]]; then
-            COMPREPLY=( $(compgen -d -- "$cur") )
-        else
-            : # keep the default --help completion set above
-        fi
+      if [[ $prev == "--framework" ]]; then
+        COMPREPLY=( $(compgen -W "pytest robot" -- "$cur") )
+      elif [[ $prev == "--output" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+      elif [[ $prev == "--project_path" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+      else
+        : # keep the default --help completion set above
+      fi
       ;;
 
     setup)

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -36,6 +36,8 @@ _optics_completions() {
   local state
 
   _arguments -C \
+    '(-)--version[Show the Optics Framework version]' \
+    '(-)--help[-h]' \
     '1:command:->cmds' \
     '*::arg:->args'
 
@@ -135,7 +137,7 @@ _optics_completions() {
 
   case ${COMP_CWORD} in
     1)
-      COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+      COMPREPLY=( $(compgen -W "$subcommands --version --help -h" -- "$cur") )
       return 0
       ;;
     *)

--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 from optics_framework.helper.list_keyword import main as list_main
 from optics_framework.helper.config_manager import main as config_main
-from optics_framework.helper.initialize import create_project
+from optics_framework.helper.initialize import create_project, available_templates
 from optics_framework.helper.version import VERSION
 from optics_framework.helper.execute import execute_main, dryrun_main
 from optics_framework.helper.live import live_main
@@ -212,8 +212,7 @@ class InitCommand(Command):
         )
         parser.add_argument(
             "--template",
-            help="Start from a sample template: contact, clock, calendar, "
-                 "youtube, gmail_web, or playwright",
+            help="Start from a sample template: " + ", ".join(available_templates()),
         )
         parser.add_argument(
             "--git-init",

--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -211,7 +211,9 @@ class InitCommand(Command):
             "--force", action="store_true", help="Override if the project exists"
         )
         parser.add_argument(
-            "--template", help="Select a project template (e.g., 'sample1')"
+            "--template",
+            help="Start from a sample template: contact, clock, calendar, "
+                 "youtube, gmail_web, or playwright",
         )
         parser.add_argument(
             "--git-init",

--- a/optics_framework/helper/config_manager.py
+++ b/optics_framework/helper/config_manager.py
@@ -1,5 +1,5 @@
 from textual.app import App, ComposeResult
-from textual.widgets import Header, Footer, ListView, ListItem, Label, Input, Button
+from textual.widgets import Header, Footer, ListView, ListItem, Label, Input, Button, Static
 from textual.containers import Vertical, Horizontal, Container
 from textual.screen import ModalScreen
 from optics_framework.common.config_handler import ConfigHandler, Config, DependencyConfig
@@ -113,6 +113,12 @@ class LoggerTUI(App):
 
     def compose(self) -> ComposeResult:
         yield Header()
+        yield Static(
+            f"Editing GLOBAL config: {self.config_handler.global_config_path}\n"
+            "Note: `optics execute <folder>` reads that folder's own config.yaml, "
+            "not this global file.",
+            classes="option-label",
+        )
         yield ListView(*[ListItem(Label(f"{key}: {self.get_value(key)}", classes="option-label"))
                        for key in self.options], id="config-list")
         yield Footer()
@@ -175,8 +181,11 @@ class LoggerTUI(App):
                 parsed = ast.literal_eval(new_value)
                 if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
                     raise ValueError("Must be a list of strings")
+                # Each entry must be keyed by the actual source name (e.g. "appium"),
+                # not the literal "name" — otherwise every source collapses to one
+                # unresolvable key.
                 setattr(self.config_handler.config, key,
-                        [{"name": DependencyConfig(enabled=True)} for _ in parsed])
+                        [{source: DependencyConfig(enabled=True)} for source in parsed])
             else:
                 parsed = type(current_value)(new_value)
                 setattr(self.config_handler.config, key, parsed)

--- a/optics_framework/helper/initialize.py
+++ b/optics_framework/helper/initialize.py
@@ -59,6 +59,13 @@ elements_sources:
       enabled: false
   - appium_screenshot:
       enabled: false
+  # Selenium locators / page source / screenshots:
+  - selenium_find_element:
+      enabled: false
+  - selenium_page_source:
+      enabled: false
+  - selenium_screenshot:
+      enabled: false
   # Playwright locators / page source / screenshots:
   - playwright_find_element:
       enabled: false

--- a/optics_framework/helper/initialize.py
+++ b/optics_framework/helper/initialize.py
@@ -1,9 +1,84 @@
 import os
 import shutil
 import subprocess # nosec
-import yaml
 import pathlib
-from optics_framework.common.config_handler import ConfigHandler
+
+
+# Files/directories that must never be copied out of a sample template.
+_SKIP_NAMES = {"__pycache__"}
+
+
+def _is_junk(name: str) -> bool:
+    """True for hidden files (e.g. .DS_Store) and build cruft."""
+    return name.startswith(".") or name in _SKIP_NAMES
+
+
+# A commented starter config for `optics init` without a template. It mirrors the
+# framework defaults (every source present but disabled) and tells the user how to
+# turn one on. Enable exactly one driver and at least one matching elements_source.
+_STARTER_CONFIG = """\
+# Optics Framework project configuration.
+#
+# Getting started:
+#   1. Enable ONE driver under driver_sources (set enabled: true) and fill in its
+#      capabilities/url.
+#   2. Enable the matching elements_sources for that driver.
+#   3. Install the driver's packages, e.g.  optics setup --install appium
+#
+# Full reference: https://mozarkai.github.io/optics-framework/configuration/
+
+driver_sources:
+  # Native Android/iOS via Appium. Needs a running Appium server and a connected
+  # device/emulator.  Install:  optics setup --install appium
+  - appium:
+      enabled: false
+      url: "http://localhost:4723"
+      capabilities:
+        appPackage: com.example.app
+        appActivity: com.example.app.MainActivity
+        automationName: UiAutomator2
+        deviceName: emulator-5554
+        platformName: Android
+  # Web via a Selenium/WebDriver server.  Install:  optics setup --install selenium
+  - selenium:
+      enabled: false
+      url: "http://localhost:4444/wd/hub"
+      capabilities: {}
+  # Web via Playwright (no external server).  Install:  optics setup --install playwright
+  - playwright:
+      enabled: false
+      capabilities:
+        browser: chromium
+        headless: false
+
+elements_sources:
+  # Appium locators / page source / screenshots:
+  - appium_find_element:
+      enabled: false
+  - appium_page_source:
+      enabled: false
+  - appium_screenshot:
+      enabled: false
+  # Playwright locators / page source / screenshots:
+  - playwright_find_element:
+      enabled: false
+  - playwright_page_source:
+      enabled: false
+  - playwright_screenshot:
+      enabled: false
+
+# Optional vision fallbacks: locate elements by on-screen text (OCR) or image.
+text_detection:
+  - easyocr:            # install: optics setup --install easyocr
+      enabled: false
+image_detection:
+  - templatematch:
+      enabled: false
+
+log_level: INFO
+json_log: true
+file_log: true
+"""
 
 
 def _check_and_prepare_directory(project_path: str, force: bool) -> bool:
@@ -22,51 +97,52 @@ def _check_and_prepare_directory(project_path: str, force: bool) -> bool:
     return True
 
 
-def _create_csv_files(project_path: str) -> None:
-    """Create CSV files with predefined headers in the project directory."""
-    csv_files = {
-        "test_cases.csv": "test_case,test_step\n",
-        "test_modules.csv": "module_name,module_step,param_1,param_2\n",
-        "elements.csv": "Element_Name,Element_ID\n",
+def _scaffold_project(project_path: str) -> None:
+    """Create an empty-but-runnable project skeleton (subdir layout matching the
+    samples) plus a commented starter config."""
+    files = {
+        os.path.join("test_cases", "test_cases.csv"): "test_case,test_step\n",
+        os.path.join("modules", "modules.csv"): "module_name,module_step,param_1,param_2,param_3\n",
+        os.path.join("test_data", "elements.csv"): "Element_Name,Element_ID\n",
     }
-    for filename, content in csv_files.items():
-        file_path = os.path.join(project_path, filename)
+    for rel_path, content in files.items():
+        file_path = os.path.join(project_path, rel_path)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(content)
-    print("CSV files created.")
+
+    with open(os.path.join(project_path, "config.yaml"), "w", encoding="utf-8") as f:
+        f.write(_STARTER_CONFIG)
+    print("Created starter project (test_cases/, modules/, test_data/, config.yaml).")
 
 
-def _create_config_file(project_path: str) -> None:
-    """Create config.yaml with default values from ConfigHandler."""
-    config_path = os.path.join(project_path, "config.yaml")
-    try:
-        with open(ConfigHandler.DEFAULT_GLOBAL_CONFIG_PATH,'r') as f:
-            global_yaml_data = yaml.safe_load(f)
-    except Exception:
-            global_yaml_data = ""
-    with open(config_path, "w", encoding="utf-8") as f:
-        yaml.dump(global_yaml_data,
-                  f, default_flow_style=False)
-    print("Created config.yaml with default values.")
-
-
-def _copy_template(project_path: str, template: str) -> None:
-    """Copy files from the specified template directory if it exists."""
+def _copy_template(project_path: str, template: str) -> bool:
+    """Copy a sample template into the project. Returns True on success."""
     package_root = pathlib.Path(__file__).parent.parent
     template_path = package_root / "samples" / template
     if not os.path.exists(template_path):
-        print(
-            f"Template '{template}' not found in {os.path.abspath(template_path)}")
-        return
+        available = sorted(
+            p.name for p in (package_root / "samples").iterdir()
+            if p.is_dir() and not _is_junk(p.name)
+        )
+        print(f"Template '{template}' not found. Available templates: {', '.join(available)}")
+        return False
 
     for item in os.listdir(template_path):
+        if _is_junk(item):
+            continue
         src_item = os.path.join(template_path, item)
         dest_item = os.path.join(project_path, item)
         if os.path.isdir(src_item):
-            shutil.copytree(src_item, dest_item)
+            shutil.copytree(
+                src_item, dest_item,
+                ignore=shutil.ignore_patterns(*_SKIP_NAMES, ".*"),
+            )
         else:
             shutil.copy2(src_item, dest_item)
-    print(f"Copied template '{template}' files into the project.")
+    print(f"Copied template '{template}' into the project.")
+    return True
+
 
 def create_project(args):
     """
@@ -93,13 +169,17 @@ def create_project(args):
     if not _check_and_prepare_directory(project_path, args.force):
         return
 
-    _create_csv_files(project_path)
-    _create_config_file(project_path)
+    # A template is a complete, runnable sample — copy it verbatim. Otherwise
+    # scaffold an empty starter project. (Previously we always scaffolded AND
+    # then copied on top, producing a confusing hybrid layout.)
     if args.template:
-        _copy_template(project_path, args.template)
-    if args.git_init:  # Check if git_init flag is set
-        try:
+        if not _copy_template(project_path, args.template):
+            return
+    else:
+        _scaffold_project(project_path)
 
+    if args.git_init:
+        try:
             git_path = shutil.which("git")  # Get the absolute path of Git
             if git_path:
                 subprocess.run([git_path, "init"], cwd=project_path,               #nosec B603
@@ -108,3 +188,10 @@ def create_project(args):
             print("Error: Git not found!")
         except subprocess.CalledProcessError as e:
             print(f"Error initializing git repository: {e}")
+
+    print(f"\nProject ready at: {project_path}")
+    if args.template:
+        print(f"Next: review {project_name}/config.yaml, then run:  optics dry_run {project_path}")
+    else:
+        print(f"Next: enable a driver in {project_name}/config.yaml and add your "
+              f"test cases, then run:  optics dry_run {project_path}")

--- a/optics_framework/helper/initialize.py
+++ b/optics_framework/helper/initialize.py
@@ -13,6 +13,23 @@ def _is_junk(name: str) -> bool:
     return name.startswith(".") or name in _SKIP_NAMES
 
 
+def _samples_dir() -> pathlib.Path:
+    return pathlib.Path(__file__).parent.parent / "samples"
+
+
+def available_templates() -> list[str]:
+    """Sample project names shippable via ``optics init --template``, discovered
+    from the packaged ``samples/`` directory. Single source of truth for the
+    ``--template`` help text and the shell-completion candidate lists."""
+    samples = _samples_dir()
+    if not samples.is_dir():
+        return []
+    return sorted(
+        p.name for p in samples.iterdir()
+        if p.is_dir() and not _is_junk(p.name)
+    )
+
+
 # A commented starter config for `optics init` without a template. It mirrors the
 # framework defaults (every source present but disabled) and tells the user how to
 # turn one on. Enable exactly one driver and at least one matching elements_source.
@@ -125,13 +142,9 @@ def _scaffold_project(project_path: str) -> None:
 
 def _copy_template(project_path: str, template: str) -> bool:
     """Copy a sample template into the project. Returns True on success."""
-    package_root = pathlib.Path(__file__).parent.parent
-    template_path = package_root / "samples" / template
+    template_path = _samples_dir() / template
     if not os.path.exists(template_path):
-        available = sorted(
-            p.name for p in (package_root / "samples").iterdir()
-            if p.is_dir() and not _is_junk(p.name)
-        )
+        available = available_templates()
         print(f"Template '{template}' not found. Available templates: {', '.join(available)}")
         return False
 


### PR DESCRIPTION
Part **3 of 4** of the onboarding overhaul split out of #395. This chunk fixes first-run UX: `optics init` scaffolding, the `optics config` TUI dependency-list corruption, and stale shell completions.

## `fix(init)`: produce a valid, runnable project scaffold
`optics init` previously built `config.yaml` by reading `~/.optics/global_config.yaml`, which does not ship and does not exist on a fresh machine — so it wrote a config containing literally `''` while printing "Created config.yaml with default values." It also always wrote flat root CSVs and *then* copied any template on top, yielding a confusing hybrid layout, and copied `.DS_Store` into the project.
- **No template:** scaffold the sample subdir layout (`test_cases/`, `modules/`, `test_data/`) plus a commented starter `config.yaml` mirroring framework defaults (every source present but disabled, documented how to enable one). The result is recognised as a valid project config.
- **With a template:** copy the sample verbatim only (no more hybrid), skipping hidden files and `__pycache__`.
- Unknown template now lists available templates; fix the `--template` help text (was the nonexistent `sample1`); print next-step guidance.

## `fix(config)`: stop corrupting dependency lists
The config TUI keyed every dependency-list entry (`driver_sources`, `elements_sources`, …) by the literal string `"name"`, collapsing e.g. `['appium']` to `[{'name': ...}]` — an unresolvable config. Key each entry by its actual source name. Also show which file the TUI edits (the GLOBAL `~/.optics` config) and note that `optics execute <folder>` reads the folder's own `config.yaml` (see #392 for reconciling the two surfaces).

## `fix(completion)`: refresh shell completions
The embedded scripts advertised a nonexistent `version` subcommand and omitted `live`/`mcp`; the template list missed `playwright` (and stale top-level copies had a `calender` typo and missed `clock`). Fix the subcommand/template lists, add `live`/`mcp`, adjust the driver-list filter to the new `setup --list` output, regenerate the top-level copies, and add default cases to every shell `case` statement (SonarQube).

## Verification
Full suite green on top of current `main`: **565 passed, 1 skipped, 2 xfailed**.

Relates to #392 (global vs project config reconciliation).

---
### Completion ↔ setup coupling (added commit)
`optics setup --list` (#402) renamed its category headers to "OCR Engines:" / "LLM Engines:". The completion scripts scraped keys by blacklisting header words — fragile, and it leaked any un-blacklisted header. Now they parse **only the two-space-indented key lines**, which is header-agnostic (also fixes a pre-existing leak), and the remaining `driver`→`engine` labels/vars are aligned with setup's vocabulary. Top-level `autocompletion/` copies regenerated; both pass `bash -n`/`zsh -n`.