### PR TITLE
feat(setup): allow pinning an engine version in `optics setup --install`

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -45,7 +45,7 @@ optics setup --list                # list installable engines
 optics setup --install appium easyocr
 ```
 
-Convenience bundles also exist: `mobile`, `web`, `vision`, `all`.
+Convenience bundles also exist: `mobile`, `web`, `vision`, `all`. Append a version specifier to pin an engine (e.g. `optics setup --install appium==4.2.0`).
 
 ---
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -45,7 +45,7 @@ optics setup --list                # list installable engines
 optics setup --install appium easyocr
 ```
 
-Convenience bundles also exist: `mobile`, `web`, `vision`, `all`. Append a version specifier to pin an engine (e.g. `optics setup --install appium==4.2.0`).
+Convenience bundles also exist: `mobile`, `web`, `vision`, `all`. Append a version specifier to pin an engine (e.g. `optics setup --install appium==5.0.0`).
 
 ---
 

--- a/docs/usage/CLI_usage.md
+++ b/docs/usage/CLI_usage.md
@@ -29,10 +29,10 @@ This is equivalent to `pip install "optics-framework[appium,easyocr]"`. See [Ins
 Pin a specific version by appending a specifier to any engine (handy for reproducible CI):
 
 ```bash
-optics setup --install appium==4.2.0 "easyocr>=1.7,<2.0"
+optics setup --install appium==5.0.0 "easyocr>=1.7,<2.0"
 ```
 
-The version applies to the engine's main package and is intersected with the extra's supported range, so an out-of-range pin fails loudly instead of silently downgrading. A specifier on a bundle (e.g. `all==1.0`) is rejected.
+The version applies to the engine's main package and is intersected with the extra's supported range, so an out-of-range pin fails loudly instead of silently downgrading. A malformed specifier (e.g. `appium=5.0.0` with a single `=`), two conflicting versions for the same engine, or a specifier on a bundle (e.g. `all==1.0`) are all rejected up front with a clear error.
 
 ## Executing Test Cases
 

--- a/docs/usage/CLI_usage.md
+++ b/docs/usage/CLI_usage.md
@@ -26,6 +26,14 @@ optics setup --install appium easyocr
 
 This is equivalent to `pip install "optics-framework[appium,easyocr]"`. See [Installation & Prerequisites](../prerequisites.md) for the full extras table and the external tooling (Appium server, adb, browsers) each engine needs.
 
+Pin a specific version by appending a specifier to any engine (handy for reproducible CI):
+
+```bash
+optics setup --install appium==4.2.0 "easyocr>=1.7,<2.0"
+```
+
+The version applies to the engine's main package and is intersected with the extra's supported range, so an out-of-range pin fails loudly instead of silently downgrading. A specifier on a bundle (e.g. `all==1.0`) is rejected.
+
 ## Executing Test Cases
 
 Run test cases from a project folder. The runner discovers test cases (and modules, elements, config) from that folder:

--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -365,7 +365,8 @@ class EngineInstaller(Command):
             "setup", help="Install optional engine backends (drivers/OCR/LLM)")
         parser.add_argument(
             "--install", nargs="+", metavar="NAME",
-            help="Install the given engines, e.g. --install appium easyocr")
+            help="Install the given engines, e.g. --install appium easyocr. "
+                 "Append a version to pin it, e.g. --install appium==4.2.0")
         parser.add_argument("--list", action="store_true",
                         help="List all available engines")
         parser.set_defaults(func=self.execute)

--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -9,7 +9,7 @@ from optics_framework.helper.version import VERSION
 from optics_framework.helper.execute import execute_main, dryrun_main
 from optics_framework.helper.live import live_main
 from optics_framework.helper.generate import generate_test_file as generate_framework_code
-from optics_framework.helper.setup import EngineInstallerApp, list_engines, install_extras, resolve_engines
+from optics_framework.helper.setup import EngineInstallerApp, SetupError, list_engines, install_extras, resolve_engines
 from optics_framework.helper.serve import run_uvicorn_server
 from optics_framework.helper.autocompletion import update_shell_rc
 
