### PR TITLE
fix(generate): discover project files recursively

### DIFF
--- a/optics_framework/helper/generate.py
+++ b/optics_framework/helper/generate.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple, Optional, Union, Any
+from typing import Dict, List, Tuple, Optional, Union, Any, Iterator
 import logging
 import pandas as pd
 import yaml
@@ -636,6 +636,32 @@ def _assign_yaml_files(yaml_files, files):
             if key in data and not files[content_type]:
                 files[content_type] = yaml_file
 
+# Directories that never hold source project files — skipped when scanning so a
+# recursive walk doesn't pick up generated code, run artefacts or caches.
+_SKIP_SCAN_DIRS = {"__pycache__", "generated", "execution_output"}
+
+
+def _iter_project_files(folder_path: str) -> Iterator[Tuple[str, str, str]]:
+    """Yield ``(file_path, file_format, content_type)`` for every recognised file.
+
+    Walks ``folder_path`` recursively so files organised into subfolders
+    (``test_cases/``, ``modules/``, ``test_data/`` — the layout ``optics init``
+    scaffolds) are discovered, not only files sitting at the project root. Caches,
+    generated code and run artefacts are skipped.
+    """
+    for root, dirs, files in os.walk(folder_path):
+        dirs[:] = [
+            d for d in dirs if d not in _SKIP_SCAN_DIRS and not d.startswith(".")
+        ]
+        for name in files:
+            file_path = os.path.join(root, name)
+            result = detect_file_type(file_path)
+            if not result:
+                continue
+            file_format, content_type = result
+            yield file_path, file_format, content_type
+
+
 def find_all_files(folder_path: str) -> dict[str, list[str]]:
     """Find all CSV and YAML files for each content type, supporting mixed formats with priority rules."""
     files: dict[str, list[str]] = {
@@ -653,13 +679,7 @@ def find_all_files(folder_path: str) -> dict[str, list[str]]:
         "config": {"csv": [], "yaml": []},
     }
 
-    for file in os.listdir(folder_path):
-        file_path = os.path.join(folder_path, file)
-        result = detect_file_type(file_path)
-        if not result:
-            continue
-        file_format, content_type = result
-
+    for file_path, file_format, content_type in _iter_project_files(folder_path):
         if content_type in all_files_by_type:
             all_files_by_type[content_type][file_format].append(file_path)
 
@@ -696,12 +716,7 @@ def find_files(
     }
     yaml_files = []
 
-    for file in os.listdir(folder_path):
-        file_path = os.path.join(folder_path, file)
-        result = detect_file_type(file_path)
-        if not result:
-            continue
-        file_format, content_type = result
+    for file_path, file_format, content_type in _iter_project_files(folder_path):
         if file_format == "csv":
             files[content_type] = file_path
         elif file_format == "yaml" and content_type != "config":

--- a/tests/units/helpers/test_generate.py
+++ b/tests/units/helpers/test_generate.py
@@ -120,6 +120,18 @@ def yaml_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def nested_csv_project(tmp_path: Path) -> Path:
+    """The CSV project in the subfolder layout ``optics init`` scaffolds."""
+    for sub in ("test_cases", "modules", "test_data"):
+        (tmp_path / sub).mkdir()
+    _write(tmp_path / "test_cases", "test_cases.csv", CSV_TEST_CASES)
+    _write(tmp_path / "modules", "modules.csv", CSV_MODULES)
+    _write(tmp_path / "test_data", "elements.csv", CSV_ELEMENTS)
+    _write(tmp_path, "config.yaml", CONFIG_YAML)
+    return tmp_path
+
+
 # --------------------------------------------------------------------------- #
 # Readers                                                                      #
 # --------------------------------------------------------------------------- #
@@ -411,6 +423,21 @@ class TestFindFiles:
         assert el.endswith(f"elements.{ext}")
         assert cfg.endswith("config.yaml")
 
+    def test_find_all_files_discovers_subfolder_layout(self, nested_csv_project):
+        """Files split across ``test_cases/``, ``modules/`` and ``test_data/`` are found."""
+        found = find_all_files(str(nested_csv_project))
+        assert found["test_cases"] == [str(nested_csv_project / "test_cases" / "test_cases.csv")]
+        assert found["modules"] == [str(nested_csv_project / "modules" / "modules.csv")]
+        assert found["elements"] == [str(nested_csv_project / "test_data" / "elements.csv")]
+        assert found["config"] == [str(nested_csv_project / "config.yaml")]
+
+    def test_find_files_discovers_subfolder_layout(self, nested_csv_project):
+        tc, mod, el, cfg = find_files(str(nested_csv_project))
+        assert tc is not None and tc.endswith("test_cases.csv")
+        assert mod is not None and mod.endswith("modules.csv")
+        assert el is not None and el.endswith("elements.csv")
+        assert cfg is not None and cfg.endswith("config.yaml")
+
 
 # --------------------------------------------------------------------------- #
 # read_mixed_data merge + conflict detection                                  #
@@ -474,6 +501,12 @@ class TestGenerateTestFile:
         generate_test_file(str(tmp_path), framework="pytest")
         code = _generated_output(tmp_path, "pytest")
         assert "def test_login_test(optics):" in code
+
+    def test_pipeline_from_scaffolded_subfolder_layout(self, nested_csv_project):
+        """`optics generate` works on a project laid out the way `optics init` scaffolds it."""
+        generate_test_file(str(nested_csv_project), framework="pytest")
+        code = _generated_output(nested_csv_project, "pytest")
+        assert "Login Module" in code or "login_module" in code
 
     def test_custom_output_filename(self, csv_project):
         generate_test_file(str(csv_project), framework="pytest", output_filename="my_suite.py")


### PR DESCRIPTION
## What

`optics generate <project>` aborts with `Error: Missing test cases file` on any project created by `optics init`.

Root cause: `generate`'s discovery (`find_all_files` / `find_files`) scanned the folder with a flat `os.listdir()`, but `optics init` scaffolds files into subfolders (`test_cases/`, `modules/`, `test_data/`). So only `config.yaml` at the root was found — the two commands were incompatible out of the box.

## Fix

Walk the tree recursively so subfoldered layouts are discovered — the same approach the runner's own `execute.py:find_files` already uses (which is why `dry_run`/`execute` work on scaffolded projects but `generate` didn't). A shared `_iter_project_files` helper now backs both `find_all_files` and `find_files`, and prunes `__pycache__`, `generated/` and `execution_output/` so a re-run doesn't ingest its own generated tree or run artefacts.

## Testing

- New tests: `find_all_files` / `find_files` discover the `init` subfolder layout, and the end-to-end `generate_test_file` pipeline runs on a scaffolded project.
- Existing flat-layout tests still pass (walk visits the root first): full `test_generate.py` = 99 passed.
- Manual: `optics init --template contact` → `optics generate` now emits `generated/Tests/…` instead of aborting.
- `pre-commit` clean.

## Context

One of a set of independent fixes from a fresh-install audit of the README's onboarding commands (v1.9.1).

---
**Follow-ups:** #446 (make `--output` honor an arbitrary path)
