### PR TITLE
fix/letterboxed window bounds scaling

### DIFF
--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -942,13 +942,20 @@ def _window_size_from_source(element_source: Any) -> Optional[Tuple[int, int]]:
     return None
 
 
+# Appium reports the window size as integers, so the two axis ratios can differ by
+# roughly 1/window_dim purely from that rounding (e.g. a 375x812 window on a 1080x2340
+# screenshot: 2.8800 vs 2.8818). Below this relative difference the window is treated as
+# filling the screenshot; above it, the mismatch is a real letterbox.
+LETTERBOX_RATIO_TOLERANCE = 0.01
+
+
 def _pixel_scale_for_source(
     element_source: Any,
     screenshot: Optional[np.ndarray],
-) -> Optional[Tuple[float, float]]:
+) -> Optional[Tuple[float, float, float, float]]:
     """
-    Compute the per-axis scale that maps the driver's window coordinate space onto
-    the screenshot's pixel space, or ``None`` when scaling should not be applied.
+    Compute the transform that maps the driver's window coordinate space onto the
+    screenshot's pixel space, or ``None`` when it should not be applied.
 
     * Gated to **Appium** sources. Their page-source/WebElement coordinates and the
       driver's window size share one coordinate system (points on iOS, pixels on
@@ -956,13 +963,25 @@ def _pixel_scale_for_source(
       (Selenium/Playwright) report element coordinates (CSS pixels, scroll-relative)
       and window size in unrelated spaces, so the ratio is not correct there and we
       return ``None`` to leave their coordinates untouched.
+    * The window does not always cover the whole screenshot. A legacy iOS app (one
+      built without a modern launch storyboard) runs in compatibility mode: iOS gives
+      it a smaller window — e.g. 320x568 points on a 390x844-point iPhone — scales it
+      uniformly to fit the screen width and centres it, leaving black bars top and
+      bottom that the screenshot still includes. Stretching each axis independently
+      there spreads the window's 568 points across the full 2532-pixel frame, which
+      places boxes above the middle too high and boxes below it too low, with the error
+      growing toward both edges. When the two axis ratios disagree by more than
+      ``LETTERBOX_RATIO_TOLERANCE`` the smaller (fitting) ratio is used on both axes and
+      the leftover is returned as a centring offset. A window that fills the screenshot
+      yields equal ratios and zero offsets, i.e. the previous behaviour.
     * Best-effort and non-failing: returns ``None`` when no screenshot is available,
       the window size can't be determined, or its shape can't be read — callers then
       leave coordinates unscaled rather than raising.
 
     :param element_source: Element source (possibly an ``InstanceFallback`` wrapper).
     :param screenshot: The captured frame whose pixel space is the target.
-    :return: ``(scale_x, scale_y)``, or ``None`` when scaling must not be applied.
+    :return: ``(scale_x, scale_y, offset_x, offset_y)``, or ``None`` when the transform
+        must not be applied.
     """
     if screenshot is None:
         return None
