### PR TITLE
docs(readme): fix onboarding inaccuracies from a fresh-install audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python3 -m venv venv && source venv/bin/activate
 pip install "optics-framework[appium,easyocr]"
 ```
 
-Extra names match the `config.yaml` source keys, so the word you install is the word you enable:
+Most extra names match the `config.yaml` source keys, so the word you install is usually the word you enable (exceptions: `llm` enables the `gemini` engine, `google-vision` enables `google_vision`, and the bundles and `mcp` aren't config keys):
 
 | | |
 |---|---|
@@ -62,15 +62,18 @@ Extra names match the `config.yaml` source keys, so the word you install is the 
 | **AI** | `llm` (natural-language mode + self-heal) · `mcp` (MCP server) |
 | **Bundles** | `mobile` · `web` · `vision` · `all` |
 
-Or install them by name — `optics setup` pins to your installed Optics version, and bare `optics setup` opens a TUI picker:
+`optics setup` installs the drivers, OCR and LLM engines above (and the bundles) by name — pinned to your installed Optics version — and bare `optics setup` opens a TUI picker:
 
 ```bash
 optics setup --list
 optics setup --install appium easyocr
 ```
 
+> [!NOTE]
+> The `mcp` server extra is **pip-only** (it isn't an engine backend `optics setup` manages): `pip install "optics-framework[mcp]"`.
+
 > [!IMPORTANT]
-> A driver extra installs only the **Python client**. Mobile testing also needs the Appium server, a device/emulator, and platform tooling (Node.js, Android SDK/`adb`, JDK). See the [Installation & Prerequisites guide](https://mozarkai.github.io/optics-framework/prerequisites/).
+> Some extras need system tooling beyond the Python package. A driver extra installs only the **Python client** — mobile testing also needs the Appium server, a device/emulator, and platform tooling (Node.js, Android SDK/`adb`, JDK). `pytesseract` needs the Tesseract binary; `playwright` needs its browsers (`playwright install`). See the [Installation & Prerequisites guide](https://mozarkai.github.io/optics-framework/prerequisites/).
 
 > [!WARNING]
 > Conda is not supported for `easyocr` + `optics-framework` together (conflicting NumPy 1.x/2.x requirements). Use a standard `venv`.
@@ -80,11 +83,18 @@ optics setup --install appium easyocr
 ```bash
 optics init --name my_test_project --template contact
 # point my_test_project/config.yaml at your device/app, start the Appium server, then:
-optics dry_run my_test_project    # validate keywords, elements and module refs — no device needed
+optics dry_run my_test_project    # validate keywords, elements and module refs — no device (but the config's engines must be installed)
 optics execute my_test_project
 ```
 
-`--template` scaffolds a working project from a bundled sample: `contact`, `calendar`, `youtube` (Appium/Android), `clock` (Android + image templates), `gmail_web` (Selenium), `playwright` (Playwright). Omit it for an empty scaffold with a commented starter `config.yaml`.
+`--template` scaffolds a working project from a bundled sample. Each needs the matching extras installed (see [Install](#install)); the headline `[appium,easyocr]` above covers the first three:
+
+- `contact` · `calendar` · `youtube` — Appium/Android, easyocr → `[appium,easyocr]`
+- `clock` — Appium/Android, image templates + Tesseract OCR → `[appium,pytesseract]` (plus the Tesseract binary)
+- `gmail_web` — Selenium → `[selenium,easyocr]`
+- `playwright` — Playwright → `[playwright]` (then `playwright install` for the browsers)
+
+Omit `--template` for an empty scaffold with a commented starter `config.yaml`.
 
 ## Write a test as data
 
@@ -98,6 +108,8 @@ my_test_project/
     ├── error_definitions.csv      # optional
     └── input_templates/*.png      # optional, for image matching
 ```
+
+Optics discovers these files by their **content** (CSV headers / YAML top-level keys), not their path — the folder names above are a convention, so `elements.csv` works equally under `test_data/` or `elements/` (the folder `optics live`'s `/save` writes to).
 
 **`test_data/elements.csv`** — names mapped to locators. Doubles as a general variable store; repeating a name builds a fallback list.
 
@@ -276,7 +288,7 @@ Drop an `error_definitions.csv` into `test_data/` and Optics scans visible text 
 ## CLI reference
 
 ```text
-optics init        Scaffold a new project (--template, --path, --force, --git-init)
+optics init        Scaffold a new project (--name, --template, --path, --force, --git-init)
 optics setup       Install engine backends (--list, --install); bare command opens a TUI
 optics dry_run     Validate a project without touching a device
 optics execute     Run a project (--runner test_runner|pytest)


### PR DESCRIPTION
## What

Doc-only fixes for mismatches found by running every README onboarding command against a clean PyPI install (v1.9.1):

- **`mcp` install path.** The table lists `mcp` and the text says "install them by name" with `optics setup`, but `optics setup --install mcp` → `Invalid engine(s): mcp`. Added a NOTE that `mcp` is pip-only, and reworded so `setup` only claims the engines/bundles it actually installs.
- **"Extra names match config keys."** Softened — `llm`→`gemini`, `google-vision`→`google_vision`, and the bundles/`mcp` aren't config keys.
- **System tooling.** The IMPORTANT note only mentioned Appium; added that `pytesseract` needs the Tesseract binary and `playwright` needs `playwright install`.
- **Per-template extras.** `--template` claimed to scaffold "a working project", but the headline `[appium,easyocr]` only dry-runs contact/calendar/youtube. Annotated each template with the extras it needs (clock → pytesseract, gmail_web → selenium, playwright → playwright).
- **dry_run.** Clarified it needs the configured engines installed ("no device" ≠ "no deps") — a missing OCR/driver extra fails it before validation.
- **CLI reference.** `optics init`'s line omitted the required `--name`.
- **Elements path.** The layout uses `test_data/elements.csv` while `optics live`'s `/save` section writes `elements/elements.csv`; noted that files are discovered by content, so both work.

## Testing

Doc-only. `pre-commit` clean; relative `[Install](#install)` anchor verified.

## Context

Part of a set of fixes from the same audit (companion PRs fix the SDK import, `generate`, the gmail_web template, and the deprecated aliases).

---
**Follow-ups:** #445 (template↔extras drift guard)
