### PR TITLE
fix(setup): make the engine-installer TUI responsive and legible

### DIFF
--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -384,7 +384,10 @@ class EngineInstaller(Command):
                 print(f"Error: Invalid engine(s): {', '.join(invalid)}")
                 print("Use `optics setup --list` to see available engines")
                 return
-            install_extras(engines)
+            success, message = install_extras(engines)
+            print(message)
+            if not success:
+                sys.exit(1)
         else:
             EngineInstallerApp().run()
 

--- a/optics_framework/helper/setup.py
+++ b/optics_framework/helper/setup.py
@@ -3,7 +3,9 @@ import subprocess  # nosec B404
 from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List, Optional
 import sys
+from textual import work
 from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll
 from textual.widgets import Checkbox, Button, Header, Footer, Static
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pydantic import BaseModel
@@ -217,7 +219,12 @@ def resolve_engines(tokens: List[str]) -> tuple[List[InstallRequest], List[str]]
 
 
 class EngineInstallerApp(App):
+    TITLE = "optics setup"
+
     CSS = """
+    #engine-list {
+        height: 1fr;
+    }
     Checkbox {
         margin: 1;
     }
@@ -228,6 +235,9 @@ class EngineInstallerApp(App):
     Static {
         padding: 1;
     }
+    #status {
+        color: $text-muted;
+    }
     """
 
     def __init__(self):
@@ -236,20 +246,24 @@ class EngineInstallerApp(App):
 
     def compose(self) -> ComposeResult:
         yield Header()
-        yield Static("Select engines to install:", classes="title")
+        # Scroll the (potentially long) engine list so the action buttons below
+        # stay on-screen even on a short terminal.
+        with VerticalScroll(id="engine-list"):
+            yield Static("Select engines to install:", classes="title")
 
-        yield Static("Action Drivers:")
-        for name, engine in ACTION_DRIVERS.engines.items():
-            yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"action_{name.lower().replace(' ', '_')}")
+            yield Static("Action Drivers:")
+            for name, engine in ACTION_DRIVERS.engines.items():
+                yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"action_{name.lower().replace(' ', '_')}")
 
-        yield Static("OCR Engines:")
-        for name, engine in TEXT_ENGINES.engines.items():
-            yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"text_{name.lower().replace(' ', '_')}")
+            yield Static("OCR Engines:")
+            for name, engine in TEXT_ENGINES.engines.items():
+                yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"text_{name.lower().replace(' ', '_')}")
 
-        yield Static("LLM Engines:")
-        for name, engine in LLM_ENGINES.engines.items():
-            yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"llm_{name.lower().replace(' ', '_')}")
+            yield Static("LLM Engines:")
+            for name, engine in LLM_ENGINES.engines.items():
+                yield Checkbox(f"{name} ({', '.join(engine.packages)})", id=f"llm_{name.lower().replace(' ', '_')}")
 
+        yield Static("", id="status")
         yield Button("Install Selected", id="install", variant="primary")
         yield Button("Quit", id="quit", variant="error")
         yield Footer()
@@ -277,12 +291,37 @@ class EngineInstallerApp(App):
             self.exit()
 
     def install_engines(self) -> None:
-        """Install every checked engine. The checkbox UI has no version field,
-        so each selection installs at its extra's default bound."""
+        """Kick off installation of every checked engine in a worker thread.
+
+        The checkbox UI has no version field, so each selection installs at its
+        extra's default bound. The pip install (and any Playwright browser
+        download) runs off the UI thread so the TUI stays responsive instead of
+        freezing for the duration."""
         if not self.selected_engines:
             self.notify("No engines selected!", severity="warning")
             return
-        install_extras([InstallRequest(engine=e) for e in self.selected_engines.values()])
+        requests = [InstallRequest(engine=e) for e in self.selected_engines.values()]
+        self.query_one("#install", Button).disabled = True
+        self.query_one("#status", Static).update(
+            "Installing… this can take a while (browser/model downloads); the UI stays responsive."
+        )
+        self._install_worker(requests)
+
+    @work(thread=True)
+    def _install_worker(self, requests: List[InstallRequest]) -> None:
+        """Run the blocking install off the UI thread, then report back on it."""
+        success, message = install_extras(requests)
+        self.call_from_thread(self._on_install_finished, success, message)
+
+    def _on_install_finished(self, success: bool, message: str) -> None:
+        self.query_one("#status", Static).update(message)
+        self.notify(
+            message.splitlines()[0],
+            severity="information" if success else "error",
+            timeout=10,
+        )
+        # Re-enable Install so a failed run can be retried; harmless on success.
+        self.query_one("#install", Button).disabled = False
 
 
 def _installed_version() -> Optional[str]:
