### PR TITLE
fix: pin and wheel-only-restrict pip/poetry installs across CI and Docker

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,7 +24,10 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocstrings[python] mkdocs-minify-plugin
+      # jsmin/csscompressor are sdist-only on PyPI, hence --no-binary.
+      - run: |
+          pip install --no-cache-dir --only-binary=:all: --no-binary=jsmin,csscompressor \
+            mkdocs-material==9.7.6 "mkdocstrings[python]==1.0.4" mkdocs-minify-plugin==0.8.0
       - run: mkdocs build
 
   deploy:
@@ -51,5 +54,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocstrings[python] mkdocs-minify-plugin
+      - run: |
+          pip install --no-cache-dir --only-binary=:all: --no-binary=jsmin,csscompressor \
+            mkdocs-material==9.7.6 "mkdocstrings[python]==1.0.4" mkdocs-minify-plugin==0.8.0
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,8 +18,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          pip install --no-cache-dir --only-binary=:all: poetry==2.4.1
 
       - name: Configure Poetry
         run: poetry config virtualenvs.create false

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ cython_debug/
 # Runtime execution artifacts (never commit)
 execution_output/
 MagicMock/
+
+# Local SonarQube scan — scanner workdir and any local token
+.sonar-local/
+.scannerwork/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,10 @@ For an `execute` run, `config.execution_output_path` (default `<project>/executi
 - screenshots — saved by `ActionKeyword._save_screenshot_if_available` (`:288`), AOI overlays by `_maybe_save_aoi_screenshot` (`:32`), strategy-annotated frames by `_save_annotated_for_result` (`:54`). Element bboxes come back in the driver's **window coordinate space**, so they are scaled to the screenshot's **pixel space** via `utils.scale_bboxes_for_screenshot` (`common/utils.py:978`) before drawing (call site in `strategies.py`); skipping this skews annotations on high-DPI / scaled displays. Persistence to disk is gated by `Config.save_captures` (`config_handler.py:32`, default `True`) via `Verifier.capture_output_dir` — `optics serve` sessions explicitly disable it since HTTP callers get the bytes/XML in the response and don't need a disk copy.
 - an end-of-run screenshot + pagesource, captured once per batch run by `TestRunner._capture_end_of_run_artifacts` (`test_runnner.py:492`) and fed into on-screen error detection (see that section above).
 
+## Local SonarQube analysis
+
+CI runs static analysis on every push to `main` via `.github/workflows/mozarksonar.yml` (`sonarqube-scan-action` against a company-hosted SonarQube, project key from `sonar-project.properties`). To catch the same findings before pushing, run the `sonarsource/sonar-scanner-cli` container against a local `sonarqube:community` container — see [Local Static Analysis](docs/contribution/developer_guide.md#5-local-static-analysis-sonarqube-optional) in the developer guide.
+
 ## Working agreement (how to collaborate here)
 
 - **Never co-author commits with your name.** Do not add `Co-Authored-By: Claude ...` (or any AI attribution) trailer to commit messages or PR bodies. Commits are authored solely by the human committer.

--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -31,21 +31,23 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    && rm -rf /var/lib/apt/lists/*
 
 # Install common Python packages and optics-framework wheel and vision backend
-RUN pip install --no-cache-dir \
-   appium-python-client playwright \
+RUN pip install --no-cache-dir --only-binary=:all: \
+   appium-python-client==4.5.1 playwright==1.61.0 \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \
         echo "ERROR: No wheel in dist/. Run 'poetry build' first or set WHL_FILE to the .whl filename."; \
         exit 1; \
       fi \
-   && pip install --no-cache-dir "$WHEEL" \
+   && WHEEL_VERSION=$(basename "$WHEEL" .whl | cut -d- -f2) \
+   && pip install --no-cache-dir --only-binary=:all: --find-links="$(dirname "$WHEEL")" \
+        "optics-framework==${WHEEL_VERSION}" \
    && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-      pip install --no-cache-dir easyocr; \
+      pip install --no-cache-dir --only-binary=:all: easyocr==1.7.2; \
    elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-      pip install --no-cache-dir google-cloud-vision; \
+      pip install --no-cache-dir --only-binary=:all: google-cloud-vision==3.15.0; \
    elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-      pip install --no-cache-dir pytesseract; \
+      pip install --no-cache-dir --only-binary=:all: pytesseract==0.3.13; \
    fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/mcp/dev/Dockerfile
+++ b/Docker/mcp/dev/Dockerfile
@@ -30,21 +30,23 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    && rm -rf /var/lib/apt/lists/*
 
 # Install common Python packages and optics-framework wheel with MCP extra and vision backend
-RUN pip install --no-cache-dir \
-   appium-python-client playwright \
+RUN pip install --no-cache-dir --only-binary=:all: \
+   appium-python-client==4.5.1 playwright==1.61.0 \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \
         echo "ERROR: No wheel in dist/. Run 'poetry build' first or set WHL_FILE to the .whl filename."; \
         exit 1; \
       fi \
-   && pip install --no-cache-dir "${WHEEL}[mcp]" \
+   && WHEEL_VERSION=$(basename "$WHEEL" .whl | cut -d- -f2) \
+   && pip install --no-cache-dir --only-binary=:all: --find-links="$(dirname "$WHEEL")" \
+        "optics-framework[mcp]==${WHEEL_VERSION}" \
    && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-      pip install --no-cache-dir easyocr; \
+      pip install --no-cache-dir --only-binary=:all: easyocr==1.7.2; \
    elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-      pip install --no-cache-dir google-cloud-vision; \
+      pip install --no-cache-dir --only-binary=:all: google-cloud-vision==3.15.0; \
    elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-      pip install --no-cache-dir pytesseract; \
+      pip install --no-cache-dir --only-binary=:all: pytesseract==0.3.13; \
    fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/mcp/prod/Dockerfile
+++ b/Docker/mcp/prod/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 ARG VISION_BACKEND=easyocr
 ENV VISION_BACKEND=${VISION_BACKEND}
 
+ARG OPTICS_FRAMEWORK_VERSION=1.8.6
 
 # Install system dependencies (first layer for cache)
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -23,18 +24,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir uv \
-    && uv pip install --system appium-python-client playwright \
+RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
+    && uv pip install --system --only-binary=:all: appium-python-client==4.5.1 playwright==1.61.0 \
     && playwright install-deps chromium firefox
 
 # Install optics-framework with MCP extra and vision backend (late layer for cache efficiency)
-RUN uv pip install --system "optics-framework[mcp]" \
+RUN uv pip install --system --only-binary=:all: "optics-framework[mcp]==${OPTICS_FRAMEWORK_VERSION}" \
     && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-        uv pip install --system easyocr; \
+        uv pip install --system --only-binary=:all: easyocr==1.7.2; \
     elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-        uv pip install --system google-cloud-vision; \
+        uv pip install --system --only-binary=:all: google-cloud-vision==3.15.0; \
     elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-        uv pip install --system pytesseract; \
+        uv pip install --system --only-binary=:all: pytesseract==0.3.13; \
     fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/prod/Dockerfile
+++ b/Docker/prod/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 ARG VISION_BACKEND=easyocr
 ENV VISION_BACKEND=${VISION_BACKEND}
 
+ARG OPTICS_FRAMEWORK_VERSION=1.8.6
 
 # Install system dependencies (first layer for cache)
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -23,18 +24,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir uv \
-    && uv pip install --system appium-python-client playwright \
+RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
+    && uv pip install --system --only-binary=:all: appium-python-client==4.5.1 playwright==1.61.0 \
     && playwright install-deps chromium firefox
 
 # Install optics-framework and vision backend (late layer for cache efficiency)
-RUN uv pip install --system optics-framework \
+RUN uv pip install --system --only-binary=:all: "optics-framework==${OPTICS_FRAMEWORK_VERSION}" \
     && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-        uv pip install --system easyocr; \
+        uv pip install --system --only-binary=:all: easyocr==1.7.2; \
     elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-        uv pip install --system google-cloud-vision; \
+        uv pip install --system --only-binary=:all: google-cloud-vision==3.15.0; \
     elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-        uv pip install --system pytesseract; \
+        uv pip install --system --only-binary=:all: pytesseract==0.3.13; \
     fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/docs/contribution/developer_guide.md
+++ b/docs/contribution/developer_guide.md
@@ -153,3 +153,29 @@ poetry run cz commit
 This will interactively guide you through creating a commit message that follows the Conventional Commits format.
 
 **NOTE:** If you installed the pre-commit hooks (step 1.3), they will automatically run on each commit to check code quality and validate commit messages.
+
+## 5. Local Static Analysis (SonarQube, Optional)
+
+CI runs SonarQube static analysis on every push to `main` (`.github/workflows/mozarksonar.yml`). To catch the same findings before you push, run the scanner locally against a throwaway SonarQube container instead of the shared server.
+
+Start a local SonarQube server once:
+
+```bash
+docker run -d --name sonarqube -p 9000:9000 sonarqube:community
+```
+
+Open `http://localhost:9000` (default login `admin`/`admin`), wait for it to finish starting, and generate a token under **My Account → Security**.
+
+Then run the scanner from the repo root, pointing it at that server:
+
+```bash
+docker run --rm \
+    -v "$(pwd):/usr/src" \
+    --network=host \
+    -e SONAR_HOST_URL="http://localhost:9000" \
+    -e SONAR_SCANNER_OPTS="-Dsonar.projectKey=optics-framework" \
+    -e SONAR_TOKEN="<your-token>" \
+    sonarsource/sonar-scanner-cli
+```
+
+Findings are printed by the scanner and shown on the dashboard at `http://localhost:9000/dashboard?id=optics-framework`. The scanner writes a `.scannerwork/` directory into the repo; it's gitignored.

--- a/tools/mock_remote_ocr/scalable/Dockerfile
+++ b/tools/mock_remote_ocr/scalable/Dockerfile
@@ -17,14 +17,14 @@ RUN apt-get update \
      libxrender1 \
  && rm -rf /var/lib/apt/lists/*
 
-# Copy poetry/pyproject if present to cache deps
-COPY pyproject.toml /app/
+COPY optics_framework /app/optics_framework
+COPY pyproject.toml README.md /app/
 
 # Install pip and build dependencies
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --upgrade --only-binary=:all: pip==26.1.2 setuptools==83.0.0 wheel==0.47.0
 
-# Install production dependencies into a wheelhouse
-RUN pip wheel --wheel-dir=/wheels . || true
+# --only-binary=:all: still builds this local project; only its deps must be wheels
+RUN pip wheel --only-binary=:all: --wheel-dir=/wheels .
 
 # ---- Final stage ----
 FROM python:3.12-slim
@@ -53,14 +53,12 @@ COPY optics_framework /app/optics_framework
 COPY tools/mock_remote_ocr /app/tools/mock_remote_ocr
 COPY pyproject.toml /app/
 
-# Install runtime deps from wheelhouse if present, otherwise fallback to pip install
 COPY --from=build /wheels /wheels
-RUN if [ -d /wheels ] && [ "$(ls -A /wheels)" ]; then \
-        pip install --no-cache-dir /wheels/*; \
-    else \
-        pip install --no-cache-dir .; \
-    fi && \
-    pip install --no-cache-dir "easyocr" "gunicorn>=20.0" "uvicorn[standard]" && \
+RUN WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
+    pip install --no-cache-dir --only-binary=:all: --no-index --find-links=/wheels \
+        "optics-framework==${WHEEL_VERSION}" && \
+    pip install --no-cache-dir --only-binary=:all: \
+        easyocr==1.7.2 gunicorn==26.0.0 "uvicorn[standard]==0.37.0" && \
     mkdir -p /home/optics && \
     python - <<'PY'
 import os

--- a/tools/mock_remote_ocr/scalable/Dockerfile.cuda
+++ b/tools/mock_remote_ocr/scalable/Dockerfile.cuda
@@ -25,25 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-pip \
   python3-venv \
  && rm -rf /var/lib/apt/lists/* \
- && python3 -m pip install --upgrade pip setuptools wheel
+ && python3 -m pip install --upgrade --only-binary=:all: pip==26.1.2 setuptools==83.0.0 wheel==0.47.0
 
-# Copy dependency files and build wheels if present
-COPY pyproject.toml /app/
-RUN python3 -m pip wheel --wheel-dir=/wheels . || true
+# --only-binary=:all: still builds this local project; only its deps must be wheels
+COPY optics_framework /app/optics_framework
+COPY pyproject.toml README.md /app/
+RUN python3 -m pip wheel --only-binary=:all: --wheel-dir=/wheels .
 
 # Copy application
-COPY optics_framework /app/optics_framework
 COPY tools/mock_remote_ocr /app/tools/mock_remote_ocr
-COPY pyproject.toml /app/
 
-# Install runtime deps
-COPY --from=0 /wheels /wheels
-RUN if [ -d /wheels ] && [ "$(ls -A /wheels)" ]; then \
-      python3 -m pip install --no-cache-dir /wheels/*; \
-    else \
-      python3 -m pip install --no-cache-dir .; \
-    fi && \
-    python3 -m pip install --no-cache-dir "easyocr" "gunicorn>=20.0" "uvicorn[standard]" && \
+RUN WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
+    python3 -m pip install --no-cache-dir --only-binary=:all: --no-index --find-links=/wheels \
+        "optics-framework==${WHEEL_VERSION}" && \
+    python3 -m pip install --no-cache-dir --only-binary=:all: \
+        easyocr==1.7.2 gunicorn==26.0.0 "uvicorn[standard]==0.37.0" && \
     mkdir -p /home/optics && \
     python3 - <<'PY'
 import os


### PR DESCRIPTION
## Summary

Fixes SonarQube security-hotspot findings across the CI workflows and Docker images: unpinned installs and source builds that let a dependency's `setup.py`/build backend run arbitrary code.

- **CI workflows** (`publish_docs.yml`, `pypi-publish.yml`): pin mkdocs deps to poetry.lock versions, restrict to prebuilt wheels, and replace the `curl | python3` Poetry installer with a pinned, TLS/hash-verified `pip install poetry==2.4.1`.
- **App/MCP images** (`Docker/{dev,prod}`, `Docker/mcp/{dev,prod}`): pin every dep with `--only-binary=:all:`, install the locally built wheel via a derived-version `--find-links` pin, and add an `OPTICS_FRAMEWORK_VERSION` build arg for the prod images that pulled from PyPI unpinned.
- **Mock OCR images** (`tools/mock_remote_ocr/scalable/Dockerfile{,.cuda}`): copy the full source so the wheelhouse builds a real wheel, drop the `|| true` fallback, and install wheel-only from that wheelhouse.

Also documents a local SonarQube scan (via `sonarsource/sonar-scanner-cli`) in the developer guide for catching these findings before pushing.

## Notes

- `--only-binary=:all:` is applied wherever a *named* third-party package is installed; local source (`pip wheel .`) still builds, since that's the repo's own unpublished code, not a third-party build.
- `jsmin`/`csscompressor` are sdist-only on PyPI, so they're carved out with `--no-binary`.
- `poetry install --sync` has no wheel-only equivalent (it builds via each package's PEP 517 backend); accepted as residual risk on the ephemeral release runner.

## Validation

- Version pins checked against a live `pip`/`uv --only-binary=:all:` resolution on `python:3.12-slim`.
- `Docker/mcp/dev/Dockerfile` built end-to-end; `pre-commit` clean on all changed files.