@@ -366,7 +366,7 @@ class EngineInstaller(Command):
         parser.add_argument(
             "--install", nargs="+", metavar="NAME",
             help="Install the given engines, e.g. --install appium easyocr. "
-                 "Append a version to pin it, e.g. --install appium==4.2.0")
+                 "Append a version to pin it, e.g. --install appium==5.0.0")
         parser.add_argument("--list", action="store_true",
                         help="List all available engines")
         parser.set_defaults(func=self.execute)
@@ -375,7 +375,11 @@ class EngineInstaller(Command):
         if args.list:
             list_engines()
         elif args.install:
-            engines, invalid = resolve_engines(args.install)
+            try:
+                engines, invalid = resolve_engines(args.install)
+            except SetupError as exc:
+                print(f"Error: {exc}")
+                return
             if invalid:
                 print(f"Error: Invalid engine(s): {', '.join(invalid)}")
                 print("Use `optics setup --list` to see available engines")

--- a/optics_framework/helper/setup.py
+++ b/optics_framework/helper/setup.py
@@ -5,10 +5,17 @@ from typing import Dict, List, Optional
 import sys
 from textual.app import App, ComposeResult
 from textual.widgets import Checkbox, Button, Header, Footer, Static
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pydantic import BaseModel
 
 
 DISTRIBUTION_NAME = "optics-framework"
+
+
+class SetupError(Exception):
+    """A user-facing engine-setup error (bad version specifier, version
+    conflict). Raised by `resolve_engines` and surfaced by the CLI as a clean
+    message instead of a Python traceback."""
 
 
 class EngineBackend(BaseModel):
@@ -32,7 +39,7 @@ class EngineCategory(BaseModel):
 class InstallRequest(BaseModel):
     """One engine to install, optionally with a user-supplied version specifier.
 
-    ``version`` is the raw PEP 508 tail (e.g. ``"==4.2.0"``, ``">=4.0,<4.3"``)
+    ``version`` is the raw PEP 508 tail (e.g. ``"==5.0.0"``, ``">=5.0,<5.4"``)
     parsed off the CLI token; ``None`` means "let the extra's own bound decide"."""
     engine: EngineBackend
     version: Optional[str] = None
