### PR TITLE
fix(appium): honor index in AppiumFindElement Text branch

### DIFF
--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -113,8 +113,16 @@ class AppiumFindElement(ElementSourceInterface):
         elif element_type == 'Text':
             locator = element[len("text="):] if element.lower().startswith("text=") else element
             try:
-                found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)
-                return found_element
+                found_elements = driver.find_elements(AppiumBy.ACCESSIBILITY_ID, locator)
+                index_to_use = 0 if index is None else index
+                if not found_elements or index_to_use < 0 or index_to_use >= len(found_elements):
+                    raise OpticsError(
+                        Code.E0201,
+                        message=f"Element of type {element_type} and index {index_to_use} not found using: {element}",
+                    )
+                return found_elements[index_to_use]
+            except OpticsError:
+                raise
             except NoSuchElementException as e:
                 raise OpticsError(Code.E0201, message=f"Element of type {element_type} not found using: {element}", cause=e) from e
             except Exception as e:

--- a/tests/units/engines/elementsources/test_appium_find_element.py
+++ b/tests/units/engines/elementsources/test_appium_find_element.py
@@ -139,3 +139,50 @@ class TestAssertElementsVisible:
     def test_invalid_rule_raises_immediately(self, source):
         with pytest.raises(OpticsError):
             source.assert_elements_visible(["Anything"], timeout=1, rule="bogus")
+
+
+class TestLocateIndex:
+    """locate() must honor `index` when several elements share a locator.
+
+    The Text branch previously used find_element (singular), so it always returned
+    the first match and silently ignored index -- this locks in that index selects the
+    Nth match and that an out-of-range index raises E0201 (mirroring the Class branch)."""
+
+    def test_text_index_selects_nth_accessibility_id_match(self, source):
+        first, second = MagicMock(name="first"), MagicMock(name="second")
+        source.driver.driver.find_elements.return_value = [first, second]
+
+        assert source.locate("NEXT", index=1) is second
+
+    def test_text_index_none_selects_first_match(self, source):
+        first, second = MagicMock(name="first"), MagicMock(name="second")
+        source.driver.driver.find_elements.return_value = [first, second]
+
+        assert source.locate("NEXT") is first
+
+    def test_text_index_out_of_range_raises_e0201(self, source):
+        source.driver.driver.find_elements.return_value = [MagicMock(), MagicMock()]
+
+        with pytest.raises(OpticsError) as exc:
+            source.locate("NEXT", index=2)
+        assert exc.value.code == Code.E0201
+
+    def test_text_no_matches_raises_e0201(self, source):
+        source.driver.driver.find_elements.return_value = []
+
+        with pytest.raises(OpticsError) as exc:
+            source.locate("NEXT")
+        assert exc.value.code == Code.E0201
+
+    def test_class_index_selects_nth_class_name_match(self, source):
+        first, second = MagicMock(name="first"), MagicMock(name="second")
+        source.driver.driver.find_elements.return_value = [first, second]
+
+        assert source.locate("android.widget.Button", index=1) is second
+
+    def test_class_index_out_of_range_raises_e0201(self, source):
+        source.driver.driver.find_elements.return_value = [MagicMock(), MagicMock()]
+
+        with pytest.raises(OpticsError) as exc:
+            source.locate("android.widget.Button", index=5)
+        assert exc.value.code == Code.E0201


### PR DESCRIPTION
## Summary

The `Text` (accessibility-id) branch of `AppiumFindElement.locate()` ignored the `index` argument, so `press_element` / `press_element_with_index` could never disambiguate among multiple elements sharing the same accessibility id — it always returned the first match.

## Root cause

```python
found_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)  # singular, index dropped
return found_element
```

`find_element` (singular) returns only the first match, and `index` was never consulted. So `index="2"` behaved identically to `index="0"`. The sibling `Class` branch already did this correctly with `find_elements` + `index`; the `Text` branch was simply inconsistent.