### PR TITLE
fix(sdk): re-export Optics from the package root

### DIFF
--- a/optics_framework/__init__.py
+++ b/optics_framework/__init__.py
@@ -1,0 +1,12 @@
+"""Optics Framework — self-healing test automation for mobile, web and TV.
+
+The public Python SDK entry point is :class:`~optics_framework.optics.Optics`.
+It is re-exported here so the documented import works::
+
+    from optics_framework import Optics
+
+"""
+
+from optics_framework.optics import Optics
+
+__all__ = ["Optics"]

--- a/tests/units/test_optics.py
+++ b/tests/units/test_optics.py
@@ -16,6 +16,15 @@ ELEMENTS_CSV_PATH = os.path.join(os.path.dirname(__file__), '../../optics_framew
 MOCK_API_YAML_PATH = os.path.join(os.path.dirname(__file__), '../mock_servers/api.yaml')
 
 
+def test_optics_is_reexported_from_package_root():
+    """The documented ``from optics_framework import Optics`` import must resolve."""
+    import optics_framework
+    from optics_framework import Optics as RootOptics
+
+    assert RootOptics is Optics
+    assert "Optics" in optics_framework.__all__
+
+
 def load_config(config_path):
     with open(config_path, 'r') as f:
         return yaml.safe_load(f)


### PR DESCRIPTION
## What

`optics_framework/__init__.py` was empty, so the Python SDK import advertised in the README —

```python
from optics_framework import Optics
```

— raised `ImportError: cannot import name 'Optics' from 'optics_framework'`. Only the longer `from optics_framework.optics import Optics` worked.

This re-exports the `Optics` facade from the package root and declares `__all__`, so the documented import resolves.

## Why this fix (vs. changing the README)

Exporting the class is the ergonomic, conventional public API for a library's main entry point, and it makes the existing README example correct as-is. `optics.py` imports no optional/heavy backends at module load — drivers, OCR and LLM engines are resolved lazily via the factories, and `robotframework` is guarded — so this adds no import cost to the CLI path (verified `optics --version` / `optics list` still work).

## Testing

- `from optics_framework import Optics` now succeeds and is the same object as `optics_framework.optics.Optics`.
- Added a regression test: `tests/units/test_optics.py::test_optics_is_reexported_from_package_root`.
- `optics --version` and `optics list` unaffected (no import cycle).
- `pre-commit` clean on changed files.

## Context

Found while auditing every onboarding command in the README against a fresh PyPI install (v1.9.1). One of a set of independent fixes for issues that audit surfaced.