@@ -979,27 +998,36 @@ def _pixel_scale_for_source(
         return None
     if window_width <= 0 or window_height <= 0:
         return None
-    return screenshot_width / window_width, screenshot_height / window_height
+    scale_x = screenshot_width / window_width
+    scale_y = screenshot_height / window_height
+    if abs(scale_x - scale_y) <= LETTERBOX_RATIO_TOLERANCE * max(scale_x, scale_y):
+        return scale_x, scale_y, 0.0, 0.0
+    scale = min(scale_x, scale_y)
+    offset_x = (screenshot_width - window_width * scale) / 2
+    offset_y = (screenshot_height - window_height * scale) / 2
+    return scale, scale, offset_x, offset_y
 
 
 def _apply_scale_to_bbox(
     bbox: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
     scale_x: float,
     scale_y: float,
+    offset_x: float = 0.0,
+    offset_y: float = 0.0,
 ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
     """
-    Multiply a single ``((x1,y1),(x2,y2))`` bbox by the given per-axis scale.
+    Map a single ``((x1,y1),(x2,y2))`` bbox through ``point * scale + offset`` per axis.
 
-    When the scale is 1.0 this is a no-op (``int(x * 1.0) == x``). Returns the bbox
-    unchanged on any structural failure.
+    With a scale of 1.0 and no offset this is a no-op (``int(x * 1.0) == x``). Returns
+    the bbox unchanged on any structural failure.
     """
     if bbox is None:
         return bbox
     try:
         (x1, y1), (x2, y2) = bbox
         return (
-            (int(x1 * scale_x), int(y1 * scale_y)),
-            (int(x2 * scale_x), int(y2 * scale_y)),
+            (int(x1 * scale_x + offset_x), int(y1 * scale_y + offset_y)),
+            (int(x2 * scale_x + offset_x), int(y2 * scale_y + offset_y)),
         )
     except (TypeError, ValueError, AttributeError):
         return bbox
@@ -1035,11 +1063,11 @@ def scale_bboxes_for_screenshot(
     """
     if not bboxes:
         return bboxes
-    scale = _pixel_scale_for_source(element_source, screenshot)
-    if scale is None:
+    transform = _pixel_scale_for_source(element_source, screenshot)
+    if transform is None:
         return bboxes
-    scale_x, scale_y = scale
-    return [_apply_scale_to_bbox(b, scale_x, scale_y) for b in bboxes]
+    scale_x, scale_y, offset_x, offset_y = transform
+    return [_apply_scale_to_bbox(b, scale_x, scale_y, offset_x, offset_y) for b in bboxes]
 
 
 def scale_interactive_element_bounds(
@@ -1071,10 +1099,10 @@ def scale_interactive_element_bounds(
     """
     if not elements:
         return
-    scale = _pixel_scale_for_source(element_source, screenshot)
-    if scale is None:
+    transform = _pixel_scale_for_source(element_source, screenshot)
+    if transform is None:
         return
-    scale_x, scale_y = scale
+    scale_x, scale_y, offset_x, offset_y = transform
     for el in elements:
         if not isinstance(el, dict):
             continue
@@ -1083,10 +1111,10 @@ def scale_interactive_element_bounds(
             continue
         try:
             el["bounds"] = {
-                "x1": int(bounds["x1"] * scale_x),
-                "y1": int(bounds["y1"] * scale_y),
-                "x2": int(bounds["x2"] * scale_x),
-                "y2": int(bounds["y2"] * scale_y),
+                "x1": int(bounds["x1"] * scale_x + offset_x),
+                "y1": int(bounds["y1"] * scale_y + offset_y),
+                "x2": int(bounds["x2"] * scale_x + offset_x),
+                "y2": int(bounds["y2"] * scale_y + offset_y),
             }
         except (KeyError, TypeError, ValueError):
             continue

--- a/tests/units/common/test_bbox_scaling.py
+++ b/tests/units/common/test_bbox_scaling.py
@@ -110,12 +110,13 @@ class TestScaleBboxesForScreenshot:
         src = _DirectSource(_FakeWebDriver(375, 812))
         assert utils.scale_bboxes_for_screenshot([], src, _pixel_screenshot()) == []
 
-    def test_non_uniform_scale_uses_correct_axis(self):
-        # window 100x200, screenshot 300x200 -> scale_x=3.0, scale_y=1.0.
-        # Distinct per-axis factors catch an x/y axis swap that aspect-matched
-        # fixtures cannot (a swap would yield ((10,30),(20,60)) instead).
+    def test_letterboxed_window_is_centred_not_stretched(self):
+        # window 100x200, screenshot 300x200: the window already fills the height, so
+        # it is a 100px-wide column centred in the frame, not something to stretch 3x
+        # horizontally. Both axes scale by 1.0 and x gains a 100px offset — distinct
+        # per-axis offsets still catch an x/y swap (which would yield ((10,110),(20,120))).
         src = _DirectSource(_FakeWebDriver(100, 200))
         result = utils.scale_bboxes_for_screenshot(
             [((10, 10), (20, 20))], src, _pixel_screenshot(width=300, height=200)
         )
-        assert result == [((30, 10), (60, 20))]
+        assert result == [((110, 10), (120, 20))]

--- a/tests/units/common/test_interactive_bounds_scaling.py
+++ b/tests/units/common/test_interactive_bounds_scaling.py
@@ -129,6 +129,54 @@ class TestScaleInteractiveElementBounds:
 
 
 # ---------------------------------------------------------------------------
+# A window that does not cover the screenshot: a legacy iOS app in compatibility
+# mode gets a 320x568-point window, scaled to fit the width of a 1170x2532-pixel
+# screen and centred, so the screenshot keeps a 227px black bar above and below.
+# Numbers below are from a real BitbarIOSSample session on an iPhone 14.
+# ---------------------------------------------------------------------------
+class TestLetterboxedWindow:
+    SRC = _AppiumSource(_FakeWebDriver(320, 568))
+
+    def _scaled(self, bounds):
+        els = [{"bounds": dict(bounds)}]
+        utils.scale_interactive_element_bounds(els, self.SRC, _screenshot(1170, 2532))
+        return els[0]["bounds"]
+
+    def test_uses_the_fitting_ratio_on_both_axes(self):
+        # 3.65625 (1170/320) on both, not 4.4577 (2532/568) vertically.
+        assert self._scaled({"x1": 0, "y1": 0, "x2": 320, "y2": 568}) == {
+            "x1": 0, "y1": 227, "x2": 1170, "y2": 2304,
+        }
+
+    def test_element_above_the_middle_is_not_lifted(self):
+        # "Buy 101 devices": the old per-axis stretch put y1 at 1016, 45px too high.
+        assert self._scaled({"x1": 52, "y1": 228, "x2": 181, "y2": 250}) == {
+            "x1": 190, "y1": 1061, "x2": 661, "y2": 1141,
+        }
+
+    def test_element_below_the_middle_is_not_dropped(self):
+        # "Answer": the old stretch put y1 at 1885, 111px too low.
+        assert self._scaled({"x1": 224, "y1": 423, "x2": 276, "y2": 442}) == {
+            "x1": 819, "y1": 1774, "x2": 1009, "y2": 1843,
+        }
+
+    def test_window_height_maps_inside_the_screenshot(self):
+        # The old stretch mapped the window's last row onto the frame's last row,
+        # hiding the letterbox entirely.
+        b = self._scaled({"x1": 0, "y1": 568, "x2": 1, "y2": 568})
+        assert b["y1"] == 2304 and b["y1"] < 2532
+
+    def test_near_uniform_ratios_keep_per_axis_scaling(self):
+        # 1080/375 = 2.8800 vs 2340/812 = 2.8818 — integer rounding of the window
+        # size, not a letterbox: no offset is introduced.
+        els = [{"bounds": {"x1": 20, "y1": 96, "x2": 355, "y2": 140}}]
+        utils.scale_interactive_element_bounds(
+            els, _AppiumSource(_FakeWebDriver(375, 812)), _screenshot()
+        )
+        assert els[0]["bounds"] == {"x1": 57, "y1": 276, "x2": 1022, "y2": 403}
+
+
+# ---------------------------------------------------------------------------
 # Both consumers share one gate/ratio helper — this cross-checks that the dict
 # path and the tuple path land on the same pixel geometry (tuple-path breadth
 # lives in test_bbox_scaling.py).
@@ -143,6 +191,17 @@ class TestSharedGateConsistency:
         # Both paths must land on the same pixel geometry.
         assert (b["x1"], b["y1"], b["x2"], b["y2"]) == (57, 276, 1022, 403)
         assert tuple_out == ((57, 276), (1022, 403))
+
+    def test_both_paths_agree_on_letterboxed_window(self):
+        src = _AppiumSource(_FakeWebDriver(320, 568))
+        els = [{"bounds": {"x1": 52, "y1": 228, "x2": 181, "y2": 250}}]
+        utils.scale_interactive_element_bounds(els, src, _screenshot(1170, 2532))
+        b = els[0]["bounds"]
+        tuple_out = utils.scale_bboxes_for_screenshot(
+            [((52, 228), (181, 250))], src, _screenshot(1170, 2532)
+        )[0]
+        assert (b["x1"], b["y1"], b["x2"], b["y2"]) == (190, 1061, 661, 1141)
+        assert tuple_out == ((190, 1061), (661, 1141))
 
     def test_both_paths_skip_non_appium(self):
         src = _SeleniumSource(_FakeWebDriver(375, 812))


### PR DESCRIPTION
This pr fixes the bug which returns wrong bounding boxes for ios when the app is letterboxed