### PR TITLE
fix/select highest confidence match in easyocr and remoteocr

### DIFF
--- a/optics_framework/engines/vision_models/ocr_models/easyocr.py
+++ b/optics_framework/engines/vision_models/ocr_models/easyocr.py
@@ -5,6 +5,9 @@ from optics_framework.common.text_interface import TextInterface
 from optics_framework.common import utils
 from optics_framework.common.logging_config import internal_logger
 
+# below this, a match is likely noise misread as containing the target substring.
+_MIN_MATCH_CONFIDENCE = 0.3
+
 
 class EasyOCRHelper(TextInterface):
     """
@@ -57,38 +60,42 @@ class EasyOCRHelper(TextInterface):
         else:
             _, ocr_results = detect_result
 
-        detected_texts = []
-
-        # Iterate over each detected text
+        # sort by confidence so a noise match can't outrank a real one.
+        candidates = []
         if ocr_results is not None:
             for bbox, detected_text, confidence in ocr_results:
                 detected_text = detected_text.strip()
-                if text in detected_text:
-                    top_left_ocr = bbox[0]  # (x1, y1)
-                    bottom_right_ocr = bbox[2]  # (x3, y3)
+                if text in detected_text and confidence >= _MIN_MATCH_CONFIDENCE:
+                    candidates.append((confidence, bbox))
+        candidates.sort(key=lambda c: c[0], reverse=True)
 
-                    x_top_left, y_top_left = int(top_left_ocr[0]), int(top_left_ocr[1])
-                    x_bottom_right, y_bottom_right = (
-                        int(bottom_right_ocr[0]),
-                        int(bottom_right_ocr[1]),
-                    )
+        detected_texts = []
+        for _confidence, bbox in candidates:
+            top_left_ocr = bbox[0]  # (x1, y1)
+            bottom_right_ocr = bbox[2]  # (x3, y3)
 
-                    # Create the (x,y) tuples for cv2.rectangle
-                    pt1 = (x_top_left, y_top_left)
-                    pt2 = (x_bottom_right, y_bottom_right)
+            x_top_left, y_top_left = int(top_left_ocr[0]), int(top_left_ocr[1])
+            x_bottom_right, y_bottom_right = (
+                int(bottom_right_ocr[0]),
+                int(bottom_right_ocr[1]),
+            )
 
-                    w = x_bottom_right - x_top_left
-                    h = y_bottom_right - y_top_left
+            # Create the (x,y) tuples for cv2.rectangle
+            pt1 = (x_top_left, y_top_left)
+            pt2 = (x_bottom_right, y_bottom_right)
 
-                    # Calculate the center coordinates
-                    center_x = x_top_left + w // 2
-                    center_y = y_top_left + h // 2
+            w = x_bottom_right - x_top_left
+            h = y_bottom_right - y_top_left
 
-                    detected_texts.append((True, (center_x, center_y), (pt1, pt2)))
+            # Calculate the center coordinates
+            center_x = x_top_left + w // 2
+            center_y = y_top_left + h // 2
 
-                    # Draw bounding box around the detected text
-                    cv2.rectangle(input_data, pt1, pt2, (0, 255, 0), 2)
-                    cv2.circle(input_data, (center_x, center_y), 5, (0, 0, 255), -1)
+            detected_texts.append((True, (center_x, center_y), (pt1, pt2)))
+
+            # Draw bounding box around the detected text
+            cv2.rectangle(input_data, pt1, pt2, (0, 255, 0), 2)
+            cv2.circle(input_data, (center_x, center_y), 5, (0, 0, 255), -1)
 
         if not detected_texts:
             return None

--- a/optics_framework/engines/vision_models/ocr_models/remote_ocr.py
+++ b/optics_framework/engines/vision_models/ocr_models/remote_ocr.py
@@ -9,6 +9,9 @@ from optics_framework.common import utils
 from optics_framework.common.config_handler import Config
 from optics_framework.common.logging_config import internal_logger
 
+# Below this, a match is likely noise misread as containing the target substring.
+_MIN_MATCH_CONFIDENCE = 0.3
+
 
 class RemoteOCR(TextInterface):
     DEPENDENCY_TYPE = "text_detection"
@@ -163,32 +166,37 @@ class RemoteOCR(TextInterface):
             return input_data
         return None
 
-    def _find_matching_elements(self, detections: List[Tuple[List[Tuple[int, int]], str, float]], text: str) -> List[Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]]:
-        """Find all matching elements for the given text."""
+    def _find_matching_elements(self, detections: List[Tuple[List[Tuple[int, int]], str, float]], text: str) -> List[Tuple[float, Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]]]:
+        """Find all matching elements for the given text, paired with their confidence.
+
+        Filters out low-confidence noise that happens to contain `text` as a substring
+        (same reasoning as EasyOCRHelper.find_element).
+        """
         matching_elements = []
-        for bbox, detected_text, _ in detections:
-            if text.lower() in detected_text.lower() and len(bbox) >= 4:
+        for bbox, detected_text, confidence in detections:
+            if text.lower() in detected_text.lower() and len(bbox) >= 4 and confidence >= _MIN_MATCH_CONFIDENCE:
                 top_left = (int(bbox[0][0]), int(bbox[0][1]))
                 bottom_right = (int(bbox[2][0]), int(bbox[2][1]))
                 center_x = (top_left[0] + bottom_right[0]) // 2
                 center_y = (top_left[1] + bottom_right[1]) // 2
                 matching_elements.append(
-                    (True, (center_x, center_y), (top_left, bottom_right))
+                    (confidence, (True, (center_x, center_y), (top_left, bottom_right)))
                 )
+        matching_elements.sort(key=lambda m: m[0], reverse=True)
         return matching_elements
 
-    def _select_matching_result(self, matching_elements: List[Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]], text: str, index: Optional[int]) -> Optional[Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]]:
-        """Select the matching result based on index or return the first match."""
+    def _select_matching_result(self, matching_elements: List[Tuple[float, Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]]], text: str, index: Optional[int]) -> Optional[Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]]:
+        """Select the matching result based on index (highest confidence first) or the best match."""
         if not matching_elements:
             internal_logger.debug(f"Text '{text}' not found in the image")
             return None
         if index is not None:
             if 0 <= index < len(matching_elements):
-                return matching_elements[index]
+                return matching_elements[index][1]
             internal_logger.debug(
                 f"Index {index} out of bounds for {len(matching_elements)} matches")
             return None
-        return matching_elements[0]
+        return matching_elements[0][1]
 
     def _annotate_and_save(self, img: "np.ndarray", result: Tuple[bool, Tuple[int, int], Tuple[Tuple[int, int], Tuple[int, int]]]) -> None:
         """Annotate the image with bounding box and center, then save."""

--- a/tests/units/engines/vision_models/ocr_models/test_easyocr.py
+++ b/tests/units/engines/vision_models/ocr_models/test_easyocr.py
@@ -1,0 +1,64 @@
+"""Unit tests for EasyOCRHelper.find_element -- highest-confidence match selection.
+
+A low-confidence misread elsewhere on screen can still contain the target text as a
+substring; find_element must not let that noise outrank a genuine, high-confidence match.
+"""
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from optics_framework.engines.vision_models.ocr_models.easyocr import EasyOCRHelper
+
+
+def _bbox(x1, y1, x2, y2):
+    """Quad in EasyOCR's (top-left, top-right, bottom-right, bottom-left) format."""
+    return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+
+@pytest.fixture
+def helper():
+    with patch("optics_framework.engines.vision_models.ocr_models.easyocr.easyocr.Reader"):
+        return EasyOCRHelper({"language": "en"})
+
+
+@pytest.fixture
+def frame():
+    return np.zeros((100, 100, 3), dtype=np.uint8)
+
+
+class TestFindElementConfidence:
+    def test_prefers_highest_confidence_match_over_earlier_low_confidence_substring(self, helper, frame):
+        """A low-confidence noise match listed first must not beat a later, real match."""
+        helper.reader.readtext.return_value = [
+            (_bbox(0, 0, 50, 50), 'garbled noise containing "TARGET" by chance', 0.05),
+            (_bbox(200, 200, 300, 300), "TARGET", 0.9),
+        ]
+        result = helper.find_element(frame, "TARGET", index=0)
+        assert result is not None
+        _found, (center_x, center_y), _bbox_out = result
+        assert (center_x, center_y) == (250, 250)
+
+    def test_filters_out_low_confidence_noise_below_threshold(self, helper, frame):
+        """No above-threshold candidate -- no match."""
+        helper.reader.readtext.return_value = [
+            (_bbox(0, 0, 50, 50), 'garbled noise containing "TARGET" by chance', 0.05),
+        ]
+        assert helper.find_element(frame, "TARGET", index=0) is None
+
+    def test_returns_none_when_text_not_present(self, helper, frame):
+        helper.reader.readtext.return_value = [
+            (_bbox(0, 0, 50, 50), "UNRELATED", 0.95),
+        ]
+        assert helper.find_element(frame, "TARGET", index=0) is None
+
+    def test_index_selects_among_matches_sorted_by_confidence_descending(self, helper, frame):
+        """index=0 is the highest-confidence match, index=1 the next -- not detection order."""
+        helper.reader.readtext.return_value = [
+            (_bbox(0, 0, 50, 50), "TARGET", 0.5),      # listed first, lower confidence
+            (_bbox(200, 200, 300, 300), "TARGET", 0.9),  # listed second, higher confidence
+        ]
+        first = helper.find_element(frame, "TARGET", index=0)
+        second = helper.find_element(frame, "TARGET", index=1)
+        assert first[1] == (250, 250)  # the 0.9-confidence match
+        assert second[1] == (25, 25)   # the 0.5-confidence match

