### PR TITLE
fix(actions): apply offset_x/offset_y to element-resolved presses

### DIFF
--- a/docs/architecture/strategies.md
+++ b/docs/architecture/strategies.md
@@ -747,10 +747,24 @@ def press_element(
     - Error aggregation
     """
     # located parameter is provided by decorator
+    offset_x_i, offset_y_i = int(offset_x), int(offset_y)
     if isinstance(located, tuple):
+        # Coordinate match (OCR/image) -- press at it directly, offset applied.
         x, y = located
-        self.driver.press_coordinates(x + int(offset_x), y + int(offset_y))
+        for _ in range(int(repeat)):
+            self.driver.press_coordinates(x + offset_x_i, y + offset_y_i)
+    elif offset_x_i or offset_y_i:
+        # WebElement match with an offset: clicking it would ignore the offset,
+        # so press by its centre + offset instead (see _element_centre).
+        centre = self._element_centre(located)
+        if centre is not None:
+            cx, cy = centre
+            for _ in range(int(repeat)):
+                self.driver.press_coordinates(cx + offset_x_i, cy + offset_y_i)
+        else:
+            self.driver.press_element(located, int(repeat))
     else:
+        # WebElement match, no offset -- a plain click.
         self.driver.press_element(located, int(repeat))
 ```
 

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -464,6 +464,23 @@ class ActionKeyword:
         if screenshot_np is not None:
             utils.save_screenshot(screenshot_np, name, output_dir=self.execution_dir)
 
+    @staticmethod
+    def _element_centre(element: Any) -> Optional[Tuple[int, int]]:
+        """Centre (x, y) of a located WebElement in the driver's coordinate space.
+
+        Reads location/size (available on both Appium and Selenium WebElements);
+        returns None if either is unavailable, so callers can fall back.
+        """
+        try:
+            loc = element.location
+            size = element.size
+            return (
+                int(loc["x"] + size["width"] / 2),
+                int(loc["y"] + size["height"] / 2),
+            )
+        except (AttributeError, KeyError, TypeError):
+            return None
+
     # Click actions
     @with_self_healing
     def press_element(
@@ -485,12 +502,28 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         """
+        offset_x_i, offset_y_i = int(offset_x), int(offset_y)
         if isinstance(located, tuple):
             x, y = located
             internal_logger.info(
-                f"Pressing at coordinates ({x + int(offset_x)}, {y + int(offset_y)}) with offset ({offset_x}, {offset_y})")
+                f"Pressing at coordinates ({x + offset_x_i}, {y + offset_y_i}) with offset ({offset_x_i}, {offset_y_i})")
             self.driver.press_coordinates(
-                x + int(offset_x), y + int(offset_y), event_name)
+                x + offset_x_i, y + offset_y_i, event_name)
+        elif offset_x_i or offset_y_i:
+            # located is a WebElement (accessibility/XPath). Clicking it directly would
+            # ignore offset_x/offset_y, so derive its centre and press by coordinates
+            # with the offset applied.
+            centre = self._element_centre(located)
+            if centre is not None:
+                cx, cy = centre
+                internal_logger.info(
+                    f"Pressing at coordinates ({cx + offset_x_i}, {cy + offset_y_i}) with offset ({offset_x_i}, {offset_y_i})")
+                for _ in range(int(repeat)):
+                    self.driver.press_coordinates(cx + offset_x_i, cy + offset_y_i, event_name)
+            else:
+                internal_logger.warning(
+                    f"Could not determine element centre for '{element}'; pressing element directly (offset ignored).")
+                self.driver.press_element(located, int(repeat), event_name)
         else:
             internal_logger.info(f"Pressing element '{element}'")
             self.driver.press_element(located, int(repeat), event_name)

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -466,13 +466,13 @@ class ActionKeyword:
 
     @staticmethod
     def _element_centre(element: Any) -> Optional[Tuple[int, int]]:
-        """Centre (x, y) of a located WebElement in the driver's coordinate space.
+        """Centre (x, y) of a located WebElement, or None if geometry is unavailable.
 
