### PR TITLE
fix(samples): disable camera_screenshot in the gmail_web template

### DIFF
--- a/optics_framework/samples/gmail_web/config.yaml
+++ b/optics_framework/samples/gmail_web/config.yaml
@@ -36,7 +36,7 @@ elements_sources:
       url: null
       capabilities: {}
   - camera_screenshot:
-      enabled: true
+      enabled: false
       url: null
       capabilities: {}
 


### PR DESCRIPTION
## What

`optics init --template gmail_web` then `optics dry_run` fails out of the box:

```
Value error: No camera_index or valid URL provided
```

The gmail_web sample ships `camera_screenshot: enabled: true` in its element sources. That source needs a camera index or stream URL, which a Selenium web template has no reason to require — and the README advertises `--template` as scaffolding a *working* project.

## Fix

Set `camera_screenshot: enabled: false` in the sample. The already-enabled `selenium_page_source`, `selenium_screenshot` and `easyocr` sources cover the template.

## Testing

- Before: dry-run aborts with the camera error.
- After: dry-run passes **4/4** test cases (verified against the edited sample with selenium + easyocr installed).
- `pre-commit` (incl. `check-yaml`) clean.

## Context

One of a set of independent fixes from a fresh-install audit of the README's onboarding commands (v1.9.1).

---
**Follow-ups:** #445 (drift guard so a sample can't enable an uninstallable engine)
