### PR TITLE
fix(actions): restore keywords disabled by @DeprecationWarning misuse

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -580,12 +580,13 @@ class ActionKeyword:
         else:
             internal_logger.info(f'Element {element} not found. Press is not performed.')
 
-    @DeprecationWarning
     @with_self_healing
     def press_checkbox(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
                        aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
         """
         Press a specified checkbox element.
+
+        .. deprecated:: Deprecated alias of :meth:`press_element` — use ``Press Element`` directly.
 
         :param element: The checkbox element (Image template, OCR template, or XPath).
         :param aoi_x: X percentage of Area of Interest top-left corner (0-100). Default: 0.
@@ -594,15 +595,17 @@ class ActionKeyword:
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the press.
         """
+        internal_logger.warning("'Press Checkbox' is deprecated; use 'Press Element' instead.")
         self.press_element(element, aoi_x=aoi_x, aoi_y=aoi_y, aoi_width=aoi_width,
                           aoi_height=aoi_height, event_name=event_name, located=located)
 
-    @DeprecationWarning
     @with_self_healing
     def press_radio_button(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
                            aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
         """
         Press a specified radio button.
+
+        .. deprecated:: Deprecated alias of :meth:`press_element` — use ``Press Element`` directly.
 
         :param element: The radio button element (Image template, OCR template, or XPath).
         :param aoi_x: X percentage of Area of Interest top-left corner (0-100). Default: 0.
@@ -611,6 +614,7 @@ class ActionKeyword:
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the press.
         """
+        internal_logger.warning("'Press Radio Button' is deprecated; use 'Press Element' instead.")
         self.press_element(element, aoi_x=aoi_x, aoi_y=aoi_y, aoi_width=aoi_width,
                           aoi_height=aoi_height, event_name=event_name, located=located)
 
@@ -774,13 +778,17 @@ class ActionKeyword:
         internal_logger.info(f'Swiping from ({percent_x}, {percent_y}) to the {direction} with length {swipe_length}')
         self.driver.swipe_percentage(int(percent_x), int(percent_y), direction, int(swipe_length), event_name)
 
-    @DeprecationWarning
     def swipe_seekbar_to_right_android(self, element: str, event_name: Optional[str] = None) -> None:
         """
         Swipe a seekbar to the right.
 
+        .. deprecated:: Deprecated; prefer :meth:`swipe_from_element` / :meth:`swipe`.
+
         :param element: The seekbar element (Image template, OCR template, or XPath).
         """
+        internal_logger.warning(
+            "'Swipe Seekbar To Right Android' is deprecated; use 'Swipe From Element' instead."
+        )
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "swipe_seekbar_to_right_android")
         internal_logger.info(f'Swiping seekbar element: {element} to the right')

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -474,3 +474,44 @@ class TestSwipeUntilElementAppears:
 
         assert exc_info.value.code == Code.E0201
         assert action_keyword.driver.swipe_percentage.call_count == 4
+
+
+class TestDeprecatedAliases:
+    """Deprecated keywords must stay callable, registered aliases.
+
+    A ``@DeprecationWarning`` decorator (an exception class, not a real decorator)
+    silently replaced these methods with exception *instances*, dropping them from
+    the keyword map so the runner no longer resolved them. Guard against that.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_disk_writes(self):
+        with patch('optics_framework.common.utils.save_screenshot'):
+            yield
+
+    @pytest.mark.parametrize(
+        "name", ["press_checkbox", "press_radio_button", "swipe_seekbar_to_right_android"]
+    )
+    def test_alias_is_callable_not_warning(self, name):
+        attr = getattr(ActionKeyword, name)
+        assert callable(attr)
+        assert not isinstance(attr, Warning)
+
+    @pytest.mark.parametrize("alias", ["press_checkbox", "press_radio_button"])
+    def test_alias_delegates_to_press_element_with_deprecation_log(self, action_keyword, alias):
+        located = MagicMock()
+        with patch.object(
+            action_keyword.strategy_manager, 'locate',
+            return_value=[LocateResult(located, MagicMock())],
+        ), patch.object(action_keyword, 'press_element') as mock_press, patch(
+            'optics_framework.api.action_keyword.internal_logger'
+        ) as mock_logger:
+            getattr(action_keyword, alias)("box")
+
+        mock_press.assert_called_once()
+        assert mock_press.call_args.args[0] == "box"
+        assert mock_press.call_args.kwargs.get("located") is located
+        assert any(
+            "deprecated" in str(call.args[0]).lower()
+            for call in mock_logger.warning.call_args_list
+        )


### PR DESCRIPTION
## What

`press_checkbox`, `press_radio_button` and `swipe_seekbar_to_right_android` were decorated with `@DeprecationWarning`:

```python
@DeprecationWarning
@with_self_healing
def press_checkbox(self, element, ...):
```

`DeprecationWarning` is an exception class, not a decorator. Python evaluated `press_checkbox = DeprecationWarning(<function>)`, so each attribute became an **exception instance** — not callable, and skipped by `KeywordRegistry` (which registers public *callables*). Result: these keywords silently dropped off every surface — the CSV/YAML runner, `optics list`, the HTTP API and MCP.

That directly contradicts the README, which says Press Checkbox / Press Radio Button "still resolve but are deprecated aliases of Press Element."

## Fix

Remove the bogus decorator and log a real deprecation notice via `internal_logger.warning`. The two press aliases already delegate to `press_element`, and `with_self_healing` short-circuits re-location when `located` is passed (line 228), so the delegation is correct and doesn't double-locate. `swipe_seekbar_to_right_android` had the identical bug and is fixed the same way (fixing only 2 of 3 identical bugs would be a review smell).

## Testing

- `dry_run` now resolves `Press Checkbox` / `Press Radio Button` (was failing like an unknown keyword); verified 1/1 PASS on a small project.
- `optics list` now shows all three.
- New tests (`TestDeprecatedAliases`): the methods are callable (not `Warning` instances), and the press aliases delegate to `press_element` with a deprecation log.
- Full `test_action_keyword.py` = 31 passed. `pre-commit` clean.

## Note / open question

I restored `swipe_seekbar_to_right_android` as a working-but-deprecated keyword for consistency, but it isn't documented anywhere. If the intent was to **remove** it rather than deprecate it, say so and I'll drop it instead.

## Context

One of a set of independent fixes from a fresh-install audit of the README's onboarding commands (v1.9.1).