@@ -103,13 +110,26 @@ _SPEC_START = re.compile(r"[=<>!~]")
 def _split_token(token: str) -> tuple[str, Optional[str]]:
     """Split a CLI token into its engine name and optional version specifier.
 
-    ``"appium==4.2.0"`` → ``("appium", "==4.2.0")``; ``"easyocr"`` → ``("easyocr",
-    None)``. The specifier tail is passed through to pip verbatim (pip validates
-    it), so any PEP 508 form is accepted, not just ``==``."""
+    ``"appium==5.0.0"`` → ``("appium", "==5.0.0")``; ``"easyocr"`` → ``("easyocr",
+    None)``. The specifier is only sliced off here — `_validate_spec` checks it —
+    so any operator form is accepted, not just ``==``."""
     match = _SPEC_START.search(token)
     if match is None:
         return token.strip(), None
     return token[:match.start()].strip(), token[match.start():].strip()
+
+
+def _validate_spec(spec: str, token: str) -> None:
+    """Reject a malformed version specifier up front (PEP 440), so the user gets
+    a clear error from optics instead of a pip failure later. ``"=5.0.0"`` (a
+    single ``=``) and other typos raise `SetupError`."""
+    try:
+        SpecifierSet(spec)
+    except InvalidSpecifier as exc:
+        raise SetupError(
+            f"invalid version in '{token}': {exc}. "
+            "Use an operator like '==', e.g. 'appium==5.0.0'."
+        ) from exc
 
 
 def _alias_index() -> Dict[str, EngineBackend]:
@@ -124,13 +144,24 @@ def _alias_index() -> Dict[str, EngineBackend]:
 
 
 def _add_request(resolved: List[InstallRequest], engine: EngineBackend, version: Optional[str]) -> None:
-    """Add `engine` to `resolved`, or merge `version` onto its existing entry —
-    an explicit version wins over a bare one already recorded for that engine."""
+    """Add `engine` to `resolved`, or merge `version` onto its existing entry.
+
+    An explicit version wins over a bare one already recorded for that engine; a
+    bare token folds into an existing entry. Two *different* explicit versions
+    for one engine are a conflict — raise rather than silently pick one, matching
+    how pip rejects `pkg==a pkg==b`."""
     existing = next((r for r in resolved if r.engine is engine), None)
     if existing is None:
         resolved.append(InstallRequest(engine=engine, version=version))
-    elif version and not existing.version:
+    elif version is None or version == existing.version:
+        return
+    elif existing.version is None:
         existing.version = version
+    else:
+        raise SetupError(
+            f"conflicting versions for {engine.name}: "
+            f"'{existing.version}' and '{version}'."
+        )
 
 
 def _resolve_token(
@@ -157,8 +188,10 @@ def _resolve_token(
     engine = index.get(norm)
     if engine is None:
         invalid.append(token)
-    else:
-        _add_request(resolved, engine, spec)
+        return
+    if spec is not None:
+        _validate_spec(spec, token)
+    _add_request(resolved, engine, spec)
 
 
 def resolve_engines(tokens: List[str]) -> tuple[List[InstallRequest], List[str]]:
@@ -167,11 +200,14 @@ def resolve_engines(tokens: List[str]) -> tuple[List[InstallRequest], List[str]]
     Accepts display names ("Appium", "Google Vision"), config/extra keys
     ("appium", "google-vision", "google_vision"), and convenience bundles
     ("mobile", "web", "vision", "all") — all case-insensitively. Any token may
-    carry a PEP 508 version specifier ("appium==4.2.0", "easyocr>=1.7,<2.0") to
+    carry a PEP 508 version specifier ("appium==5.0.0", "easyocr>=1.7,<2.0") to
     override the extra's default bound; a specifier on a bundle is rejected as
     invalid since one version can't apply to many packages. Bundles expand to
     their member engines, deduplicated while preserving first-seen order; when
-    the same engine is named twice, an explicit version wins over a bare one."""
+    the same engine is named twice, an explicit version wins over a bare one.
+
+    Raises `SetupError` for a malformed version specifier or two conflicting
+    explicit versions of the same engine."""
     index = _alias_index()
     resolved: List[InstallRequest] = []
     invalid: List[str] = []
@@ -262,7 +298,7 @@ def install_extras(requests: List[InstallRequest]) -> None:
     never upgraded out from under the user.
 
     A request carrying an explicit ``version`` also adds its primary package as a
-    concrete pinned requirement (e.g. ``appium-python-client==4.2.0``); pip
+    concrete pinned requirement (e.g. ``appium-python-client==5.0.0``); pip
     intersects that with the extra's own bound, so an override outside the
     supported range fails loudly rather than silently downgrading it.
     ``packages[0]`` is each engine's primary package — the one a version
@@ -316,5 +352,5 @@ def list_engines() -> None:
         print(f"  {name:<15} ({', '.join(engine.extra for engine in engines)})")
     print()
     print("Pin a version by appending a specifier, e.g. "
-          "`optics setup --install appium==4.2.0`.")
+          "`optics setup --install appium==5.0.0`.")
     print()

--- a/optics_framework/helper/setup.py
+++ b/optics_framework/helper/setup.py
@@ -1,3 +1,4 @@
+import re
 import subprocess  # nosec B404
 from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List, Optional
@@ -26,6 +27,15 @@ class EngineBackend(BaseModel):
 class EngineCategory(BaseModel):
     name: str
     engines: Dict[str, EngineBackend]
+
+
+class InstallRequest(BaseModel):
+    """One engine to install, optionally with a user-supplied version specifier.
+
+    ``version`` is the raw PEP 508 tail (e.g. ``"==4.2.0"``, ``">=4.0,<4.3"``)
+    parsed off the CLI token; ``None`` means "let the extra's own bound decide"."""
+    engine: EngineBackend
+    version: Optional[str] = None
 
 
 # Engine-backend definitions. The `extra` matches the pyproject extra name, which
@@ -86,6 +96,22 @@ def _norm(token: str) -> str:
     return token.strip().lower().replace(" ", "_").replace("-", "_")
 
 
+# First char that starts a PEP 508 version specifier ( ==, >=, ~=, !=, <, > ).
+_SPEC_START = re.compile(r"[=<>!~]")
+
+
+def _split_token(token: str) -> tuple[str, Optional[str]]:
+    """Split a CLI token into its engine name and optional version specifier.
+
+    ``"appium==4.2.0"`` → ``("appium", "==4.2.0")``; ``"easyocr"`` → ``("easyocr",
+    None)``. The specifier tail is passed through to pip verbatim (pip validates
+    it), so any PEP 508 form is accepted, not just ``==``."""
+    match = _SPEC_START.search(token)
+    if match is None:
+        return token.strip(), None
+    return token[:match.start()].strip(), token[match.start():].strip()
+
+
 def _alias_index() -> Dict[str, EngineBackend]:
     """Build a lookup from every accepted token (display name, extra, config key,
     explicit aliases) — all normalised to lowercase/underscore — to its
