### PR TITLE
fix: use versions pinned in `poetry.lock` in Dockerfiles and github workflows

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,9 +25,12 @@ jobs:
           restore-keys: |
             mkdocs-material-
       # jsmin/csscompressor are sdist-only on PyPI, hence --no-binary.
+      # Versions come from poetry.lock (single source of truth) via scripts/lock_pins.py.
       - run: |
+          eval "$(python3 scripts/lock_pins.py)"
           pip install --no-cache-dir --only-binary=:all: --no-binary=jsmin,csscompressor \
-            mkdocs-material==9.7.6 "mkdocstrings[python]==1.0.4" mkdocs-minify-plugin==0.8.0
+            mkdocs-material==$MKDOCS_MATERIAL_VERSION "mkdocstrings[python]==$MKDOCSTRINGS_VERSION" \
+            mkdocstrings-python==$MKDOCSTRINGS_PYTHON_VERSION mkdocs-minify-plugin==$MKDOCS_MINIFY_PLUGIN_VERSION
       - run: mkdocs build
 
   deploy:
@@ -54,7 +57,10 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
+      # Versions come from poetry.lock (single source of truth) via scripts/lock_pins.py.
       - run: |
+          eval "$(python3 scripts/lock_pins.py)"
           pip install --no-cache-dir --only-binary=:all: --no-binary=jsmin,csscompressor \
-            mkdocs-material==9.7.6 "mkdocstrings[python]==1.0.4" mkdocs-minify-plugin==0.8.0
+            mkdocs-material==$MKDOCS_MATERIAL_VERSION "mkdocstrings[python]==$MKDOCSTRINGS_VERSION" \
+            mkdocstrings-python==$MKDOCSTRINGS_PYTHON_VERSION mkdocs-minify-plugin==$MKDOCS_MINIFY_PLUGIN_VERSION
       - run: mkdocs gh-deploy --force

--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -15,8 +15,9 @@ ENV WHL_FILE=${WHL_FILE}
 ARG VISION_BACKEND=easyocr
 ENV VISION_BACKEND=${VISION_BACKEND}
 
-# Copy the wheel into the container
+# Copy the wheel and lockfile into the container
 COPY dist/${WHL_FILE} /app/
+COPY poetry.lock scripts/lock_pins.py /app/
 
 
 # Install system dependencies (first layer for cache)
