### PR TITLE
fix(strategies): enforce AOI for accessibility/XPath element matches

### DIFF
--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -604,14 +604,11 @@ class StrategyManager:
     ) -> bool:
         """True if a located WebElement's centre lies inside the AOI rectangle.
 
-        AOI is applied natively by strategies implementing ``locate_with_aoi`` (OCR /
-        image). Accessibility / XPath strategies return a WebElement and would otherwise
-        ignore the AOI, so this filters them by bounding box. The element centre is
-        compared as a percentage of the driver window against the AOI percentages
-        (percentages are resolution-independent, so no screenshot scaling is needed).
+        Filters accessibility/XPath matches (which return a WebElement and ignore the
+        AOI, unlike ``locate_with_aoi`` OCR/image strategies), comparing the centre as a
+        window percentage against the AOI. Fails open when bbox/window is unknown.
 
-        Fails open (returns True) when the bbox or window size can't be determined, so
-        behaviour is unchanged when the check can't run.
+        Centre-point test, so it can disagree with an OCR/image crop at the AOI edge.
         """
         element_source = getattr(strategy, "element_source", None)
         if element_source is None or not hasattr(element_source, "get_bbox_for_element"):

--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -598,6 +598,45 @@ class StrategyManager:
             execution_logger.info(f"Using AOI: x={aoi_x}%, y={aoi_y}%, width={aoi_width}%, height={aoi_height}%")
         return use_aoi
 
+    def _within_aoi(
+        self, strategy: "LocatorStrategy", value: Any,
+        aoi_x: float, aoi_y: float, aoi_width: float, aoi_height: float,
+    ) -> bool:
+        """True if a located WebElement's centre lies inside the AOI rectangle.
+
+        AOI is applied natively by strategies implementing ``locate_with_aoi`` (OCR /
+        image). Accessibility / XPath strategies return a WebElement and would otherwise
+        ignore the AOI, so this filters them by bounding box. The element centre is
+        compared as a percentage of the driver window against the AOI percentages
+        (percentages are resolution-independent, so no screenshot scaling is needed).
+
+        Fails open (returns True) when the bbox or window size can't be determined, so
+        behaviour is unchanged when the check can't run.
+        """
+        element_source = getattr(strategy, "element_source", None)
+        if element_source is None or not hasattr(element_source, "get_bbox_for_element"):
+            return True
+        try:
+            bbox = element_source.get_bbox_for_element(value)
+        except Exception:  # noqa: BLE001 - best-effort; fall back to not filtering
+            return True
+        window = utils._window_size_from_source(element_source)
+        if bbox is None or window is None:
+            return True
+        (x1, y1), (x2, y2) = bbox
+        win_w, win_h = window
+        if win_w <= 0 or win_h <= 0:
+            return True
+        cx = (x1 + x2) / 2 / win_w * 100
+        cy = (y1 + y2) / 2 / win_h * 100
+        inside = aoi_x <= cx <= aoi_x + aoi_width and aoi_y <= cy <= aoi_y + aoi_height
+        if not inside:
+            internal_logger.debug(
+                f"Element centre ({cx:.1f}%, {cy:.1f}%) outside AOI "
+                f"[{aoi_x},{aoi_y},{aoi_width},{aoi_height}]; skipping match."
+            )
+        return inside
+
     def _try_strategy_locate(
         self,
         strategy: "LocatorStrategy",
@@ -627,6 +666,12 @@ class StrategyManager:
                 value, annotated_frame = result[0], result[1]
             else:
                 value, annotated_frame = result, None
+            if use_aoi and locate_with_aoi is None and not isinstance(value, tuple):
+                # Strategy can't scope to the AOI itself (accessibility/XPath) — enforce
+                # it here so an out-of-AOI match falls through to an AOI-capable strategy.
+                if not self._within_aoi(strategy, value, aoi_x, aoi_y, aoi_width, aoi_height):
+                    execution_tracer.log_attempt(strategy, element, "fail", error="match outside AOI")
+                    return None
             execution_tracer.log_attempt(strategy, element, "success")
             return LocateResult(value, strategy, annotated_frame=annotated_frame)
         except Exception as e:

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -482,6 +482,39 @@ class TestLocateRealStrategies:
         assert exc_info.value.code == Code.E0201
 
 
+class TestTryStrategyLocateAoiFallthrough:
+    """AOI enforcement for strategies that can't scope natively (accessibility/XPath):
+    a WebElement match whose centre is outside the AOI is skipped, so locate() falls
+    through to an AOI-capable strategy; one inside is returned."""
+
+    def _stub_strategy(self, bbox):
+        source = MagicMock()
+        source.get_bbox_for_element.return_value = bbox
+        # spec omits locate_with_aoi, so the manager takes the non-native-AOI path.
+        strategy = MagicMock(spec=["supports", "locate", "element_source"])
+        strategy.supports.return_value = True
+        strategy.locate.return_value = MagicMock(name="webelement")  # a WebElement, not a tuple
+        strategy.element_source = source
+        return strategy
+
+    def _locate(self, bbox, aoi):
+        strategy = self._stub_strategy(bbox)
+        with patch.object(utils, "_window_size_from_source", return_value=(100, 100)):
+            return _sm(MagicMock())._try_strategy_locate(
+                strategy, "//div", "XPath", True, *aoi, index=0
+            )
+
+    def test_match_inside_aoi_is_returned(self):
+        # centre (50%,50%) inside AOI x25 y25 w50 h50
+        result = self._locate(((40, 40), (60, 60)), (25, 25, 50, 50))
+        assert result is not None and isinstance(result, LocateResult)
+
+    def test_match_outside_aoi_is_skipped(self):
+        # centre (5%,5%) outside the same AOI -> falls through (None)
+        result = self._locate(((0, 0), (10, 10)), (25, 25, 50, 50))
+        assert result is None
+
+
 class TestImageDetectionStrategy:
     """ImageDetectionStrategy locates an image element via image_detection."""
 


### PR DESCRIPTION
## Summary

`press_element`'s `aoi_x` / `aoi_y` / `aoi_width` / `aoi_height` were silently ignored whenever the element resolved via an accessibility or XPath strategy. The AOI only ever constrained the OCR / image strategies, so an AOI-scoped press against an element-source match could resolve and press an element outside the requested region.

## Root cause

In `StrategyManager._try_strategy_locate`, the AOI is only applied to strategies that implement `locate_with_aoi`:

```python
locate_with_aoi = getattr(strategy, "locate_with_aoi", None)
if use_aoi and locate_with_aoi is not None:
    result = locate_with_aoi(element, aoi_x, aoi_y, aoi_width, aoi_height, index=index)
else:
    result = strategy.locate(element, index=index)   # AOI dropped
```

Only `TextDetectionStrategy` (OCR) and `ImageDetectionStrategy` define `locate_with_aoi`. `TextElementStrategy` (accessibility) and `XPathStrategy` do not, and they run first in priority order, so their match was returned with the AOI discarded — the press could land anywhere the element source found the target, regardless of the AOI.
