### PR TITLE
fix: return interactive-element bounds in screenshot pixel space

### DIFF
--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -283,16 +283,37 @@ class Verifier:
             return {"page_source": page_source, "timestamp": timestamp}
         raise ValueError("Page source capture returned None.")
 
-    def get_interactive_elements(self, filter_config: Optional[List[str]] = None) -> list:
+    def _safe_capture_screenshot_np(self) -> Optional[Any]:
+        """Capture a screenshot as a NumPy frame, returning None on failure.
+
+        Bounds scaling and the API image are both derived from this frame; a capture
+        failure must degrade to unscaled bounds rather than break element retrieval.
         """
-        Retrieves a list of interactive elements on the current screen.
+        try:
+            return self.strategy_manager.capture_screenshot()
+        except Exception as e:
+            internal_logger.warning("Failed to capture screenshot for element bounds scaling: %s", e)
+            return None
 
-        XPath and text fields are converted to one-line, CSV-friendly form (newlines
-        as \\n, tabs as \\t, etc.) so output can be pasted into elements.csv or similar.
+    def _bounds_need_screenshot(self) -> bool:
+        """Whether bounds scaling needs a screenshot for the current element source.
 
-        :param filter_config: Optional list of filter types (e.g., ["buttons", "inputs"]).
-        :type filter_config: Optional[List[str]]
-        :return: A list of interactive elements.
+        Only Appium sources are rescaled (see ``utils.scale_interactive_element_bounds``),
+        so for any other backend we skip the screenshot capture entirely rather than pay
+        for a capture whose result would be discarded by a no-op scale.
+        """
+        source = self.element_source.active_instance
+        return getattr(source, "REQUIRED_DRIVER_TYPE", None) == "appium"
+
+    def _collect_interactive_elements(
+        self, filter_config: Optional[List[str]], screenshot_np: Optional[Any]
+    ) -> list:
+        """Fetch interactive elements, CSV-escape their text/xpath, and scale their
+        bounds into the given screenshot's pixel space.
+
+        Shared by ``get_interactive_elements``, ``get_screen_elements``, and the serve
+        workspace stream so all three return consistent, screenshot-aligned bounds from
+        a single capture. Does not persist anything — callers decide whether to save.
         """
         elements = self.strategy_manager.get_interactive_elements(filter_config)
         for el in elements:
@@ -301,6 +322,26 @@ class Verifier:
                     el["xpath"] = utils.escape_csv_value(str(el["xpath"]))
                 if "text" in el and el["text"] is not None:
                     el["text"] = utils.escape_csv_value(str(el["text"]))
+        # Bounds come from the page source in the driver's window coordinate space;
+        # scale them to the screenshot's pixel space so consumers can overlay them
+        # directly (no-op on Android / non-Appium / when sizes already match).
+        utils.scale_interactive_element_bounds(elements, self.element_source, screenshot_np)
+        return elements
+
+    def get_interactive_elements(self, filter_config: Optional[List[str]] = None) -> list:
+        """
+        Retrieves a list of interactive elements on the current screen.
+
+        XPath and text fields are converted to one-line, CSV-friendly form (newlines
+        as \\n, tabs as \\t, etc.) so output can be pasted into elements.csv or similar.
+        On Appium sources, element bounds are returned in the screenshot's pixel space.
+
+        :param filter_config: Optional list of filter types (e.g., ["buttons", "inputs"]).
+        :type filter_config: Optional[List[str]]
+        :return: A list of interactive elements.
+        """
+        screenshot_np = self._safe_capture_screenshot_np() if self._bounds_need_screenshot() else None
+        elements = self._collect_interactive_elements(filter_config, screenshot_np)
         utils.save_interactable_elements(elements, output_dir=self.execution_dir)
         return elements
 
@@ -308,11 +349,20 @@ class Verifier:
         """
         Captures a screenshot and retrieves interactive elements for API response.
 
+        Bounds are scaled to the returned screenshot's pixel space using a single
+        capture shared between the image and the bounds, so callers can overlay the
+        bounds on the screenshot without any scaling of their own.
+
         :return: Dict with base64-encoded screenshot and list of elements.
         """