@@ -31,8 +32,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    && rm -rf /var/lib/apt/lists/*
 
 # Install common Python packages and optics-framework wheel and vision backend
-RUN pip install --no-cache-dir --only-binary=:all: \
-   appium-python-client==5.3.1 playwright==1.61.0 \
+RUN eval "$(python3 lock_pins.py)" \
+   && rm -f poetry.lock lock_pins.py \
+   && pip install --no-cache-dir --only-binary=:all: \
+   "appium-python-client==$APPIUM_VERSION" "playwright==$PLAYWRIGHT_VERSION" \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \
@@ -43,11 +46,11 @@ RUN pip install --no-cache-dir --only-binary=:all: \
    && pip install --no-cache-dir --only-binary=:all: --find-links="$(dirname "$WHEEL")" \
         "optics-framework==${WHEEL_VERSION}" \
    && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-      pip install --no-cache-dir --only-binary=:all: easyocr==1.7.2; \
+      pip install --no-cache-dir --only-binary=:all: "easyocr==$EASYOCR_VERSION"; \
    elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-      pip install --no-cache-dir --only-binary=:all: google-cloud-vision==3.15.0; \
+      pip install --no-cache-dir --only-binary=:all: "google-cloud-vision==$GOOGLE_CLOUD_VISION_VERSION"; \
    elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-      pip install --no-cache-dir --only-binary=:all: pytesseract==0.3.13; \
+      pip install --no-cache-dir --only-binary=:all: "pytesseract==$PYTESSERACT_VERSION"; \
    fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/mcp/dev/Dockerfile
+++ b/Docker/mcp/dev/Dockerfile
@@ -16,6 +16,7 @@ ENV WHL_FILE=${WHL_FILE}
 
 # Copy wheel(s) from dist/ (empty WHL_FILE copies all of dist/, matching Docker/dev/Dockerfile)
 COPY dist/${WHL_FILE} /app/
+COPY poetry.lock scripts/lock_pins.py /app/
 
 
 # Install system dependencies (first layer for cache)
@@ -30,8 +31,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
    && rm -rf /var/lib/apt/lists/*
 
 # Install common Python packages and optics-framework wheel with MCP extra and vision backend
-RUN pip install --no-cache-dir --only-binary=:all: \
-   appium-python-client==5.3.1 playwright==1.61.0 \
+RUN eval "$(python3 lock_pins.py)" \
+   && rm -f poetry.lock lock_pins.py \
+   && pip install --no-cache-dir --only-binary=:all: \
+   "appium-python-client==$APPIUM_VERSION" "playwright==$PLAYWRIGHT_VERSION" \
    && playwright install-deps chromium firefox \
    && WHEEL=$(if [ -n "$WHL_FILE" ]; then echo "/app/${WHL_FILE}"; else ls /app/*.whl 2>/dev/null | head -1; fi) \
    && if [ -z "$WHEEL" ] || [ ! -f "$WHEEL" ]; then \
@@ -42,11 +45,11 @@ RUN pip install --no-cache-dir --only-binary=:all: \
    && pip install --no-cache-dir --only-binary=:all: --find-links="$(dirname "$WHEEL")" \
         "optics-framework[mcp]==${WHEEL_VERSION}" \
    && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-      pip install --no-cache-dir --only-binary=:all: easyocr==1.7.2; \
+      pip install --no-cache-dir --only-binary=:all: "easyocr==$EASYOCR_VERSION"; \
    elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-      pip install --no-cache-dir --only-binary=:all: google-cloud-vision==3.15.0; \
+      pip install --no-cache-dir --only-binary=:all: "google-cloud-vision==$GOOGLE_CLOUD_VISION_VERSION"; \
    elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-      pip install --no-cache-dir --only-binary=:all: pytesseract==0.3.13; \
+      pip install --no-cache-dir --only-binary=:all: "pytesseract==$PYTESSERACT_VERSION"; \
    fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/mcp/prod/Dockerfile
+++ b/Docker/mcp/prod/Dockerfile
@@ -24,18 +24,24 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
-    && uv pip install --system --only-binary=:all: appium-python-client==5.3.1 playwright==1.61.0 \
+COPY poetry.lock scripts/lock_pins.py /app/
+
+RUN eval "$(python3 lock_pins.py)" \
+    && pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
+    && uv pip install --system --only-binary=:all: \
+        "appium-python-client==$APPIUM_VERSION" "playwright==$PLAYWRIGHT_VERSION" \
     && playwright install-deps chromium firefox
 
 # Install optics-framework with MCP extra and vision backend (late layer for cache efficiency)
-RUN uv pip install --system --only-binary=:all: "optics-framework[mcp]==${OPTICS_FRAMEWORK_VERSION}" \
+RUN eval "$(python3 lock_pins.py)" \
+    && rm -f poetry.lock lock_pins.py \
+    && uv pip install --system --only-binary=:all: "optics-framework[mcp]==${OPTICS_FRAMEWORK_VERSION}" \
     && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-        uv pip install --system --only-binary=:all: easyocr==1.7.2; \
+        uv pip install --system --only-binary=:all: "easyocr==$EASYOCR_VERSION"; \
     elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-        uv pip install --system --only-binary=:all: google-cloud-vision==3.15.0; \
+        uv pip install --system --only-binary=:all: "google-cloud-vision==$GOOGLE_CLOUD_VISION_VERSION"; \
     elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-        uv pip install --system --only-binary=:all: pytesseract==0.3.13; \
+        uv pip install --system --only-binary=:all: "pytesseract==$PYTESSERACT_VERSION"; \
     fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/Docker/prod/Dockerfile
+++ b/Docker/prod/Dockerfile
@@ -24,18 +24,24 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
-    && uv pip install --system --only-binary=:all: appium-python-client==5.3.1 playwright==1.61.0 \
+COPY poetry.lock scripts/lock_pins.py /app/
+
+RUN eval "$(python3 lock_pins.py)" \
+    && pip install --no-cache-dir --only-binary=:all: uv==0.11.32 \
+    && uv pip install --system --only-binary=:all: \
+        "appium-python-client==$APPIUM_VERSION" "playwright==$PLAYWRIGHT_VERSION" \
     && playwright install-deps chromium firefox
 
 # Install optics-framework and vision backend (late layer for cache efficiency)
-RUN uv pip install --system --only-binary=:all: "optics-framework==${OPTICS_FRAMEWORK_VERSION}" \
+RUN eval "$(python3 lock_pins.py)" \
+    && rm -f poetry.lock lock_pins.py \
+    && uv pip install --system --only-binary=:all: "optics-framework==${OPTICS_FRAMEWORK_VERSION}" \
     && if [ "$VISION_BACKEND" = "easyocr" ]; then \
-        uv pip install --system --only-binary=:all: easyocr==1.7.2; \
+        uv pip install --system --only-binary=:all: "easyocr==$EASYOCR_VERSION"; \
     elif [ "$VISION_BACKEND" = "google-vision" ]; then \
-        uv pip install --system --only-binary=:all: google-cloud-vision==3.15.0; \
+        uv pip install --system --only-binary=:all: "google-cloud-vision==$GOOGLE_CLOUD_VISION_VERSION"; \
     elif [ "$VISION_BACKEND" = "pytesseract" ]; then \
-        uv pip install --system --only-binary=:all: pytesseract==0.3.13; \
+        uv pip install --system --only-binary=:all: "pytesseract==$PYTESSERACT_VERSION"; \
     fi
 
 # If using google-vision, user must mount service account json and set GOOGLE_APPLICATION_CREDENTIALS

--- a/scripts/lock_pins.py
+++ b/scripts/lock_pins.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import shlex
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11 (e.g. Ubuntu 22.04's apt python3.10)
+    import tomli as tomllib
+
+with open("poetry.lock", "rb") as f:
+    pkgs = {p["name"]: p["version"] for p in tomllib.load(f)["package"]}
+
+# name -> poetry.lock package
+PINS = {
+    "APPIUM_VERSION": "appium-python-client",
+    "PLAYWRIGHT_VERSION": "playwright",
+    "EASYOCR_VERSION": "easyocr",
+    "GOOGLE_CLOUD_VISION_VERSION": "google-cloud-vision",
+    "PYTESSERACT_VERSION": "pytesseract",
+    "MKDOCS_MATERIAL_VERSION": "mkdocs-material",
+    "MKDOCSTRINGS_VERSION": "mkdocstrings",
+    "MKDOCSTRINGS_PYTHON_VERSION": "mkdocstrings-python",
+    "MKDOCS_MINIFY_PLUGIN_VERSION": "mkdocs-minify-plugin",
+    "UVICORN_VERSION": "uvicorn",
+}
+
+for var, pkg in PINS.items():
+    print(f"{var}={shlex.quote(pkgs[pkg])}")

--- a/tools/mock_remote_ocr/scalable/Dockerfile
+++ b/tools/mock_remote_ocr/scalable/Dockerfile
@@ -54,11 +54,16 @@ COPY tools/mock_remote_ocr /app/tools/mock_remote_ocr
 COPY pyproject.toml /app/
 
 COPY --from=build /wheels /wheels
-RUN WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
+COPY poetry.lock scripts/lock_pins.py /app/
+# easyocr / uvicorn versions come from poetry.lock (single source of truth); gunicorn isn't a
+# pyproject.toml dependency, so it has no lock entry to derive from and stays hardcoded.
+RUN eval "$(python3 lock_pins.py)" && \
+    rm -f poetry.lock lock_pins.py && \
+    WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
     pip install --no-cache-dir --only-binary=:all: --no-index --find-links=/wheels \
         "optics-framework==${WHEEL_VERSION}" && \
     pip install --no-cache-dir --only-binary=:all: \
-        easyocr==1.7.2 gunicorn==26.0.0 "uvicorn[standard]==0.37.0" && \
+        "easyocr==$EASYOCR_VERSION" gunicorn==26.0.0 "uvicorn[standard]==$UVICORN_VERSION" && \
     mkdir -p /home/optics && \
     python - <<'PY'
 import os

--- a/tools/mock_remote_ocr/scalable/Dockerfile.cuda
+++ b/tools/mock_remote_ocr/scalable/Dockerfile.cuda
@@ -34,12 +34,19 @@ RUN python3 -m pip wheel --only-binary=:all: --wheel-dir=/wheels .
 
 # Copy application
 COPY tools/mock_remote_ocr /app/tools/mock_remote_ocr
+COPY poetry.lock scripts/lock_pins.py /app/
 
-RUN WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
+# easyocr / uvicorn versions come from poetry.lock (single source of truth); gunicorn isn't a
+# pyproject.toml dependency, so it has no lock entry to derive from and stays hardcoded.
+# tomli backports tomllib for this image's apt-installed Python 3.10 (tomllib is 3.11+ stdlib).
+RUN python3 -m pip install --no-cache-dir --only-binary=:all: tomli==2.4.1 && \
+    eval "$(python3 lock_pins.py)" && \
+    rm -f poetry.lock lock_pins.py && \
+    WHEEL_VERSION="$(basename "$(ls /wheels/optics_framework-*.whl)" .whl | cut -d- -f2)" && \
     python3 -m pip install --no-cache-dir --only-binary=:all: --no-index --find-links=/wheels \
         "optics-framework==${WHEEL_VERSION}" && \
     python3 -m pip install --no-cache-dir --only-binary=:all: \
-        easyocr==1.7.2 gunicorn==26.0.0 "uvicorn[standard]==0.37.0" && \
+        "easyocr==$EASYOCR_VERSION" gunicorn==26.0.0 "uvicorn[standard]==$UVICORN_VERSION" && \
     mkdir -p /home/optics && \
     python3 - <<'PY'
 import os


### PR DESCRIPTION
Instead of hardcoding the versions of dependencies as done in https://github.com/mozarkai/optics-framework/pull/408 this pr will derive them from `poetry.lock` instead

some dependencies have been left hardcoded since they were not present in `poetry.lock`