-        Reads location/size (available on both Appium and Selenium WebElements);
-        returns None if either is unavailable, so callers can fall back.
+        Uses ``location_once_scrolled_into_view`` (scrolls it on-screen first, so an
+        offset lands even on a partly off-screen element); falls back to ``location``.
         """
         try:
-            loc = element.location
+            loc = getattr(element, "location_once_scrolled_into_view", None) or element.location
             size = element.size
             return (
                 int(loc["x"] + size["width"] / 2),
@@ -510,9 +510,8 @@ class ActionKeyword:
             self.driver.press_coordinates(
                 x + offset_x_i, y + offset_y_i, event_name)
         elif offset_x_i or offset_y_i:
-            # located is a WebElement (accessibility/XPath). Clicking it directly would
-            # ignore offset_x/offset_y, so derive its centre and press by coordinates
-            # with the offset applied.
+            # located is a WebElement: clicking it would ignore the offset, so press by
+            # its centre + offset instead. _element_centre scrolls it into view first.
             centre = self._element_centre(located)
             if centre is not None:
                 cx, cy = centre

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -513,8 +513,8 @@ class ActionKeyword:
             x, y = located
             internal_logger.info(
                 f"Pressing at coordinates ({x + offset_x_i}, {y + offset_y_i}) with offset ({offset_x_i}, {offset_y_i})")
-            self.driver.press_coordinates(
-                x + offset_x_i, y + offset_y_i, event_name)
+            for _ in range(int(repeat)):
+                self.driver.press_coordinates(x + offset_x_i, y + offset_y_i, event_name)
         elif offset_x_i or offset_y_i:
             # located is a WebElement: clicking it would ignore the offset, so press by
             # its centre + offset instead. _element_centre scrolls it into view first.

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -464,22 +464,28 @@ class ActionKeyword:
         if screenshot_np is not None:
             utils.save_screenshot(screenshot_np, name, output_dir=self.execution_dir)
 
-    @staticmethod
-    def _element_centre(element: Any) -> Optional[Tuple[int, int]]:
-        """Centre (x, y) of a located WebElement, or None if geometry is unavailable.
+    def _element_centre(self, element: Any) -> Optional[Tuple[int, int]]:
+        """Centre (x, y) of a located element, or None if geometry is unavailable.
 
-        Uses ``location_once_scrolled_into_view`` (scrolls it on-screen first, so an
-        offset lands even on a partly off-screen element); falls back to ``location``.
+        Prefers ``location_once_scrolled_into_view``: on web it scrolls the element
+        on-screen and returns viewport coords, which is what ``press_coordinates``
+        expects. It is JS-backed, so it raises in a native Appium context - fall back
+        to the source-agnostic bbox accessor there.
         """
         try:
-            loc = getattr(element, "location_once_scrolled_into_view", None) or element.location
+            loc = element.location_once_scrolled_into_view
             size = element.size
             return (
                 int(loc["x"] + size["width"] / 2),
                 int(loc["y"] + size["height"] / 2),
             )
-        except (AttributeError, KeyError, TypeError):
+        except Exception as exc:  # noqa: BLE001 - JS-backed, unsupported on native
+            internal_logger.debug(f"Scrolled-into-view geometry unavailable: {exc}")
+        bbox = self.element_source.get_bbox_for_element(element)
+        if bbox is None:
             return None