--- a/tests/units/engines/vision_models/ocr_models/test_easyocr.py
+++ b/tests/units/engines/vision_models/ocr_models/test_easyocr.py
@@ -3,7 +3,7 @@
 A low-confidence misread elsewhere on screen can still contain the target text as a
 substring; find_element must not let that noise outrank a genuine, high-confidence match.
 """
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest

--- a/tests/units/engines/vision_models/ocr_models/test_remote_ocr.py
+++ b/tests/units/engines/vision_models/ocr_models/test_remote_ocr.py
@@ -1,0 +1,58 @@
+"""Unit tests for RemoteOCR.find_element -- highest-confidence match selection.
+
+Same reasoning as test_easyocr.py: a low-confidence misread elsewhere on screen can
+still contain the target text as a substring and must not outrank a real match.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.engines.vision_models.ocr_models.remote_ocr import RemoteOCR
+
+
+def _bbox(x1, y1, x2, y2):
+    return [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+
+
+@pytest.fixture
+def ocr():
+    return RemoteOCR({"url": "http://localhost:9999"})
+
+
+class TestFindElementConfidence:
+    def test_prefers_highest_confidence_match_over_earlier_low_confidence_substring(self, ocr):
+        """A low-confidence noise match listed first must not beat a later, real match."""
+        detections = [
+            (_bbox(0, 0, 50, 50), 'garbled noise containing "TARGET" by chance', 0.05),
+            (_bbox(200, 200, 300, 300), "TARGET", 0.9),
+        ]
+        with patch.object(ocr, "detect_text", return_value=("", detections)):
+            result = ocr.find_element("unused", "TARGET", index=0)
+        assert result is not None
+        _found, (center_x, center_y), _bbox_out = result
+        assert (center_x, center_y) == (250, 250)
+
+    def test_filters_out_low_confidence_noise_below_threshold(self, ocr):
+        """No above-threshold candidate -- no match."""
+        detections = [
+            (_bbox(0, 0, 50, 50), 'garbled noise containing "TARGET" by chance', 0.05),
+        ]
+        with patch.object(ocr, "detect_text", return_value=("", detections)):
+            assert ocr.find_element("unused", "TARGET", index=0) is None
+
+    def test_returns_none_when_text_not_present(self, ocr):
+        detections = [(_bbox(0, 0, 50, 50), "UNRELATED", 0.95)]
+        with patch.object(ocr, "detect_text", return_value=("", detections)):
+            assert ocr.find_element("unused", "TARGET", index=0) is None
+
+    def test_index_selects_among_matches_sorted_by_confidence_descending(self, ocr):
+        """index=0 is the highest-confidence match, index=1 the next -- not detection order."""
+        detections = [
+            (_bbox(0, 0, 50, 50), "TARGET", 0.5),        # listed first, lower confidence
+            (_bbox(200, 200, 300, 300), "TARGET", 0.9),  # listed second, higher confidence
+        ]
+        with patch.object(ocr, "detect_text", return_value=("", detections)):
+            first = ocr.find_element("unused", "TARGET", index=0)
+            second = ocr.find_element("unused", "TARGET", index=1)
+        assert first[1] == (250, 250)  # the 0.9-confidence match
+        assert second[1] == (25, 25)   # the 0.5-confidence match


### PR DESCRIPTION
This partially addresses a bug which I found while writing tests for running on emulated devices. I found that in case of multiple matches in the image, the first detected match would be selected which may or may not have the highest confidence. This pr sorts the matches with highest confidence and will select the match with the highest confidence


I would be creating issues for Google Vision and Pytesseract which I will link here

Edit: Issues #435 #436 and #437 are created