### PR TITLE
docs: overhaul onboarding to match actual CLI behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,47 +31,45 @@ This framework was designed primarily for the following use cases:
 
 ## 📦 Installation
 
-### Install via `pip`
+Optics needs **Python 3.12+**. Install the core CLI with `pip`:
 
 ```bash
 pip install optics-framework
 ```
+
+The core install is deliberately light — the drivers, OCR engines and LLM backends are **optional extras** you add per project. Install only what you need:
+
+```bash
+pip install "optics-framework[appium]"       # native Android/iOS via Appium
+pip install "optics-framework[playwright]"   # browser automation via Playwright
+pip install "optics-framework[easyocr]"      # on-screen text detection (OCR)
+```
+
+Available extras: `appium`, `selenium`, `playwright`, `ble`, `easyocr`, `pytesseract`, `google-vision`, `llm`, `mcp`, plus bundles `mobile`, `web`, `vision`, and `all`. You can also install them interactively with `optics setup` (see below).
+
+> A driver extra installs only the **Python client**. For mobile testing you also need the **Appium server**, a device/emulator, and platform tooling (Node.js, Android SDK/adb, JDK). See the [Installation & Prerequisites guide](https://mozarkai.github.io/optics-framework/prerequisites/).
+
+> **⚠️ Conda note:** `easyocr` and `optics-framework` conflict under Conda (numpy 1.x vs 2.x). Use a standard `venv` instead.
 
 ---
 
 ## 🚀 Quick Start
 
-### 1 Install Optics Framework
-
-**Note**: Ensure Appium server is running and a virtual Android device is enabled before proceeding.
-
 ```bash
-mkdir ~/test-code
-cd ~/test-code
-python3 -m venv venv
-source venv/bin/activate
+# 1. Create an isolated environment and install Optics
+python3 -m venv venv && source venv/bin/activate
 pip install optics-framework
-```
 
-> **⚠️ Important:** Conda environments are not supported for `easyocr` and `optics-framework` together, due to conflicting requirements for `numpy` (version 1.x vs 2.x). Please use a standard Python virtual environment instead.
+# 2. Install the engines you need (equivalent to the [appium]/[easyocr] extras)
+optics setup --install appium easyocr
 
-### 2 Create a New Test Project
+# 3. Scaffold a project from a ready-made sample
+optics init --name my_test_project --template contact
 
-```bash
-optics setup --install Appium EasyOCR
-optics init --name my_test_project --path . --template contact
-```
-
-### 📌 Dry Run Test Cases
-
-```bash
-optics dry_run my_test_project
-```
-
-### 📌 Execute Test Cases
-
-```bash
-optics execute my_test_project
+# 4. Point config.yaml at your device/app (see the sample's config.yaml),
+#    make sure the Appium server + emulator are running, then:
+optics dry_run my_test_project      # validate the suite without a device
+optics execute my_test_project      # run it for real
 ```
 
 ---
@@ -87,7 +85,7 @@ optics execute <project_name>
 ### Initialize a New Project
 
 ```bash
-optics init --name <project_name> --path <directory> --template <contact/youtube> --force
+optics init --name <project_name> --path <directory> --template <contact|youtube|...> --force
 ```
 
 ### List Available Keywords
@@ -105,37 +103,12 @@ optics --help
 ### Check Version
 
 ```bash
-optics version
+optics --version
 ```
 
 ---
 
 ## 🏗️ Developer Guide
-
-### Project Structure
-
-```bash
-Optics_Framework/
-├── LICENSE
-├── README.md
-├── dev_requirements.txt
-├── samples/            # Sample test cases and configurations
-|   ├── contact/
-|   ├── youtube/
-├── pyproject.toml
-├── tox.ini
-├── docs/               # Documentation using Sphinx
-├── optics_framework/   # Main package
-│   ├── api/            # Core API modules
-│   ├── common/         # Factories, interfaces, and utilities
-│   ├── engines/        # Engine implementations (drivers, vision models, screenshot tools)
-│   ├── helper/         # Configuration management
-├── tests/              # Unit tests and test assets
-│   ├── assets/         # Sample images for testing
-│   ├── units/          # Unit tests organized by module
-│   ├── functional/     # Functional tests organized by module
-
-```
 
 ### Available Keywords
 
@@ -326,15 +299,18 @@ The following keywords are available and organized by category. These keywords c
 
 ```bash
 git clone git@github.com:mozarkai/optics-framework.git
-cd Optics_Framework
+cd optics-framework
 pipx install poetry
-poetry install --with dev
+poetry install --with dev,test
+poetry run pre-commit install
 ```
+
+To work on an engine backend, add its extra, e.g. `poetry install -E appium -E easyocr`.
 
 ### Running Tests
 
 ```bash
-poetry install --with tests
+poetry install --with test
 poetry run pytest
 ```
 
@@ -362,7 +338,7 @@ We welcome contributions! Please follow these steps:
 3. Commit your changes.
 4. Open a pull request.
 
-Ensure your code follows **PEP8** standards and is formatted with **Black**.
+Ensure your code follows **PEP8** and passes the pre-commit hooks (ruff lint + format, bandit, commitizen). Run `poetry run pre-commit run --all-files` before pushing.
 
 ---
 

--- a/docs/architecture/cli_layer.md
+++ b/docs/architecture/cli_layer.md
@@ -148,7 +148,7 @@ optics dry_run ./my_project --runner test_runner
 
 **Usage:**
 ```bash
-optics setup --install Appium EasyOCR
+optics setup --install appium easyocr
 optics setup --list
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,14 +4,13 @@ This document provides comprehensive documentation for all configuration options
 
 ## Overview
 
-The Optics Framework uses a hierarchical configuration system that merges configurations in the following order (with later configurations taking priority):
+There are two configuration files:
 
-1. **Default Configuration** - Built-in defaults
-2. **Global Configuration** - `~/.optics/global_config.yaml` (user-wide settings)
-3. **Project Configuration** - `config.yaml` in your project directory (project-specific settings)
+1. **Project Configuration** — `config.yaml` in your project directory. This is the config `optics execute <folder>` / `optics dry_run <folder>` actually read. Built-in defaults fill in any field you omit.
+2. **Global Configuration** — `~/.optics/global_config.yaml`, edited by the interactive `optics config` command.
 
-!!! tip "Configuration Priority"
-    Project configuration overrides global configuration, which overrides default configuration. This allows you to set common settings globally and override them per-project.
+!!! warning "The runner reads the project config only"
+    `optics execute`/`optics dry_run` load the target folder's own `config.yaml` and do **not** merge the global file into it. Treat `config.yaml` in each project as the source of truth for that run. The global config is a convenience surface edited via `optics config`; to affect a specific run, edit that project's `config.yaml`.
 
 ## Quick Reference
 
@@ -117,7 +116,7 @@ All configurations are defined in YAML format. The main configuration file (`con
 
     **Type:** `Optional[str]` | **Default:** `null`
 
-    Root directory for test project files. This path should contain your CSV files (`test_cases.csv`, `test_modules.csv`, `elements.csv`) and `input_templates/` directory.
+    Root directory for test project files. This folder holds your test cases, modules, and elements (either the sample subdir layout — `test_cases/`, `modules/`, `test_data/` — or flat CSVs; the runner discovers them by content) plus any `input_templates/` images.
 
     ```yaml
     project_path: "./my_test_project"
@@ -823,46 +822,12 @@ driver_sources:
 
 ---
 
-## Configuration Priority and Merging
+## How configuration is loaded
 
-The Optics Framework merges configurations in the following order (later configurations override earlier ones):
+When you run `optics execute` or `optics dry_run`, the framework reads the target folder's own `config.yaml`. Any field you leave out falls back to the built-in defaults (for example, every source defaults to `enabled: false`). The global `~/.optics/global_config.yaml` is **not** merged into the run, so a project's `config.yaml` is the single source of truth for that run.
 
-1. **Default Configuration** - Built-in defaults from the `Config` class
-2. **Global Configuration** - `~/.optics/global_config.yaml` (user-wide settings)
-3. **Project Configuration** - `config.yaml` in your project directory
-
-### Merging Behavior
-
-- **Simple fields** (strings, numbers, booleans): Later values completely replace earlier values
-- **Lists** (driver_sources, elements_sources, etc.): Items are merged, with later items taking precedence for duplicates
-- **Dictionaries** (capabilities): Deep merged, with later values overriding earlier values
-
-### Example Merging
-
-**Global Config (`~/.optics/global_config.yaml`):**
-```yaml
-log_level: INFO
-driver_sources:
-  - appium:
-      enabled: true
-      url: "http://localhost:4723/wd/hub"
-      capabilities:
-        platformName: "Android"
-```
-
-**Project Config (`config.yaml`):**
-```yaml
-log_level: DEBUG
-driver_sources:
-  - appium:
-      enabled: true
-      url: "http://localhost:4723/wd/hub"
-      capabilities:
-        platformName: "Android"
-        deviceName: "emulator-5554"
-```
-
-**Result:** The merged configuration will have `log_level: DEBUG` and the Appium capabilities will include both `platformName: "Android"` and `deviceName: "emulator-5554"`.
+!!! note "Where the global config is used"
+    The global config is the file the interactive `optics config` command edits. It is a convenience for user-wide defaults and is not read by `optics execute`, so editing it has no effect on a run. To change how a specific project runs, edit that project's `config.yaml`.
 
 ---
 
@@ -872,6 +837,5 @@ driver_sources:
 2. **Use Appropriate OCR**: Choose EasyOCR for accuracy, Pytesseract for speed
 3. **Set Log Level Appropriately**: Use DEBUG during development, INFO or WARNING in production
 4. **Configure Execution Paths**: Set `project_path` and `execution_output_path` for organized output
-5. **Use Global Config for Common Settings**: Store frequently used settings in `~/.optics/global_config.yaml`
-6. **Leverage Configuration Priority**: Override global settings in project-specific configs when needed
-7. **Test Configuration Changes**: Verify configurations work correctly before running large test suites
+5. **Keep Each Project's `config.yaml` Self-Contained**: It is the config the runner reads — don't rely on the global config to supply values at run time
+6. **Test Configuration Changes**: Verify configurations work correctly before running large test suites

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,12 +53,14 @@ Get started with Optics Framework in minutes:
 
 ```bash
 pip install optics-framework
-optics setup --install Appium EasyOCR
-optics init --name my_test_project --path . --template contact
-optics execute my_test_project
+optics setup --install appium easyocr        # install the engines you need
+optics init --name my_test_project --template contact
+# edit my_test_project/config.yaml for your device, start Appium + emulator, then:
+optics dry_run my_test_project               # validate without a device
+optics execute my_test_project               # run it
 ```
 
-[:material-arrow-right: Read the Quick Start Guide →](quickstart.md)
+[:material-arrow-right: Read the Quick Start Guide →](quickstart.md) &nbsp;·&nbsp; [Installation & Prerequisites →](prerequisites.md)
 
 ## :material-book-open: Explore Documentation
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,69 @@
+# Installation & Prerequisites
+
+This page is the reference for what to install: the core CLI, the optional **engine extras**, and the **external tooling** each target platform needs. If you just want to try Optics, follow the [Quick Start](quickstart.md) — come back here when you need the full list of extras or the tooling for a specific platform.
+
+---
+
+## Core install
+
+Optics requires **Python 3.12 or newer**. Install the CLI into a standard virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate     # Windows: venv\Scripts\activate
+pip install optics-framework
+optics --version             # confirm the CLI is on your PATH
+```
+
+!!! warning "Use a standard virtualenv, not Conda"
+    `easyocr` and `optics-framework` have conflicting `numpy` requirements (1.x vs 2.x) under Conda. Use a plain `venv`.
+
+---
+
+## Engine backends (extras)
+
+The core install has **no drivers, OCR, or LLM backends** — they are optional extras. Add them either as pip extras or with `optics setup` (the names match the `config.yaml` source keys):
+
+| Extra / `optics setup` name | Installs | Use for |
+|---|---|---|
+| `appium` | appium-python-client | Native Android/iOS |
+| `selenium` | selenium | Web via a Selenium/WebDriver server |
+| `playwright` | playwright (+ Chromium) | Web via Playwright |
+| `ble` | pyserial | BLE mouse/keyboard action drivers |
+| `easyocr` | easyocr | On-screen text detection (OCR) |
+| `pytesseract` | pytesseract, pillow | OCR via a system Tesseract |
+| `google-vision` | google-cloud-vision | OCR via Google Cloud Vision |
+| `llm` | google-genai | Natural-language `optics live` + AI self-heal |
+| `mcp` | fastmcp | `optics mcp` server |
+
+```bash
+# As pip extras
+pip install "optics-framework[appium,easyocr]"
+
+# ...or by name (optics setup pins to your installed Optics version)
+optics setup --list                # list installable engines
+optics setup --install appium easyocr
+```
+
+Convenience bundles also exist: `mobile`, `web`, `vision`, `all`.
+
+---
+
+## External tooling
+
+A driver extra installs only the **Python client**. Each platform also needs its own external tooling, which we don't bundle — install it from the vendor's own docs, since setup differs per OS:
+
+- **Android (Appium):** [Node.js](https://nodejs.org/en/download), the [Appium server + UiAutomator2 driver](https://appium.io/docs/en/latest/quickstart/), the [Android platform tools](https://developer.android.com/tools/releases/platform-tools) (for `adb`), and a JDK (17+). Confirm a device is visible with `adb devices`.
+- **iOS (Appium):** macOS + Xcode and the [Appium XCUITest driver](https://appium.github.io/appium-xcuitest-driver/).
+- **Web (Playwright):** `optics setup --install playwright` runs the [browser download](https://playwright.dev/python/docs/browsers) for you.
+- **Web (Selenium):** a running [Selenium/WebDriver server](https://www.selenium.dev/documentation/grid/); set its URL in `config.yaml`.
+- **OCR (`pytesseract`):** a system [Tesseract binary](https://tesseract-ocr.github.io/tessdoc/Installation.html).
+- **OCR (`google-vision`) / LLM (`llm`):** cloud credentials in the environment (`GOOGLE_APPLICATION_CREDENTIALS`, `GEMINI_API_KEY`/`GOOGLE_API_KEY`). Never commit keys.
+
+Point your project `config.yaml` at the device/browser once the tooling is running — see [Configuration](configuration.md).
+
+---
+
+## Next steps
+
+With the CLI and the extras you need installed, continue with the [Quick Start](quickstart.md) to create and run your first project.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,20 +2,9 @@
 
 This guide will walk you through creating automated tests using Optics Framework.
 
-## :material-package: Installation & Setup
-
-### Install Optics Framework
-
-```bash
-pip install optics-framework
-```
-
 ## :material-rocket: Quick Start
 
 ### Step 1: Create Python Virtual Environment
-
-!!! warning "Prerequisites"
-    Ensure Appium server is running and a virtual Android device is enabled before proceeding.
 
 ```bash
 mkdir ~/test-code
@@ -28,34 +17,40 @@ pip install optics-framework
 !!! danger "Important"
     Conda environments are not supported for `easyocr` and `optics-framework` together, due to conflicting requirements for `numpy` (version 1.x vs 2.x). Please use a standard Python virtual environment instead.
 
-### Step 2: Create a New Test Project
+### Step 2: Install the Engines You Need
+
+The core install has no drivers. Add the ones your test needs — either as pip extras or via `optics setup` (the names match the `config.yaml` source keys):
 
 ```bash
-optics setup --install Appium EasyOCR
-optics init --name my_test_project --path . --template contact
+optics setup --install appium easyocr
+# equivalent to: pip install "optics-framework[appium,easyocr]"
 ```
 
-This creates a project structure with sample templates to help you get started.
-
 !!! warning "Note"
-    Intel based Macs cannot download easyocr.
+    Intel-based Macs cannot download easyocr.
+
+### Step 3: Create a New Test Project
+
+```bash
+optics init --name my_test_project --template contact
+```
+
+This copies the `contact` sample — a complete, runnable project — into `./my_test_project`. Omit `--template` to scaffold an empty project you fill in yourself. Templates: `contact`, `clock`, `calendar`, `youtube`, `gmail_web`, `playwright`.
 
 ## :material-file-tree: Project Structure
 
 Your test project uses four main components that work together:
 
 ```text
-optics_framework/
-└── samples/
-    └── my_test_project/
-        ├── config.yaml
-        ├── modules/
-        |   └── modules.csv
-        ├── test_data/
-        |   ├── elements.csv
-        |   └── input_templates/
-        └── test_cases/
-            └── test_cases.csv
+my_test_project/          # created in your current directory
+├── config.yaml
+├── modules/
+|   └── modules.csv
+├── test_data/
+|   ├── elements.csv
+|   └── input_templates/
+└── test_cases/
+    └── test_cases.csv
 ```
 
 *`my_test_project/` - Your specific project name (you choose this)*
@@ -244,6 +239,8 @@ Test cases define **what** to test, modules define **how** to do it. This separa
 - Appium server running: `appium`
 - Android virtual device or physical device connected and verified: `adb devices`
 
+New to Appium or the Android SDK? Install them from their official docs — [Appium](https://appium.io/docs/en/latest/quickstart/) and the [Android platform tools](https://developer.android.com/tools/releases/platform-tools). The [Installation & Prerequisites](prerequisites.md) page lists what Optics itself needs.
+
 ### Always Dry Run Test Cases Before Executing
 
 ```bash
@@ -311,19 +308,17 @@ optics execute my_test_project
 ### 6. File Organization
 
 ```text
-optics_framework/
-    └── samples/
-        └── my_test_project/
-                ├── config.yaml
-                ├── modules/
-                |   └── modules.csv
-                ├── test_data/
-                |   ├── elements.csv
-                |   └── input_templates/
-                |       ├── button_login.png
-                |       └── field_username.png
-                └── test_cases/
-                    └── test_cases.csv
+my_test_project/
+├── config.yaml
+├── modules/
+|   └── modules.csv
+├── test_data/
+|   ├── elements.csv
+|   └── input_templates/
+|       ├── button_login.png
+|       └── field_username.png
+└── test_cases/
+    └── test_cases.csv
 ```
 
 ### 7. Debugging

--- a/docs/usage/CLI_usage.md
+++ b/docs/usage/CLI_usage.md
@@ -2,27 +2,29 @@
 
 This section describes the available commands for the Optics Framework CLI. The command you run is **`optics`**; the package you install is **`optics-framework`** (e.g. `pip install optics-framework`).
 
-## Setup Optics Framework
+## Setup: install engine backends
 
-To set up the Optics Framework, use the following command:
+The core install ships without drivers, OCR, or LLM backends — they are optional extras. `optics setup` installs them by name (the names match the `config.yaml` source keys, e.g. `appium`, `easyocr`, `google-vision`), pinned to your installed Optics version.
 
-To list all possible drivers:
+List installable engines:
 
 ```bash
 optics setup --list
 ```
 
-TUI way:
+Interactive picker (TUI):
 
 ```bash
 optics setup
 ```
 
-CLI way:
+Install by name:
 
 ```bash
-optics setup --install <driver_name1> <driver_name2> ...
+optics setup --install appium easyocr
 ```
+
+This is equivalent to `pip install "optics-framework[appium,easyocr]"`. See [Installation & Prerequisites](../prerequisites.md) for the full extras table and the external tooling (Appium server, adb, browsers) each engine needs.
 
 ## Executing Test Cases
 
@@ -34,7 +36,7 @@ optics execute <folder_path> [--runner <runner_name>] [--use-printer | --no-use-
 
 **Options:**
 
-- `<folder_path>`: Path to the project directory (contains `test_cases.csv`, `test_modules.csv`, `config.yaml`, etc.).
+- `<folder_path>`: Path to the project directory. The runner discovers test cases, modules, elements, and `config.yaml` by content, so either the sample subdir layout (`test_cases/`, `modules/`, `test_data/`) or flat CSVs work.
 - `--runner <runner_name>`: Test runner to use. Supported: `test_runner` (default), `pytest`.
 - `--use-printer` (default): Enable live result printer.
 - `--no-use-printer`: Disable live result printer.
@@ -59,11 +61,12 @@ optics init --name <project_name> --path <directory> --template <sample_name> --
 
 Use `--template <name>` to copy a sample layout and assets from `optics_framework/samples/`. Available template names include:
 
-- `contact` — Contact/sample layout
-- `clock` — Clock app sample
-- `youtube` — YouTube sample
-- `gmail_web` — Gmail web sample
-- `calendar` — Calendar sample
+- `contact` — Android Contacts sample (Appium)
+- `clock` — Android Clock sample (Appium)
+- `calendar` — Android Calendar sample (Appium; also shows an API collection)
+- `youtube` — YouTube sample (Appium; uses image templates)
+- `gmail_web` — Gmail web sample (Selenium)
+- `playwright` — Minimal web sample (Playwright)
 
 Exact values depend on the directories under `optics_framework/samples/`. Use only names that exist as subdirectories there.
 
@@ -140,17 +143,11 @@ optics --help
 
 ## Managing Configuration
 
-Manage framework configuration:
-
 ```bash
-optics config [--set <key> <value>] [--reset] [--list]
+optics config
 ```
 
-**Options:**
-
-- `--set <key> <value>`: Set a configuration key-value pair.
-- `--reset`: Reset all configurations to default.
-- `--list`: Display current configuration values.
+This opens an interactive TUI for editing the **global** config at `~/.optics/global_config.yaml` (arrow keys to move, space to edit, `s` to save, `q` to quit). It takes no flags.
 
 ## Checking Version
 
@@ -169,7 +166,4 @@ optics --version
     Options such as `--runner`, `--force`, and `--git-init` are optional. Omit them to use defaults (e.g. `test_runner` for `--runner`).
 
 !!! note "Driver installation"
-    When using `optics setup --install`, use driver names listed by `optics setup --list`.
-
-!!! info "Configuration persistence"
-    Configuration changed with `optics config --set` persists until you run `optics config --reset`.
+    When using `optics setup --install`, use engine names listed by `optics setup --list` (e.g. `appium`, `easyocr`).

--- a/docs/usage/keyword_usage.md
+++ b/docs/usage/keyword_usage.md
@@ -1,6 +1,6 @@
 # Keyword Usage
 
-This document outlines the available keywords for the Optics Framework, which can be used in the `test_modules.csv` file to define test steps. Keywords are derived from the framework's Python API, with method names converted to a space-separated format (e.g., `press_element` becomes `Press Element`). Each keyword corresponds to a specific action, verification, or control flow operation. Below, each keyword includes detailed parameter explanations to guide their usage.
+This document outlines the available keywords for the Optics Framework, which can be used in the `modules.csv` file to define test steps. Keywords are derived from the framework's Python API, with method names converted to a space-separated format (e.g., `press_element` becomes `Press Element`). Each keyword corresponds to a specific action, verification, or control flow operation. Below, each keyword includes detailed parameter explanations to guide their usage.
 
 ### Keyword data sources
 

--- a/docs/user_workflow.md
+++ b/docs/user_workflow.md
@@ -4,21 +4,21 @@ This guide walks you through the workflow for using the Optics Framework to crea
 
 ## Initial Setup
 
-To begin, the Optics Framework requires at least one YAML configuration file (`config.yaml`) and CSV files to define your tests. You can bootstrap a project using the `optics init` command:
+To begin, the Optics Framework requires a YAML configuration file (`config.yaml`) and CSV files to define your tests. You can bootstrap a project using the `optics init` command:
 
 ```bash
-optics init --name youtube --path ./youtube
+optics init --name my_project --template contact
 ```
 
-- **--name**: Specifies the project name (e.g., `youtube`).
-- **--path**: Defines where the project folder will be created.
-- **--template**: (Optional) Uses a predefined sample template to populate initial files.
+- **--name**: Specifies the project name (required).
+- **--path**: Directory where the project folder is created (default: current directory).
+- **--template**: (Optional) Copy a complete sample project (`contact`, `clock`, `calendar`, `youtube`, `gmail_web`, `playwright`).
 
-This command generates a project directory with a default structure, including a `config.yaml` and placeholder CSV files.
+With `--template`, the project is a ready-to-run copy of that sample. Without it, `optics init` scaffolds the subdirectory layout (`test_cases/`, `modules/`, `test_data/`) plus a commented starter `config.yaml` for you to fill in.
 
 ## CSV Use Cases
 
-The framework uses three primary CSV files to organize test logic: `test_cases.csv`, `test_modules.csv`, and `elements.csv`. Below are their purposes and examples.
+The framework uses three primary CSV files to organize test logic: `test_cases.csv`, `modules.csv`, and `elements.csv`. Below are their purposes and examples.
 
 ### test_cases.csv
 
@@ -49,7 +49,7 @@ Running youtube unknown,Repeat Test
 
 You can define setup and teardown steps in the test_cases.csv to ensure proper initialization and cleanup for both the entire test suite and individual test cases.
 
-### test_modules.csv
+### modules.csv
 
 This file lists all modules, their steps, and associated parameters. Columns include `module_name`, `module_step`, and optional `param_1` to `param_n` (as many parameters as needed).
 
@@ -96,7 +96,7 @@ METHOD,None
 List,"[""xpath"",""text"",""images""]"
 ```
 
-- **Element_Name**: The variable name used in `test_modules.csv`.
+- **Element_Name**: The variable name used in `modules.csv`.
 - **Element_ID**: The actual identifier (e.g., XPath, text value, or image filename). To include newlines in XPath or locator values, use `\n` in the CSV; use `\t` for tab and `\\` for a literal backslash.
 
 ## Configuration File (config.yaml)
@@ -160,25 +160,31 @@ exclude:
 Your project folder should look like this:
 
 ```
-/youtube
+youtube/
 ├── config.yaml
-├── elements.csv
-├── execution_output
-│   └── logs.log
-├── input_templates
-│   ├── home.png
-│   ├── sub.jpeg
-│   └── youtube.jpeg
-├── test_cases.csv
-└── test_modules.csv
+├── test_cases/
+│   └── test_cases.csv
+├── modules/
+│   └── modules.csv
+├── test_data/
+│   ├── elements.csv
+│   └── input_templates/
+│       ├── home.png
+│       ├── sub.jpeg
+│       └── youtube.jpeg
+└── execution_output/        # generated at run time
+    └── ...
 ```
 
-- **input_templates/**: Store any input images (e.g., `home.png`) referenced in `elements.csv`.
+- **test_data/input_templates/**: Store any input images (e.g., `home.png`) referenced in `elements.csv`.
 - **execution_output/**: Contains logs and other output generated during test runs.
+
+!!! note "File discovery is content-based"
+    The runner identifies each file by its contents, not its name or location, so a flat layout (all CSVs in the project root) also works. The subdirectory layout above is what the samples and `optics init` use.
 
 ## Using Keywords in Modules
 
-Modules in `test_modules.csv` use a predefined set of keywords (e.g., `Launch App`, `Press Element`, `Assert Presence`). For a complete list, refer to the [Keywords Reference](usage/keyword_usage.md).
+Modules in `modules.csv` use a predefined set of keywords (e.g., `Launch App`, `Press Element`, `Assert Presence`). For a complete list, refer to the [Keywords Reference](usage/keyword_usage.md).
 
 ## Samples For Your Reference
 Sample test scripts are provided to demonstrate the framework’s capabilities and guide users in writing their own. These examples show how texts, XPaths, and images can be used interchangeably, and how test data can be structured using CSV files.
@@ -207,13 +213,7 @@ To check for syntactical errors in your CSV files and configuration, run a dry r
 optics dry_run ./contact
 ```
 
-For a specific test case:
-
-```bash
-optics dry_run ./contact
-```
-
-This command simulates the test execution without interacting with the device, helping you catch issues early.
+`dry_run` takes a project folder (not a single test case). It simulates execution without interacting with the device — validating that every keyword exists and every `${element}` resolves — helping you catch issues early.
 
 ## Executing Tests
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ theme:
 nav:
   - Home: index.md
   - Introduction: introduction.md
+  - Installation & Prerequisites: prerequisites.md
   - Quick Start: quickstart.md
   - Configuration: configuration.md
   - User Workflow: user_workflow.md


### PR DESCRIPTION
Part **4 of 4** of the onboarding overhaul split out of #395. Docs only — rewrites onboarding to match actual CLI behaviour (best reviewed/merged after the setup-extras and init/config chunks, since it documents that behaviour).

## What changed
- **New Installation & Prerequisites page** (`docs/prerequisites.md`): Python 3.12+, the extras table, `optics setup`, and the external tooling each platform needs (Appium server, Node, Android SDK/adb, JDK, browsers, OCR binaries). Added to the mkdocs nav between Introduction and Quick Start.
- **README:** describe the extras-based install; fix the Quick Start flow (install engines → `init --template` → `dry_run` → `execute`); correct `optics version` → `optics --version`; fix the stale developer section (MkDocs not Sphinx, ruff/pre-commit not Black, `poetry install --with dev,test`, correct directory/package tree; drop the nonexistent `dev_requirements.txt`).
- **Quick Start / index:** use config-key setup names, add the `dry_run` step, fix the project-location diagrams (created in the CWD, not under `optics_framework/samples/`).
- **CLI Usage:** rewrite the setup section for extras; correct `optics config` (interactive TUI, no `--set/--reset/--list` flags); add `playwright` to the template list.
- **Configuration:** correct the load model — `optics execute`/`dry_run` read the project `config.yaml` and do not merge the global `~/.optics` config; document which surface each command touches.
- **User Workflow:** reconcile the project layout with the subdir scaffold, rename `test_modules.csv` → `modules.csv`, de-duplicate the `dry_run` example.

## Verification
`mkdocs build` succeeds; full suite green on top of current `main`: **565 passed, 1 skipped, 2 xfailed**.

Relates to #392 (config model), #393 (Docker/devcontainer docs + broken mcp link), #394 (sample/doc test-data inconsistencies).
