### PR TITLE
fix(docker): bump appium-python-client pin to 5.3.1

### DIFF
--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Install common Python packages and optics-framework wheel and vision backend
 RUN pip install --no-cache-dir --only-binary=:all: \
-   appium-python-client==4.5.1 playwright==1.61.0 \
+   appium-python-client==5.3.1 playwright==1.61.0 \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \

--- a/Docker/mcp/dev/Dockerfile
+++ b/Docker/mcp/dev/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Install common Python packages and optics-framework wheel with MCP extra and vision backend
 RUN pip install --no-cache-dir --only-binary=:all: \
-   appium-python-client==4.5.1 playwright==1.61.0 \
+   appium-python-client==5.3.1 playwright==1.61.0 \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \

--- a/Docker/mcp/prod/Dockerfile
+++ b/Docker/mcp/prod/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
-    && uv pip install --system --only-binary=:all: appium-python-client==4.5.1 playwright==1.61.0 \
+    && uv pip install --system --only-binary=:all: appium-python-client==5.3.1 playwright==1.61.0 \
     && playwright install-deps chromium firefox
 
 # Install optics-framework with MCP extra and vision backend (late layer for cache efficiency)

--- a/Docker/prod/Dockerfile
+++ b/Docker/prod/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
-    && uv pip install --system --only-binary=:all: appium-python-client==4.5.1 playwright==1.61.0 \
+    && uv pip install --system --only-binary=:all: appium-python-client==5.3.1 playwright==1.61.0 \
     && playwright install-deps chromium firefox
 
 # Install optics-framework and vision backend (late layer for cache efficiency)


### PR DESCRIPTION
## Summary
- All four Dockerfiles pinned `appium-python-client==4.5.1`, which is no longer on PyPI (only 5.2.0+ remain), breaking every image build
- Bumped to `5.3.1`, satisfying `pyproject.toml`'s `>=5.0,<6.0` constraint

## Test plan
- [x] `docker build` succeeds for each of `Docker/dev`, `Docker/prod`, `Docker/mcp/dev`, `Docker/mcp/prod`