### PR TITLE
chore: add local SonarQube scan workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,7 @@ cython_debug/
 # Runtime execution artifacts (never commit)
 execution_output/
 MagicMock/
+
+# Local SonarQube scan (colima/docker) — credentials and scanner workdir
+.sonar-local/
+.scannerwork/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,15 @@ For an `execute` run, `config.execution_output_path` (default `<project>/executi
 - screenshots — saved by `ActionKeyword._save_screenshot_if_available` (`:288`), AOI overlays by `_maybe_save_aoi_screenshot` (`:32`), strategy-annotated frames by `_save_annotated_for_result` (`:54`). Element bboxes come back in the driver's **window coordinate space**, so they are scaled to the screenshot's **pixel space** via `utils.scale_bboxes_for_screenshot` (`common/utils.py:978`) before drawing (call site in `strategies.py`); skipping this skews annotations on high-DPI / scaled displays. Persistence to disk is gated by `Config.save_captures` (`config_handler.py:32`, default `True`) via `Verifier.capture_output_dir` — `optics serve` sessions explicitly disable it since HTTP callers get the bytes/XML in the response and don't need a disk copy.
 - an end-of-run screenshot + pagesource, captured once per batch run by `TestRunner._capture_end_of_run_artifacts` (`test_runnner.py:492`) and fed into on-screen error detection (see that section above).
 
+## Local SonarQube analysis
+
+CI runs static analysis on every push to `main` via `.github/workflows/mozarksonar.yml` (`sonarqube-scan-action` against a company-hosted SonarQube, using `sonar-project.properties` for the project key). To catch the same findings before pushing, `scripts/sonar-local.sh` runs an equivalent scan against a **local** SonarQube instance instead of the shared server:
+
+- One-time setup: `colima` + `docker` + `sonar-scanner` (Homebrew), a `sonarqube:community` Docker container, and a generated scanner token stored in `.sonar-local/token` (gitignored, never committed).
+- `./scripts/sonar-local.sh` is idempotent — it starts `colima` and the `sonarqube` container only if they aren't already running, waits for `/api/system/status` to report `UP`, runs `sonar-scanner`, then polls the compute-engine task (`ceTaskUrl` from `.scannerwork/report-task.txt`) before querying `/api/qualitygates/project_status` — querying the quality gate before the server finishes processing the report returns a stale/empty `NONE` status, so the poll step is load-bearing.
+- Dashboard: `http://localhost:9000/dashboard?id=optics-framework` (login `admin`, password in `.sonar-local/admin-password`).
+- The colima VM and container persist across runs (not auto-stopped) so repeat scans are fast; stop them with `docker stop sonarqube` / `colima stop` if you want to reclaim the ~2-4GB they hold.
+
 ## Working agreement (how to collaborate here)
 
 - **Never co-author commits with your name.** Do not add `Co-Authored-By: Claude ...` (or any AI attribution) trailer to commit messages or PR bodies. Commits are authored solely by the human committer.
@@ -232,4 +241,5 @@ optics generate <folder>                   # emit pytest/robot code from CSV/YAM
 optics serve                               # FastAPI server exposing keyword endpoints
 optics live [folder]                       # interactive REPL/TUI: run keywords (or NL) against a live target
 optics mcp [--transport http]              # MCP server exposing keywords as tools/resources (needs [mcp] extra)
+./scripts/sonar-local.sh                   # local SonarQube scan before pushing (see "Local SonarQube analysis" above)
 ```

--- a/scripts/sonar-local.sh
+++ b/scripts/sonar-local.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Run a local SonarQube analysis before raising a PR.
+#
+# One-time setup (already done for this checkout): colima + docker + sonar-scanner
+# installed via Homebrew, a `sonarqube` container created, and a scanner token
+# generated into .sonar-local/token (gitignored). This script only starts what
+# isn't already running, then runs the scan.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SONAR_URL="http://localhost:9000"
+TOKEN_FILE="$REPO_ROOT/.sonar-local/token"
+
+if [ ! -f "$TOKEN_FILE" ]; then
+  echo "Missing $TOKEN_FILE — run the one-time setup first (see conversation history / README)." >&2
+  exit 1
+fi
+
+if ! colima status >/dev/null 2>&1; then
+  echo "Starting colima..."
+  colima start
+fi
+
+if ! docker inspect -f '{{.State.Running}}' sonarqube >/dev/null 2>&1; then
+  echo "Container 'sonarqube' does not exist — creating it..."
+  docker run -d --name sonarqube \
+    -p 9000:9000 \
+    -v sonarqube_data:/opt/sonarqube/data \
+    -v sonarqube_extensions:/opt/sonarqube/extensions \
+    -v sonarqube_logs:/opt/sonarqube/logs \
+    sonarqube:community
+elif [ "$(docker inspect -f '{{.State.Running}}' sonarqube)" != "true" ]; then
+  echo "Starting existing 'sonarqube' container..."
+  docker start sonarqube >/dev/null
+fi
+
+echo "Waiting for SonarQube to be UP..."
+for _ in $(seq 1 60); do
+  resp="$(curl -s "$SONAR_URL/api/system/status" || true)"
+  if echo "$resp" | grep -q '"status":"UP"'; then
+    break
+  fi
+  sleep 5
+done
+if ! echo "$resp" | grep -q '"status":"UP"'; then
+  echo "SonarQube did not become ready in time. Last status: $resp" >&2
+  exit 1
+fi
+
+TOKEN="$(cat "$TOKEN_FILE")"
+REPORT_FILE="$REPO_ROOT/.scannerwork/report-task.txt"
+
+sonar-scanner \
+  -Dsonar.host.url="$SONAR_URL" \
+  -Dsonar.token="$TOKEN" \
+  -Dsonar.projectBaseDir="$REPO_ROOT"
+
+# The scanner only submits the report; SonarQube processes it asynchronously.
+# Poll the compute-engine task so the quality gate query below reflects this run.
+CE_TASK_URL="$(grep '^ceTaskUrl=' "$REPORT_FILE" | cut -d= -f2-)"
+echo
+echo "Waiting for server-side report processing..."
+for _ in $(seq 1 30); do
+  task_resp="$(curl -s -u "$TOKEN:" "$CE_TASK_URL")"
+  task_status="$(echo "$task_resp" | python3 -c "import json,sys; print(json.load(sys.stdin)['task']['status'])")"
+  if [ "$task_status" = "SUCCESS" ] || [ "$task_status" = "FAILED" ] || [ "$task_status" = "CANCELED" ]; then
+    break
+  fi
+  sleep 2
+done
+echo "Report processing status: $task_status"
+
+echo
+echo "Quality gate status:"
+curl -s -u "$TOKEN:" "$SONAR_URL/api/qualitygates/project_status?projectKey=optics-framework" \
+  | python3 -m json.tool
+
+echo
+echo "Dashboard: $SONAR_URL/dashboard?id=optics-framework"


### PR DESCRIPTION
## Summary
- Adds `scripts/sonar-local.sh`, which runs a SonarQube scan against a **local** SonarQube instance (colima + docker + sonar-scanner) equivalent to the `mozarksonar.yml` CI check, so findings surface before pushing instead of only after.
- Documents the one-time setup and the script's behavior (including why it polls the compute-engine task before reading the quality gate) in `CLAUDE.md`.
- Gitignores `.sonar-local/` (generated credentials/token) and `.scannerwork/` (scanner workdir) — neither is ever committed.

## Why local instead of pointing at the CI SonarQube host
No personal token for the shared/company-hosted SonarQube server, and running local/WIP-branch scans against it would pollute its project history. A fully local server sidesteps both.

## Test plan
- [x] Ran `./scripts/sonar-local.sh` end-to-end against this repo: colima/container auto-start, scan completes, quality gate reads back `OK` with `new_violations: 0`
- [x] `poetry run pre-commit run --files .gitignore CLAUDE.md scripts/sonar-local.sh` — all hooks pass
- [ ] Reviewer: confirm `sonarqube:community` (OSS edition) is an acceptable local stand-in for whatever edition the company-hosted server runs — rule/plugin sets can differ between editions