### PR TITLE
fix(api): add /health route to match Docker healthcheck

### DIFF
--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -393,6 +393,7 @@ def discover_keywords() -> List[KeywordInfo]:
     return keywords
 
 @app.get("/", response_model=HealthCheckResponse, status_code=status.HTTP_200_OK)
+@app.get("/health", response_model=HealthCheckResponse, status_code=status.HTTP_200_OK)
 async def health_check():
     """
     Health check endpoint for Optics Framework API.


### PR DESCRIPTION
## Summary
- `Docker/docker-compose.yml` healthchecks for the `app` and `dev` services probe `http://localhost:8000/health`, but only `/` was registered as a health route in `expose_api.py`.
- `curl -f` against `/health` returned 404, so both containers were reported permanently unhealthy.
- Added `@app.get("/health", ...)` alongside the existing `/` route, returning the same `HealthCheckResponse`.

## Test plan
- [x] `poetry run pre-commit run --files optics_framework/common/expose_api.py`
- [x] Verified via `TestClient` that both `/` and `/health` return `200` with the expected `HealthCheckResponse` body