@@ -292,7 +331,7 @@ def _installed_version() -> Optional[str]:
         return None
 
 
-def install_extras(requests: List[InstallRequest]) -> None:
+def install_extras(requests: List[InstallRequest]) -> tuple[bool, str]:
     """Install the selected engine backends by pulling the matching
     `optics-framework` extras, pinned to the installed version so the CLI is
     never upgraded out from under the user.
@@ -303,10 +342,13 @@ def install_extras(requests: List[InstallRequest]) -> None:
     supported range fails loudly rather than silently downgrading it.
     ``packages[0]`` is each engine's primary package — the one a version
     override targets. Extra packages, like pytesseract's pillow, stay on the
-    extra's bound."""
+    extra's bound.
+
+    Returns ``(success, message)`` rather than printing, so both the CLI
+    (`optics setup --install`) and the TUI can surface the outcome — the TUI's
+    alternate screen swallows ``print``. Callers decide how to display it."""
     if not requests:
-        print("No engines selected.")
-        return
+        return False, "No engines selected."
 
     extras = sorted({req.engine.extra for req in requests})
     installed = _installed_version()
@@ -322,7 +364,6 @@ def install_extras(requests: List[InstallRequest]) -> None:
             capture_output=True, text=True, check=True, shell=False)
 
         if any(req.engine.extra == "playwright" for req in requests):
-            print("Installing Playwright Chromium browser and system dependencies...")
             # Per https://playwright.dev/python/docs/browsers this must run after
             # the pip install. Chromium is the most common target; --with-deps
             # pulls the required OS libraries.
@@ -330,14 +371,16 @@ def install_extras(requests: List[InstallRequest]) -> None:
                 [sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"],
                 capture_output=True, text=True, check=True, shell=False)
 
-        print("Engines installed successfully!")
+        return True, "Engines installed successfully!"
     except subprocess.CalledProcessError as e:
         # capture_output routes the command's diagnostics to e.stderr/e.stdout
-        # rather than the console, so surface them here for a debuggable failure.
-        print(f"Installation failed: {e}")
+        # rather than the console, so fold them into the message for a debuggable
+        # failure.
         detail = (e.stderr or "").strip() or (e.stdout or "").strip()
+        message = f"Installation failed: {e}"
         if detail:
-            print(detail)
+            message = f"{message}\n{detail}"
+        return False, message
 
 
 def list_engines() -> None:

--- a/tests/units/helpers/test_setup.py
+++ b/tests/units/helpers/test_setup.py
@@ -15,9 +15,12 @@ from unittest.mock import call, patch
 
 import pytest
 
+from textual.widgets import Static
+
 from optics_framework.helper.setup import (
     ALL_ENGINES,
     DISTRIBUTION_NAME,
+    EngineInstallerApp,
     InstallRequest,
     SetupError,
     _BUNDLES,
@@ -200,11 +203,19 @@ class TestSplitToken:
 # --------------------------------------------------------------------------- #
 
 class TestInstallExtras:
-    def test_noop_on_empty(self, capsys):
+    def test_returns_false_on_empty(self):
         with patch(f"{MODULE}.subprocess.run") as run:
-            install_extras([])
+            ok, message = install_extras([])
         run.assert_not_called()
-        assert "No engines selected" in capsys.readouterr().out
+        assert ok is False
+        assert "No engines selected" in message
+
+    def test_success_returns_true_and_message(self):
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.run"):
+            ok, message = install_extras(_reqs("Appium"))
+        assert ok is True
+        assert "installed successfully" in message.lower()
 
     def test_installs_version_pinned_spec(self):
         engines = _reqs("Appium")
@@ -264,21 +275,22 @@ class TestInstallExtras:
             install_extras(_reqs("Appium"))
         assert run.call_count == 1
 
-    def test_failure_prints_captured_stderr(self, capsys):
+    def test_failure_returns_message_with_stderr(self):
         err = subprocess.CalledProcessError(1, "pip", stderr="boom: could not resolve")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            install_extras(_reqs("Appium"))
-        out = capsys.readouterr().out
-        assert "Installation failed" in out
-        assert "boom: could not resolve" in out
+            ok, message = install_extras(_reqs("Appium"))
+        assert ok is False
+        assert "Installation failed" in message
+        assert "boom: could not resolve" in message
 
-    def test_failure_falls_back_to_stdout(self, capsys):
+    def test_failure_falls_back_to_stdout(self):
         err = subprocess.CalledProcessError(1, "pip", output="stdout detail", stderr="")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            install_extras(_reqs("Appium"))
-        assert "stdout detail" in capsys.readouterr().out
+            ok, message = install_extras(_reqs("Appium"))
+        assert ok is False
+        assert "stdout detail" in message
 
 
 # --------------------------------------------------------------------------- #
@@ -311,3 +323,66 @@ class TestPyprojectParity:
                 f"bundle '{bundle}' expands to {expanded} "
                 f"but pyproject declares {declared}"
             )
+
+
+# --------------------------------------------------------------------------- #
+# EngineInstallerApp (TUI)                                                     #
+# --------------------------------------------------------------------------- #
+
+class TestEngineInstallerApp:
+    """The picker must give visible feedback and stay responsive.
+
+    install runs in a thread worker (not inline on the event loop), the outcome
+    is shown in a Static/notification (not a swallowed print), and the checkbox
+    list lives in a scroll container so the buttons stay reachable.
+    """
+
+    async def test_list_is_scrollable_and_status_present(self):
+        from textual.containers import VerticalScroll
+        app = EngineInstallerApp()
+        async with app.run_test():
+            # The engine list lives in a scroll container so the buttons below it
+            # stay reachable on a short terminal.
+            assert app.query(VerticalScroll)
+            assert app.query_one("#status", Static) is not None
+            assert app.query_one("#install") is not None
+
+    async def test_no_selection_notifies_and_skips_install(self):
+        app = EngineInstallerApp()
+        with patch(f"{MODULE}.install_extras") as inst:
+            async with app.run_test() as pilot:
+                await pilot.click("#install")
+                await pilot.pause()
+        inst.assert_not_called()
+
+    async def test_install_runs_in_worker_and_reports_result(self):
+        app = EngineInstallerApp()
+        with patch(
+            f"{MODULE}.install_extras",
+            return_value=(True, "Engines installed successfully!"),
+        ) as inst:
+            async with app.run_test() as pilot:
+                app.selected_engines = {"Appium": ALL_ENGINES["Appium"]}
+                await pilot.click("#install")
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+                status = app.query_one("#status", Static)
+                assert "installed successfully" in str(status.render()).lower()
+        inst.assert_called_once()
+
+    async def test_failure_result_shown_and_install_reenabled(self):
+        from textual.widgets import Button
+        app = EngineInstallerApp()
+        with patch(
+            f"{MODULE}.install_extras",
+            return_value=(False, "Installation failed: boom"),
+        ):
+            async with app.run_test() as pilot:
+                app.selected_engines = {"Appium": ALL_ENGINES["Appium"]}
+                await pilot.click("#install")
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+                status = app.query_one("#status", Static)
+                assert "failed" in str(status.render()).lower()
+                # Install re-enabled so the user can retry after a failure.
+                assert app.query_one("#install", Button).disabled is False


### PR DESCRIPTION
## What

Bare `optics setup` opens a Textual picker that *looked* broken — the handler chain is wired correctly (checkbox → selection → `install_extras`), but three UX bugs made pressing **Install Selected** feel like a no-op:

1. **UI freeze.** The install ran `subprocess.run(pip install …)` synchronously on Textual's event loop, so the whole TUI hung for the duration (and again for the Playwright browser download).
2. **Invisible feedback.** Success/failure went through `print()`, which is swallowed while Textual owns the alternate screen — the screen looked unchanged.
3. **Unreachable buttons.** The checkbox list wasn't in a scroll container, so on a short terminal (e.g. 80×24) the buttons fell below the fold.

## Fix

- Run the install in a `@work(thread=True)` worker; disable **Install** and show an "Installing…" status while it runs, then report the result in a status line + `notify(...)` and re-enable for retry.
- `install_extras` now returns `(success, message)` instead of only printing. The CLI `--install` path prints that message and **exits non-zero on failure** (it previously exited 0 even when pip failed — bad for scripts/CI).
- Wrap the checkbox list in a `VerticalScroll` so the buttons stay reachable.

## Testing

- New `TestEngineInstallerApp` (Textual `run_test` harness): the list is in a `VerticalScroll` and a status line exists; no-selection notifies without installing; a selected install runs in a worker and shows the result; a failed install shows the error and re-enables Install.
- Updated `install_extras` tests for the `(success, message)` contract; full `test_setup.py` = 53 passed.
- `pre-commit` clean; CLI: failed `--install` now exits 1, `--list` exits 0.

## Context

Reported from a headless probe of the picker; part of the same README/onboarding hardening pass as the companion PRs.

---
**Follow-ups:** #447 (stream long-install progress; report installed extras)