@@ -97,32 +123,60 @@ def _alias_index() -> Dict[str, EngineBackend]:
     return index
 
 
-def resolve_engines(tokens: List[str]) -> tuple[List[EngineBackend], List[str]]:
-    """Resolve user-supplied tokens to EngineBackends. Returns (resolved, invalid).
+def _add_request(resolved: List[InstallRequest], engine: EngineBackend, version: Optional[str]) -> None:
+    """Add `engine` to `resolved`, or merge `version` onto its existing entry —
+    an explicit version wins over a bare one already recorded for that engine."""
+    existing = next((r for r in resolved if r.engine is engine), None)
+    if existing is None:
+        resolved.append(InstallRequest(engine=engine, version=version))
+    elif version and not existing.version:
+        existing.version = version
+
+
+def _resolve_token(
+    token: str,
+    index: Dict[str, EngineBackend],
+    resolved: List[InstallRequest],
+    invalid: List[str],
+) -> None:
+    """Resolve one CLI token, appending to `resolved` or `invalid` in place.
+
+    A bundle token expands to its member engines (bare, no version); a
+    specifier on a bundle token is rejected since one version can't apply to
+    many packages. Anything else resolves through the alias index."""
+    name, spec = _split_token(token)
+    norm = _norm(name)
+    bundle = _BUNDLES.get(norm)
+    if bundle is not None:
+        if spec is not None:
+            invalid.append(token)
+            return
+        for engine in bundle:
+            _add_request(resolved, engine, None)
+        return
+    engine = index.get(norm)
+    if engine is None:
+        invalid.append(token)
+    else:
+        _add_request(resolved, engine, spec)
+
+
+def resolve_engines(tokens: List[str]) -> tuple[List[InstallRequest], List[str]]:
+    """Resolve user-supplied tokens to InstallRequests. Returns (resolved, invalid).
 
     Accepts display names ("Appium", "Google Vision"), config/extra keys
     ("appium", "google-vision", "google_vision"), and convenience bundles
-    ("mobile", "web", "vision", "all") — all case-insensitively. Bundles expand
-    to their member engines, deduplicated while preserving first-seen order."""
+    ("mobile", "web", "vision", "all") — all case-insensitively. Any token may
+    carry a PEP 508 version specifier ("appium==4.2.0", "easyocr>=1.7,<2.0") to
+    override the extra's default bound; a specifier on a bundle is rejected as
+    invalid since one version can't apply to many packages. Bundles expand to
+    their member engines, deduplicated while preserving first-seen order; when
+    the same engine is named twice, an explicit version wins over a bare one."""
     index = _alias_index()