-        base64_screenshot = self.capture_screenshot()
-        elements = self.get_interactive_elements()
-
+        screenshot_np = self._safe_capture_screenshot_np()
+        elements = self._collect_interactive_elements(None, screenshot_np)
+        utils.save_interactable_elements(elements, output_dir=self.execution_dir)
+        if screenshot_np is not None and self.capture_output_dir is not None:
+            utils.save_screenshot(screenshot_np, "capture_screenshot", output_dir=self.capture_output_dir)
+        base64_screenshot = (
+            utils.encode_numpy_to_base64(screenshot_np) if screenshot_np is not None else ""
+        )
         return {
             "screenshot": base64_screenshot,
             "elements": elements

--- a/optics_framework/common/base_factory.py
+++ b/optics_framework/common/base_factory.py
@@ -216,6 +216,18 @@ class InstanceFallback(BaseModel, Generic[T]):
         super().__init__(instances=instances, **data)
         self.current_instance = instances[0] if instances else None
 
+    @property
+    def active_instance(self) -> Optional[T]:
+        """The concrete instance currently in play.
+
+        Prefers ``current_instance`` (the one the last fallback call selected), falling
+        back to the first configured instance, or ``None`` when there are none. Callers
+        that need a real attribute off the wrapped source (e.g. ``REQUIRED_DRIVER_TYPE``
+        or ``driver``) must go through this -- reading such an attribute off the wrapper
+        directly would be intercepted by ``__getattr__`` and returned as a callable.
+        """
+        return self.current_instance or (self.instances[0] if self.instances else None)
+
     def __getattr__(self, attr):
         def fallback_method(*args, **kwargs):
             if not self.instances:

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -29,7 +29,7 @@ from optics_framework.common.logging_config import internal_logger, reconfigure_
 from optics_framework.common.error import OpticsError, Code
 from optics_framework.common.config_handler import Config, DependencyConfig
 from optics_framework.common.runner.keyword_register import KeywordRegistry
-from optics_framework.common.utils import _is_list_type
+from optics_framework.common.utils import _is_list_type, encode_numpy_to_base64
 from optics_framework.api import ActionKeyword, AppManagement, FlowControl, Verifier
 from optics_framework.helper.execute import discover_templates
 from optics_framework.helper.version import VERSION
@@ -1095,10 +1095,17 @@ async def _gather_workspace_data(
     try:
         verifier = session.optics.build(Verifier)
 
-        screenshot_task = asyncio.create_task(asyncio.to_thread(verifier.capture_screenshot))
-        elements_task = asyncio.create_task(asyncio.to_thread(verifier.get_interactive_elements, filter_config))
-
-        screenshot, elements = await asyncio.gather(screenshot_task, elements_task)
+        # Capture one frame and derive both the returned image and the element bounds
+        # from it, so bounds are scaled to the exact screenshot pixel space the client
+        # renders (see Verifier._collect_interactive_elements).
+        screenshot_np = await asyncio.to_thread(verifier._safe_capture_screenshot_np)
+        elements = await asyncio.to_thread(
+            verifier._collect_interactive_elements, filter_config, screenshot_np
+        )
+        screenshot = (
+            await asyncio.to_thread(encode_numpy_to_base64, screenshot_np)
+            if screenshot_np is not None else ""
+        )
 
         workspace_data: Dict[str, Any] = {
             KEY_SCREENSHOT: screenshot or "",

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -942,31 +942,61 @@ def _window_size_from_source(element_source: Any) -> Optional[Tuple[int, int]]:
     return None
 
 
-def _scale_bbox(
+def _pixel_scale_for_source(
+    element_source: Any,
+    screenshot: Optional[np.ndarray],
+) -> Optional[Tuple[float, float]]:
+    """
+    Compute the per-axis scale that maps the driver's window coordinate space onto
+    the screenshot's pixel space, or ``None`` when scaling should not be applied.
+
+    * Gated to **Appium** sources. Their page-source/WebElement coordinates and the
+      driver's window size share one coordinate system (points on iOS, pixels on
+      Android), so ``screenshot / window`` is a meaningful ratio. Web sources
+      (Selenium/Playwright) report element coordinates (CSS pixels, scroll-relative)
+      and window size in unrelated spaces, so the ratio is not correct there and we
+      return ``None`` to leave their coordinates untouched.
+    * Best-effort and non-failing: returns ``None`` when no screenshot is available,
+      the window size can't be determined, or its shape can't be read — callers then
+      leave coordinates unscaled rather than raising.
+
+    :param element_source: Element source (possibly an ``InstanceFallback`` wrapper).
+    :param screenshot: The captured frame whose pixel space is the target.
+    :return: ``(scale_x, scale_y)``, or ``None`` when scaling must not be applied.
+    """
+    if screenshot is None:
+        return None
+    source = getattr(element_source, "active_instance", None) or element_source
+    if getattr(source, "REQUIRED_DRIVER_TYPE", None) != "appium":
+        return None
+    window_size = _window_size_from_source(source)
+    if window_size is None:
+        return None
+    window_width, window_height = window_size
+    try:
+        screenshot_height, screenshot_width = screenshot.shape[:2]
+    except (AttributeError, TypeError):
+        return None
+    if window_width <= 0 or window_height <= 0:
+        return None
+    return screenshot_width / window_width, screenshot_height / window_height
+
+
+def _apply_scale_to_bbox(
     bbox: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
-    window_size: Tuple[int, int],
-    screenshot: np.ndarray,
+    scale_x: float,
+    scale_y: float,
 ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
     """
-    Scale a single bbox from window-coordinate space into the screenshot's
-    pixel space.
+    Multiply a single ``((x1,y1),(x2,y2))`` bbox by the given per-axis scale.
 
-    A bbox is reported in the driver's window coordinate space, while the
-    screenshot may be captured at a different resolution. Multiply each corner by
-    the per-axis scale (screenshot size / window size) to map it onto the image.
-    When the window size equals the screenshot size the scale is 1.0 and this is a
-    no-op (``int(x * 1.0) == x``). Returns the bbox unchanged on any failure.
+    When the scale is 1.0 this is a no-op (``int(x * 1.0) == x``). Returns the bbox
+    unchanged on any structural failure.
     """
     if bbox is None:
         return bbox
     try:
         (x1, y1), (x2, y2) = bbox
-        win_w, win_h = window_size
-        sh_h, sh_w = screenshot.shape[:2]
-        if win_w <= 0 or win_h <= 0:
-            return bbox
-        scale_x = sh_w / win_w
-        scale_y = sh_h / win_h
         return (
             (int(x1 * scale_x), int(y1 * scale_y)),
             (int(x2 * scale_x), int(y2 * scale_y)),
@@ -991,10 +1021,10 @@ def scale_bboxes_for_screenshot(
     maps them correctly. When the two sizes match, the scale is 1.0 and the boxes
     are left unchanged.
 
-    Best-effort and non-failing: if the window size can't be determined (e.g. the
-    source has no driver, or the driver errors) or no screenshot is available, the
-    bboxes are returned unchanged so annotation falls back to drawing them as-is.
-    Window size is fetched once for the whole list. Do not use this for OCR /
+    Best-effort and non-failing: scaling is applied only when ``_pixel_scale_for_source``
+    yields a ratio (Appium source, determinable window size, screenshot available);
+    otherwise the bboxes are returned unchanged so annotation falls back to drawing
+    them as-is. The scale is computed once for the whole list. Do not use this for OCR /
     image-detection bboxes — those are already computed in the screenshot's pixel
     space and need no conversion.
 
@@ -1003,12 +1033,63 @@ def scale_bboxes_for_screenshot(
     :param screenshot: The captured frame the bboxes will be drawn onto.
     :return: bboxes scaled to the screenshot's pixel space, or unchanged on any failure.
     """
-    if screenshot is None or not bboxes:
+    if not bboxes:
         return bboxes
-    window_size = _window_size_from_source(element_source)
-    if window_size is None:
+    scale = _pixel_scale_for_source(element_source, screenshot)
+    if scale is None:
         return bboxes
-    return [_scale_bbox(b, window_size, screenshot) for b in bboxes]
+    scale_x, scale_y = scale
+    return [_apply_scale_to_bbox(b, scale_x, scale_y) for b in bboxes]
+
+
+def scale_interactive_element_bounds(
+    elements: List[Any],
+    element_source: Any,
+    screenshot: Optional[np.ndarray],
+) -> None:
+    """
+    Scale the ``bounds`` of interactive-element dicts from the driver's window
+    coordinate space into the screenshot's pixel space, mutating ``elements`` in place.
+
+    Interactive elements returned by ``get_interactive_elements`` carry ``bounds``
+    ({"x1","y1","x2","y2"}) sourced from the page source, expressed in the driver's
+    window coordinate space. When that differs in resolution from the captured
+    screenshot (e.g. Retina iOS, where the page source reports points and the
+    screenshot is in pixels), a client drawing the bounds over the screenshot would
+    mis-place them. Rewriting each ``bounds`` in place leaves them already aligned to
+    the screenshot's pixels, so API/workspace consumers need no scaling of their own.
+
+    Shares ``_pixel_scale_for_source`` with ``scale_bboxes_for_screenshot`` — the same
+    Appium gate and window-size logic — so the two paths can never disagree. No-op on
+    Android (window == screenshot), on non-Appium sources, or when no screenshot /
+    window size is available. (Dicts are mutable, so this mutates in place; the tuple
+    variant returns a new list because its bboxes are immutable.)
+
+    :param elements: List of element dicts; each may carry a ``bounds`` dict. Modified in place.
+    :param element_source: Element source (possibly an ``InstanceFallback`` wrapper).
+    :param screenshot: The captured frame whose pixel space bounds are mapped into.
+    """
+    if not elements:
+        return
+    scale = _pixel_scale_for_source(element_source, screenshot)
+    if scale is None:
+        return
+    scale_x, scale_y = scale
+    for el in elements:
+        if not isinstance(el, dict):
+            continue
+        bounds = el.get("bounds")
+        if not isinstance(bounds, dict):
+            continue
+        try:
+            el["bounds"] = {
+                "x1": int(bounds["x1"] * scale_x),
+                "y1": int(bounds["y1"] * scale_y),
+                "x2": int(bounds["x2"] * scale_x),
+                "y2": int(bounds["y2"] * scale_y),
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
 
 
 def bboxes_from_webelements(

--- a/tests/units/common/test_bbox_scaling.py
+++ b/tests/units/common/test_bbox_scaling.py
@@ -2,8 +2,12 @@
 
 Regression coverage for annotation boxes drawn in the wrong position/size when
 the driver's window coordinate space differs in resolution from the captured
-screenshot. See utils.scale_bboxes_for_screenshot / _window_size_from_source /
-_scale_bbox.
+screenshot. See utils.scale_bboxes_for_screenshot / _pixel_scale_for_source /
+_window_size_from_source / _apply_scale_to_bbox.
+
+Scaling is gated to Appium sources (their window and element coordinates share one
+space), so the fixtures here declare REQUIRED_DRIVER_TYPE = "appium"; a non-Appium
+regression guard lives in test_non_appium_annotation_is_noop.
 """
 import numpy as np
 
@@ -24,11 +28,15 @@ class _FakeWebDriver:
 class _WrappedSource:
     """Element source whose .driver wraps the real WebDriver one level in (.driver.driver)."""
 
+    REQUIRED_DRIVER_TYPE = "appium"
+
     def __init__(self, wd):
         self.driver = type("Wrapper", (), {"driver": wd})()
 
 
 class _DirectSource:
+    REQUIRED_DRIVER_TYPE = "appium"
+
     def __init__(self, wd):
         self.driver = wd
 
@@ -58,7 +66,15 @@ class TestScaleBboxesForScreenshot:
         assert result == [self.BBOX]
 
     def test_source_without_window_size_falls_back_unchanged(self):
-        src = type("NoWindowSource", (), {"driver": object()})()
+        src = type("NoWindowSource", (), {"REQUIRED_DRIVER_TYPE": "appium", "driver": object()})()
+        result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
+        assert result == [self.BBOX]
+
+    def test_non_appium_annotation_is_noop(self):
+        # Regression guard: the annotation path shares the Appium gate with the API
+        # path, so a web source's window/element spaces (unrelated) are never scaled.
+        src = type("SeleniumSource", (), {"REQUIRED_DRIVER_TYPE": "selenium"})()
+        src.driver = _FakeWebDriver(375, 812)
         result = utils.scale_bboxes_for_screenshot([self.BBOX], src, _pixel_screenshot())
         assert result == [self.BBOX]
 
@@ -78,8 +94,8 @@ class TestScaleBboxesForScreenshot:
         assert result == [self.BBOX]
 
     def test_malformed_bbox_preserved_unchanged(self):
-        # A bbox that isn't ((x1,y1),(x2,y2)) shaped can't be unpacked; _scale_bbox
-        # returns it unchanged rather than raising.
+        # A bbox that isn't ((x1,y1),(x2,y2)) shaped can't be unpacked;
+        # _apply_scale_to_bbox returns it unchanged rather than raising.
         src = _DirectSource(_FakeWebDriver(375, 812))
         malformed = (1, 2, 3, 4)
         result = utils.scale_bboxes_for_screenshot([malformed], src, _pixel_screenshot())

--- a/tests/units/common/test_interactive_bounds_scaling.py
+++ b/tests/units/common/test_interactive_bounds_scaling.py
@@ -1,0 +1,154 @@
+"""Unit tests for scaling element coordinates into screenshot pixel space.
+
+Two consumers share one gate/ratio helper (``utils._pixel_scale_for_source``):
+
+* ``scale_interactive_element_bounds`` — scales the dict ``bounds`` on elements from
+  get_interactive_elements / get_screen_elements / the serve workspace stream, in place.
+* ``scale_bboxes_for_screenshot`` — returns scaled ``((x1,y1),(x2,y2))`` bboxes for
+  annotated screenshots.
+
+Both are gated to Appium sources; other platforms (and missing windows/screenshots)
+are left unchanged. These tests pin that shared behavior for both shapes.
+"""
+import numpy as np
+
+from optics_framework.common import utils
+from optics_framework.common.base_factory import InstanceFallback
+
+
+class _FakeWebDriver:
+    def __init__(self, width, height):
+        self._size = {"width": width, "height": height}
+
+    def get_window_size(self):
+        return self._size
+
+
+class _AppiumSource:
+    REQUIRED_DRIVER_TYPE = "appium"
+
+    def __init__(self, wd):
+        self.driver = wd
+
+
+class _SeleniumSource:
+    REQUIRED_DRIVER_TYPE = "selenium"
+
+    def __init__(self, wd):
+        self.driver = wd
+
+
+def _elements():
+    return [
+        {"text": "A", "bounds": {"x1": 20, "y1": 96, "x2": 355, "y2": 140}, "xpath": "//a"},
+        {"text": "B", "bounds": {"x1": 0, "y1": 0, "x2": 100, "y2": 50}, "xpath": "//b"},
+    ]
+
+
+def _screenshot(width=1080, height=2340):
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# scale_interactive_element_bounds — dict bounds (API / workspace path).
+# Mutates the passed list in place and returns None.
+# ---------------------------------------------------------------------------
+class TestScaleInteractiveElementBounds:
+    def test_appium_window_smaller_than_screenshot_scales(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        # ~2.88x / ~2.881x
+        assert els[0]["bounds"] == {"x1": 57, "y1": 276, "x2": 1022, "y2": 403}
+        assert els[1]["bounds"] == {"x1": 0, "y1": 0, "x2": 288, "y2": 144}
+
+    def test_resolves_instance_fallback(self):
+        src = InstanceFallback([_AppiumSource(_FakeWebDriver(375, 812))])
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0]["bounds"] == {"x1": 57, "y1": 276, "x2": 1022, "y2": 403}
+
+    def test_prefers_current_instance_over_first(self):
+        # current_instance is what actually served the request; it must win.
+        first = _SeleniumSource(_FakeWebDriver(1, 1))
+        current = _AppiumSource(_FakeWebDriver(375, 812))
+        fb = InstanceFallback([first, current])
+        fb.current_instance = current
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, fb, _screenshot())
+        assert els[0]["bounds"] == {"x1": 57, "y1": 276, "x2": 1022, "y2": 403}
+
+    def test_android_window_equals_screenshot_is_noop(self):
+        src = _AppiumSource(_FakeWebDriver(1080, 2340))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0]["bounds"] == {"x1": 20, "y1": 96, "x2": 355, "y2": 140}
+        assert els[1]["bounds"] == {"x1": 0, "y1": 0, "x2": 100, "y2": 50}
+
+    def test_non_appium_source_is_left_unchanged(self):
+        # Selenium driver exposes get_window_size, but its space is unrelated to the
+        # screenshot's; scaling must NOT touch it.
+        src = _SeleniumSource(_FakeWebDriver(375, 812))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0]["bounds"] == {"x1": 20, "y1": 96, "x2": 355, "y2": 140}
+
+    def test_no_screenshot_is_noop(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, None)
+        assert els[0]["bounds"] == {"x1": 20, "y1": 96, "x2": 355, "y2": 140}
+
+    def test_missing_window_size_is_noop(self):
+        class _NoWinSource:
+            REQUIRED_DRIVER_TYPE = "appium"
+            driver = object()
+
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, _NoWinSource(), _screenshot())
+        assert els[0]["bounds"] == {"x1": 20, "y1": 96, "x2": 355, "y2": 140}
+
+    def test_elements_without_bounds_preserved(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = [{"text": "x", "xpath": "//x"}, {"text": "y", "bounds": None}]
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0] == {"text": "x", "xpath": "//x"}
+        assert els[1]["bounds"] is None
+
+    def test_malformed_bounds_skipped(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = [{"bounds": {"x1": 1, "y1": 2}}]  # missing x2/y2
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0]["bounds"] == {"x1": 1, "y1": 2}
+
+    def test_empty_list_is_noop(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = []
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els == []
+
+
+# ---------------------------------------------------------------------------
+# Both consumers share one gate/ratio helper — this cross-checks that the dict
+# path and the tuple path land on the same pixel geometry (tuple-path breadth
+# lives in test_bbox_scaling.py).
+# ---------------------------------------------------------------------------
+class TestSharedGateConsistency:
+    def test_both_paths_produce_matching_geometry(self):
+        src = _AppiumSource(_FakeWebDriver(375, 812))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        b = els[0]["bounds"]
+        tuple_out = utils.scale_bboxes_for_screenshot([((20, 96), (355, 140))], src, _screenshot())[0]
+        # Both paths must land on the same pixel geometry.
+        assert (b["x1"], b["y1"], b["x2"], b["y2"]) == (57, 276, 1022, 403)
+        assert tuple_out == ((57, 276), (1022, 403))
+
+    def test_both_paths_skip_non_appium(self):
+        src = _SeleniumSource(_FakeWebDriver(375, 812))
+        els = _elements()
+        utils.scale_interactive_element_bounds(els, src, _screenshot())
+        assert els[0]["bounds"] == {"x1": 20, "y1": 96, "x2": 355, "y2": 140}
+        assert utils.scale_bboxes_for_screenshot([((20, 96), (355, 140))], src, _screenshot()) == [
+            ((20, 96), (355, 140))
+        ]


### PR DESCRIPTION
## Problem

`get_interactive_elements`, `get_screen_elements`, and the `optics serve` workspace stream return element `bounds` sourced from the page source — the driver's **window coordinate space** (points on iOS, pixels on Android) — alongside a screenshot in **pixel space**. On Retina iOS these spaces differ by the device scale factor, so a client overlaying the bounds on the screenshot mis-places every box. On Android the two coincide, so it's a no-op today.

## Approach

Scale the bounds into the screenshot's pixel space inside the framework, so API/workspace consumers can draw them directly with no scaling of their own.

Main already had a parallel scaler for the **annotation** path (`scale_bboxes_for_screenshot`, tuple-shaped, drawn onto saved screenshots). Rather than add a second copy of the same arithmetic for the dict-shaped API bounds, this PR reconciles both behind **one gated ratio helper** so they can't drift:

- `utils._pixel_scale_for_source` — resolves an `InstanceFallback` wrapper to its concrete source, gates to **Appium** (whose window and element coordinates share one space; web sources report them in unrelated spaces so the ratio is meaningless), reads the window size, returns per-axis `(scale_x, scale_y)` or `None`.
- `scale_bboxes_for_screenshot` (tuples) and the new `scale_interactive_element_bounds` (dicts) are thin adapters over it.
- The shared gate also corrects the annotation path, which previously scaled Selenium bboxes with no gate.
- `Verifier` derives the returned image and the bounds from a **single** capture; `get_interactive_elements` only captures on Appium (no-op elsewhere).

## Commits

1. `refactor(utils)` — unify scaling behind the gated ratio helper.
2. `fix(verifier)` — pixel-space bounds from a shared capture.
3. `fix(serve)` — workspace stream aligns bounds with the returned frame.

## Tests

`tests/units/common/test_bbox_scaling.py` (annotation path, incl. non-Appium regression guard) and `test_interactive_bounds_scaling.py` (API path + cross-path consistency). Full unit suite green (610 passed).

## Follow-ups

- #417 — extra screenshot capture on `get_interactive_elements` for callers that only need text/xpath; also tracks real-device verification and the multi-source `current_instance` edge case.

## Notes for reviewers

- Behavior change for HiDPI Selenium annotations (now un-scaled) — a no-op when `devicePixelRatio == 1`.