+        (x1, y1), (x2, y2) = bbox
+        return ((x1 + x2) // 2, (y1 + y2) // 2)
 
     # Click actions
     @with_self_healing

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -154,6 +154,50 @@ class TestPressElementWithIndex:
                 action_keyword.press_element("ghost_button")
         assert exc_info.value.code in (Code.E0201, Code.X0201)
 
+    def test_offset_on_webelement_presses_centre_plus_offset(self, action_keyword, mock_dependencies):
+        """Offset on a WebElement presses centre+offset via coordinates, not click.
+        Centre of (100,200)+(50x80) is (125,240); +offset (10,-20) -> (135,220)."""
+        element = MagicMock()
+        element.location_once_scrolled_into_view = {"x": 100, "y": 200}
+        element.size = {"width": 50, "height": 80}
+        with self._mock_locate(action_keyword, element):
+            action_keyword.press_element("//zone", offset_x="10", offset_y="-20")
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(135, 220, None)
+        mock_dependencies['driver'].press_element.assert_not_called()
+
+    def test_offset_on_partly_offscreen_element_uses_scrolled_into_view_coords(
+        self, action_keyword, mock_dependencies
+    ):
+        """Partly off-screen element: centre must come from the scrolled-into-view
+        coords, not the raw off-viewport .location."""
+        element = MagicMock()
+        element.location = {"x": 0, "y": -500}            # off the top of the viewport
+        element.location_once_scrolled_into_view = {"x": 100, "y": 200}  # after scrolling in
+        element.size = {"width": 50, "height": 80}
+        with self._mock_locate(action_keyword, element):
+            action_keyword.press_element("//zone", offset_x="10", offset_y="-20")
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(135, 220, None)
+
+    def test_offset_on_webelement_repeats_coordinate_press(self, action_keyword, mock_dependencies):
+        element = MagicMock()
+        element.location_once_scrolled_into_view = {"x": 0, "y": 0}
+        element.size = {"width": 20, "height": 20}
+        with self._mock_locate(action_keyword, element):
+            action_keyword.press_element("//zone", offset_x="5", offset_y="5", repeat="3")
+        assert mock_dependencies['driver'].press_coordinates.call_count == 3
+        mock_dependencies['driver'].press_coordinates.assert_called_with(15, 15, None)
+
+    def test_offset_on_webelement_without_geometry_falls_back_to_press_element(
+        self, action_keyword, mock_dependencies
+    ):
+        """If centre can't be derived (no location/size at all), fall back to clicking
+        the element rather than pressing bogus coordinates."""
+        element = MagicMock(spec=[])  # no location / size attributes
+        with self._mock_locate(action_keyword, element):
+            action_keyword.press_element("//zone", offset_x="10", offset_y="20")
+        mock_dependencies['driver'].press_coordinates.assert_not_called()
+        mock_dependencies['driver'].press_element.assert_called_once_with(element, 1, None)
+
 
 class TestScreenshotFailureFallback:
     """Tests for behavior when screenshot capture fails (e.g. secure/protected pages)."""

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -190,13 +190,29 @@ class TestPressElementWithIndex:
     def test_offset_on_webelement_without_geometry_falls_back_to_press_element(
         self, action_keyword, mock_dependencies
     ):
-        """If centre can't be derived (no location/size at all), fall back to clicking
-        the element rather than pressing bogus coordinates."""
+        """If centre can't be derived (no location/size, and no bbox from the element
+        source either), fall back to clicking the element rather than pressing bogus
+        coordinates."""
         element = MagicMock(spec=[])  # no location / size attributes
+        mock_dependencies['element_source'].get_bbox_for_element.return_value = None
         with self._mock_locate(action_keyword, element):
             action_keyword.press_element("//zone", offset_x="10", offset_y="20")
         mock_dependencies['driver'].press_coordinates.assert_not_called()
         mock_dependencies['driver'].press_element.assert_called_once_with(element, 1, None)
+
+    def test_offset_falls_back_to_bbox_when_scrolled_into_view_unsupported(
+        self, action_keyword, mock_dependencies
+    ):
+        """location_once_scrolled_into_view is JS-backed and raises on native Appium
+        (UiAutomator2 doesn't implement it); centre must fall back to the
+        source-agnostic bbox accessor instead of failing the whole press.
+        Bbox ((100,200),(150,280)) -> centre (125,240); +offset (10,-20) -> (135,220)."""
+        element = MagicMock(spec=[])  # accessing location_once_scrolled_into_view raises
+        mock_dependencies['element_source'].get_bbox_for_element.return_value = ((100, 200), (150, 280))
+        with self._mock_locate(action_keyword, element):
+            action_keyword.press_element("//zone", offset_x="10", offset_y="-20")
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(135, 220, None)
+        mock_dependencies['driver'].press_element.assert_not_called()
 
 
 class TestScreenshotFailureFallback:

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -214,6 +214,14 @@ class TestPressElementWithIndex:
         mock_dependencies['driver'].press_coordinates.assert_called_once_with(135, 220, None)
         mock_dependencies['driver'].press_element.assert_not_called()
 
+    def test_coordinate_result_with_repeat_repeats_press(self, action_keyword, mock_dependencies):
+        """A coordinate-located press (from an OCR/image match, not a WebElement) must
+        also honour `repeat`, not just the WebElement-offset branch."""
+        with self._mock_locate(action_keyword, (100, 150)):
+            action_keyword.press_element("button", offset_x="5", offset_y="5", repeat="3")
+        assert mock_dependencies['driver'].press_coordinates.call_count == 3
+        mock_dependencies['driver'].press_coordinates.assert_called_with(105, 155, None)
+
 
 class TestScreenshotFailureFallback:
     """Tests for behavior when screenshot capture fails (e.g. secure/protected pages)."""


### PR DESCRIPTION
## Summary

`press_element`'s `offset_x` / `offset_y` were silently ignored whenever the element resolved to a WebElement (accessibility / XPath match). The offset only ever took effect for coordinate-resolved matches (OCR / image), so an offset press against an accessibility- or XPath-located element just clicked the element centre.

## Root cause

```python
if isinstance(located, tuple):
    x, y = located
    self.driver.press_coordinates(x + int(offset_x), y + int(offset_y), event_name)  # offset applied
else:
    self.driver.press_element(located, int(repeat), event_name)                      # WebElement → offset dropped
```

`located` is a `(x, y)` tuple only for coordinate strategies; for accessibility/XPath it is a WebElement, and that branch never consulted `offset_x` / `offset_y`. So the offset reached the tap only for OCR/image matches and was discarded for every element-resolved match.