-    resolved: List[EngineBackend] = []
+    resolved: List[InstallRequest] = []
     invalid: List[str] = []
-
-    def _add(engine: EngineBackend) -> None:
-        if engine not in resolved:
-            resolved.append(engine)
-
     for token in tokens:
-        norm = _norm(token)
-        if norm in _BUNDLES:
-            for engine in _BUNDLES[norm]:
-                _add(engine)
-            continue
-        engine = index.get(norm)
-        if engine is None:
-            invalid.append(token)
-        else:
-            _add(engine)
+        _resolve_token(token, index, resolved, invalid)
     return resolved, invalid
 
 
@@ -187,10 +241,12 @@ class EngineInstallerApp(App):
             self.exit()
 
     def install_engines(self) -> None:
+        """Install every checked engine. The checkbox UI has no version field,
+        so each selection installs at its extra's default bound."""
         if not self.selected_engines:
             self.notify("No engines selected!", severity="warning")
             return
-        install_extras(list(self.selected_engines.values()))
+        install_extras([InstallRequest(engine=e) for e in self.selected_engines.values()])
 
 
 def _installed_version() -> Optional[str]:
@@ -200,26 +256,36 @@ def _installed_version() -> Optional[str]:
         return None
 
 
-def install_extras(engines: List[EngineBackend]) -> None:
+def install_extras(requests: List[InstallRequest]) -> None:
     """Install the selected engine backends by pulling the matching
     `optics-framework` extras, pinned to the installed version so the CLI is
-    never upgraded out from under the user."""
-    if not engines:
+    never upgraded out from under the user.
+
+    A request carrying an explicit ``version`` also adds its primary package as a
+    concrete pinned requirement (e.g. ``appium-python-client==4.2.0``); pip
+    intersects that with the extra's own bound, so an override outside the
+    supported range fails loudly rather than silently downgrading it.
+    ``packages[0]`` is each engine's primary package — the one a version
+    override targets. Extra packages, like pytesseract's pillow, stay on the
+    extra's bound."""
+    if not requests:
         print("No engines selected.")
         return
 
-    extras = sorted({engine.extra for engine in engines})
+    extras = sorted({req.engine.extra for req in requests})
     installed = _installed_version()
     spec = f"{DISTRIBUTION_NAME}[{','.join(extras)}]"
     if installed:
         spec = f"{spec}=={installed}"
 
+    pinned = [f"{req.engine.packages[0]}{req.version}" for req in requests if req.version]
+
     try:
         subprocess.run(  # nosec B603
-            [sys.executable, "-m", "pip", "install", spec],
+            [sys.executable, "-m", "pip", "install", spec, *pinned],
             capture_output=True, text=True, check=True, shell=False)
 
-        if any(engine.extra == "playwright" for engine in engines):
+        if any(req.engine.extra == "playwright" for req in requests):
             print("Installing Playwright Chromium browser and system dependencies...")
             # Per https://playwright.dev/python/docs/browsers this must run after
             # the pip install. Chromium is the most common target; --with-deps
@@ -248,4 +314,7 @@ def list_engines() -> None:
     print("Bundles (install several at once):")
     for name, engines in _BUNDLES.items():
         print(f"  {name:<15} ({', '.join(engine.extra for engine in engines)})")
+    print()
+    print("Pin a version by appending a specifier, e.g. "
+          "`optics setup --install appium==4.2.0`.")
     print()

--- a/poetry.lock
+++ b/poetry.lock
@@ -6277,4 +6277,4 @@ web = ["playwright", "selenium"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3d3850e4ad6385b56067d77a94fdb270c734115f5889dc72953e90103fa8777c"
+content-hash = "ca5fac2a181c3254fd44bf98e8b05fcc29cf310f98fd27680413272f24422188"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ scikit-image = "^0.25.2"
 uvicorn = ">=0.35,<0.43"
 jsonpath-ng = "^1.7.0"
 beautifulsoup4 = "^4.12"
+packaging = ">=24"
 appium-python-client = { version = ">=5.0,<6.0", optional = true }
 selenium = { version = ">=4.10,<5.0", optional = true }
 playwright = { version = ">=1.40,<2.0", optional = true }

--- a/tests/units/helpers/test_setup.py
+++ b/tests/units/helpers/test_setup.py
@@ -18,9 +18,11 @@ import pytest
 from optics_framework.helper.setup import (
     ALL_ENGINES,
     DISTRIBUTION_NAME,
+    InstallRequest,
     _BUNDLES,
     _alias_index,
     _norm,
+    _split_token,
     install_extras,
     resolve_engines,
 )
@@ -28,6 +30,11 @@ from optics_framework.helper.setup import (
 pytestmark = pytest.mark.white_box
 
 MODULE = "optics_framework.helper.setup"
+
+
+def _reqs(*names: str) -> list[InstallRequest]:
+    """InstallRequests (no version) for the named engines, as the TUI builds them."""
+    return [InstallRequest(engine=ALL_ENGINES[name]) for name in names]
 
 
 # --------------------------------------------------------------------------- #
@@ -84,22 +91,22 @@ class TestAliasIndex:
 class TestResolveEngines:
     def test_resolves_display_name(self):
         resolved, invalid = resolve_engines(["Appium"])
-        assert [e.extra for e in resolved] == ["appium"]
+        assert [r.engine.extra for r in resolved] == ["appium"]
         assert invalid == []
 
     def test_resolves_extra_and_config_key_case_insensitively(self):
         resolved, invalid = resolve_engines(["APPIUM", "google-vision"])
-        assert [e.extra for e in resolved] == ["appium", "google-vision"]
+        assert [r.engine.extra for r in resolved] == ["appium", "google-vision"]
         assert invalid == []
 
     def test_reports_unknown_tokens_as_invalid(self):
         resolved, invalid = resolve_engines(["appium", "not-a-driver"])
-        assert [e.extra for e in resolved] == ["appium"]
+        assert [r.engine.extra for r in resolved] == ["appium"]
         assert invalid == ["not-a-driver"]
 
     def test_deduplicates_across_alias_forms(self):
         resolved, invalid = resolve_engines(["Appium", "appium"])
-        assert [e.extra for e in resolved] == ["appium"]
+        assert [r.engine.extra for r in resolved] == ["appium"]
         assert invalid == []
 
     @pytest.mark.parametrize(
@@ -112,26 +119,65 @@ class TestResolveEngines:
     )
     def test_bundle_expands_to_member_engines(self, bundle, expected_extras):
         resolved, invalid = resolve_engines([bundle])
-        assert [e.extra for e in resolved] == expected_extras
+        assert [r.engine.extra for r in resolved] == expected_extras
         assert invalid == []
 
     def test_all_bundle_expands_to_every_engine(self):
         resolved, invalid = resolve_engines(["all"])
-        assert {e.extra for e in resolved} == {e.extra for e in ALL_ENGINES.values()}
+        assert {r.engine.extra for r in resolved} == {e.extra for e in ALL_ENGINES.values()}
         assert invalid == []
 
     def test_bundle_is_case_insensitive(self):
         resolved, _ = resolve_engines(["WEB"])
-        assert [e.extra for e in resolved] == ["selenium", "playwright"]
+        assert [r.engine.extra for r in resolved] == ["selenium", "playwright"]
 
     def test_bundle_and_member_dedupe(self):
         # "web" pulls selenium+playwright; the explicit "selenium" must not repeat.
         resolved, invalid = resolve_engines(["web", "selenium"])
-        assert [e.extra for e in resolved] == ["selenium", "playwright"]
+        assert [r.engine.extra for r in resolved] == ["selenium", "playwright"]
         assert invalid == []
 
     def test_empty_input(self):
         assert resolve_engines([]) == ([], [])
+
+    def test_version_specifier_is_parsed_onto_request(self):
+        resolved, invalid = resolve_engines(["appium==4.2.0"])
+        assert [(r.engine.extra, r.version) for r in resolved] == [("appium", "==4.2.0")]
+        assert invalid == []
+
+    def test_range_specifier_preserved_verbatim(self):
+        resolved, _ = resolve_engines(["easyocr>=1.7,<2.0"])
+        assert resolved[0].version == ">=1.7,<2.0"
+
+    def test_version_on_bundle_is_invalid(self):
+        resolved, invalid = resolve_engines(["all==1.0"])
+        assert resolved == []
+        assert invalid == ["all==1.0"]
+
+    def test_explicit_version_wins_over_bare_duplicate(self):
+        # bundle brings selenium bare; explicit token then pins it.
+        resolved, _ = resolve_engines(["web", "selenium==4.20"])
+        selenium = next(r for r in resolved if r.engine.extra == "selenium")
+        assert selenium.version == "==4.20"
+
+
+# --------------------------------------------------------------------------- #
+# _split_token                                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestSplitToken:
+    @pytest.mark.parametrize(
+        "token, name, spec",
+        [
+            ("appium", "appium", None),
+            ("appium==4.2.0", "appium", "==4.2.0"),
+            ("google-vision==3.5", "google-vision", "==3.5"),
+            ("easyocr>=1.7,<2.0", "easyocr", ">=1.7,<2.0"),
+            ("appium ~= 4.2", "appium", "~= 4.2"),
+        ],
+    )
+    def test_splits_name_from_specifier(self, token, name, spec):
+        assert _split_token(token) == (name, spec)
 
 
 # --------------------------------------------------------------------------- #
@@ -146,7 +192,7 @@ class TestInstallExtras:
         assert "No engines selected" in capsys.readouterr().out
 
     def test_installs_version_pinned_spec(self):
-        engines = [ALL_ENGINES["Appium"]]
+        engines = _reqs("Appium")
         with patch(f"{MODULE}._installed_version", return_value="1.2.3"), \
                 patch(f"{MODULE}.subprocess.run") as run:
             install_extras(engines)
@@ -158,22 +204,39 @@ class TestInstallExtras:
     def test_unpinned_when_version_unknown(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras([ALL_ENGINES["Appium"]])
+            install_extras(_reqs("Appium"))
         args = run.call_args.args[0]
         assert args[-1] == f"{DISTRIBUTION_NAME}[appium]"
 
     def test_extras_sorted_and_deduped_in_spec(self):
-        engines = [ALL_ENGINES["Selenium"], ALL_ENGINES["Appium"], ALL_ENGINES["Selenium"]]
+        engines = _reqs("Selenium", "Appium", "Selenium")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
             install_extras(engines)
         spec = run.call_args.args[0][-1]
         assert spec == f"{DISTRIBUTION_NAME}[appium,selenium]"
 
+    def test_version_override_appends_pinned_package(self):
+        reqs = [InstallRequest(engine=ALL_ENGINES["Appium"], version="==4.2.0")]
+        with patch(f"{MODULE}._installed_version", return_value="1.2.3"), \
+                patch(f"{MODULE}.subprocess.run") as run:
+            install_extras(reqs)
+        assert run.call_args.args[0] == [
+            sys.executable, "-m", "pip", "install",
+            f"{DISTRIBUTION_NAME}[appium]==1.2.3", "appium-python-client==4.2.0",
+        ]
+
+    def test_no_version_appends_nothing(self):
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.run") as run:
+            install_extras(_reqs("Appium"))
+        # extras spec only, no trailing concrete package.
+        assert run.call_args.args[0][-1] == f"{DISTRIBUTION_NAME}[appium]"
+
     def test_playwright_triggers_browser_install(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras([ALL_ENGINES["Playwright"]])
+            install_extras(_reqs("Playwright"))
         assert run.call_count == 2
         assert run.call_args_list[1] == call(
             [sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"],
@@ -183,14 +246,14 @@ class TestInstallExtras:
     def test_non_playwright_skips_browser_install(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras([ALL_ENGINES["Appium"]])
+            install_extras(_reqs("Appium"))
         assert run.call_count == 1
 
     def test_failure_prints_captured_stderr(self, capsys):
         err = subprocess.CalledProcessError(1, "pip", stderr="boom: could not resolve")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            install_extras([ALL_ENGINES["Appium"]])
+            install_extras(_reqs("Appium"))
         out = capsys.readouterr().out
         assert "Installation failed" in out
         assert "boom: could not resolve" in out
@@ -199,7 +262,7 @@ class TestInstallExtras:
         err = subprocess.CalledProcessError(1, "pip", output="stdout detail", stderr="")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            install_extras([ALL_ENGINES["Appium"]])
+            install_extras(_reqs("Appium"))
         assert "stdout detail" in capsys.readouterr().out
 
 

--- a/tests/units/helpers/test_setup.py
+++ b/tests/units/helpers/test_setup.py
@@ -19,6 +19,7 @@ from optics_framework.helper.setup import (
     ALL_ENGINES,
     DISTRIBUTION_NAME,
     InstallRequest,
+    SetupError,
     _BUNDLES,
     _alias_index,
     _norm,
@@ -159,6 +160,20 @@ class TestResolveEngines:
         resolved, _ = resolve_engines(["web", "selenium==4.20"])
         selenium = next(r for r in resolved if r.engine.extra == "selenium")
         assert selenium.version == "==4.20"
+
+    def test_conflicting_versions_raise(self):
+        with pytest.raises(SetupError, match="conflicting versions"):
+            resolve_engines(["appium==4.2.0", "appium==5.0.0"])
+
+    def test_same_version_twice_is_deduped(self):
+        resolved, invalid = resolve_engines(["appium==5.0.0", "appium==5.0.0"])
+        assert [(r.engine.extra, r.version) for r in resolved] == [("appium", "==5.0.0")]
+        assert invalid == []
+
+    @pytest.mark.parametrize("token", ["appium=4.3.0", "appium=>4.3", "appium=="])
+    def test_malformed_specifier_raises(self, token):
+        with pytest.raises(SetupError, match="invalid version"):
+            resolve_engines([token])
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes #355.

`optics setup --install` already installs engines through version-bounded pyproject extras (pinned to your installed Optics version), so the "always latest, unbounded" part of #355 is handled. What was still missing is the issue's second ask: **letting a user pin a specific dependency version** — needed for reproducible CI/CD.

Any `--install` token may now carry a PEP 508 specifier:

```bash
optics setup --install appium==4.2.0 "easyocr>=1.7,<2.0"
```

## How it works

- `resolve_engines` splits the specifier off each token into a new `InstallRequest(engine, version)`.
- `install_extras` keeps the extras spec (`optics-framework[appium,easyocr]==<version>`) for transitive deps and, for any request with a version, appends the engine's **primary package** as a concrete pin (`appium-python-client==4.2.0`). pip intersects that with the extra's own range, so an out-of-range pin fails loudly rather than silently resolving elsewhere.
- A specifier on a bundle (`all==1.0`) is rejected — one version can't span many packages.
- The TUI picker (no version field) installs at the extra's default bound, unchanged.

## Tests

Extended `tests/units/helpers/test_setup.py`: specifier parsing (`_split_token`), version threaded onto `InstallRequest`, bundle+version rejection, explicit-version-wins dedupe, and the pinned-package install command. All 43 pass; `pre-commit` clean.

## Note (release timing)

The extras themselves land with the unreleased `1.9.0-beta.1`; the latest PyPI release (`1.8.6`) predates them, so `optics setup` only resolves extras once a build carrying them is published. This PR is about the override capability and is orthogonal to that release.