### PR TITLE
fix(serve): make optics loop non blocking enabling health checks while loop is on

### DIFF
--- a/optics_framework/common/execution.py
+++ b/optics_framework/common/execution.py
@@ -186,7 +186,10 @@ class KeywordExecutor(Executor):
             try:
                 # Deserialize parameters based on method signature
                 deserialized_params = _deserialize_params(method, self.params)
-                result = method(*deserialized_params)
+                async with session.keyword_lock:
+                    result = await asyncio.to_thread(method, *deserialized_params)
+                    heal_owner = getattr(method, "__self__", None)
+                    heal_info = heal_owner._pop_last_heal_info() if hasattr(heal_owner, "_pop_last_heal_info") else None
             except Exception as e:
                 await event_manager.publish_event(Event(
                     entity_type="keyword",
@@ -197,8 +200,6 @@ class KeywordExecutor(Executor):
                     extra={"session_id": session.session_id}
                 ))
                 raise OpticsError(Code.E0401, message=f"Keyword execution failed: {str(e)}") from e
-            heal_owner = getattr(method, "__self__", None)
-            heal_info = heal_owner._pop_last_heal_info() if hasattr(heal_owner, "_pop_last_heal_info") else None
             extra = {"session_id": session.session_id}
             if heal_info:
                 extra["healed"] = "true"

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -510,7 +510,8 @@ async def create_session(config: SessionConfig):
                     status_code=400,
                     detail=f"{MSG_INVALID_API_DATA} {e}",
                 ) from e
-        session_id = session_manager.create_session(
+        session_id = await asyncio.to_thread(
+            session_manager.create_session,
             session_config,
             test_cases=None,
             modules=None,

--- a/optics_framework/common/session_manager.py
+++ b/optics_framework/common/session_manager.py
@@ -143,6 +143,7 @@ class Session:
 
         self.driver = self.optics.get_driver()
         self.event_queue = asyncio.Queue()
+        self.keyword_lock = asyncio.Lock()
 
 
 class SessionManager(SessionHandler):

--- a/tests/units/common/test_execution_self_heal.py
+++ b/tests/units/common/test_execution_self_heal.py
@@ -23,6 +23,9 @@ def _run(coro):
 class _Session:
     session_id = "sess-1"
 
+    def __init__(self):
+        self.keyword_lock = asyncio.Lock()
+
 
 class _Runner:
     def __init__(self, keyword_map):

--- a/tests/units/common/test_execution_threading.py
+++ b/tests/units/common/test_execution_threading.py
@@ -1,0 +1,62 @@
+"""Concurrency contracts for the ``optics serve`` keyword executor."""
+import asyncio
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+
+from optics_framework.common.execution import KeywordExecutor
+
+pytestmark = pytest.mark.white_box
+
+
+class _Session:
+    session_id = "sess-1"
+
+    def __init__(self):
+        self.keyword_lock = asyncio.Lock()
+
+
+class _Runner:
+    def __init__(self, keyword_map):
+        self.keyword_map = keyword_map
+
+
+class _BlockingKeyword:
+    def __init__(self):
+        self.first_started = threading.Event()
+        self.release_first = threading.Event()
+        self.invocations: list[str] = []
+        self.thread_ids: list[int] = []
+
+    def block(self, marker: str):
+        self.invocations.append(marker)
+        self.thread_ids.append(threading.get_ident())
+        if marker == "first":
+            self.first_started.set()
+            assert self.release_first.wait(timeout=1)
+        return marker
+
+
+def test_keyword_execution_uses_a_thread_and_serializes_per_session():
+    async def run():
+        main_thread_id = threading.get_ident()
+        session = _Session()
+        keyword = _BlockingKeyword()
+        runner = _Runner({"block": keyword.block})
+        first = asyncio.create_task(
+            KeywordExecutor("block", ["first"], AsyncMock()).execute(session, runner)
+        )
+
+        await asyncio.wait_for(asyncio.to_thread(keyword.first_started.wait), timeout=0.5)
+        second = asyncio.create_task(
+            KeywordExecutor("block", ["second"], AsyncMock()).execute(session, runner)
+        )
+        await asyncio.sleep(0.05)
+
+        assert keyword.invocations == ["first"]
+        keyword.release_first.set()
+        assert await asyncio.gather(first, second) == ["first", "second"]
+        assert all(thread_id != main_thread_id for thread_id in keyword.thread_ids)
+
+    asyncio.run(run())

--- a/tests/units/common/test_expose_api.py
+++ b/tests/units/common/test_expose_api.py
@@ -15,6 +15,7 @@ Source under test: optics_framework/common/expose_api.py
 import asyncio
 import base64
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -568,13 +569,24 @@ def test_execute_keyword_success(client):
 def test_create_session_success_and_deprecation(client):
     """create_session normalizes config, warns on legacy appium_* fields, and
     returns the driver id produced by the launch_app keyword call."""
+    create_thread_id: list[int] = []
+    event_loop_thread_id: list[int] = []
+
+    def create_session(*args, **kwargs):
+        create_thread_id.append(threading.get_ident())
+        return "sess-abc"
+
+    async def launch_app(*args, **kwargs):
+        event_loop_thread_id.append(threading.get_ident())
+        return launch_response
+
     launch_response = expose_api.ExecutionResponse(
         execution_id="e1",
         status=expose_api.STATUS_SUCCESS,
         data={expose_api.KEY_RESULT: "driver-123"},
     )
-    with patch.object(expose_api.session_manager, "create_session", return_value="sess-abc"), \
-            patch.object(expose_api, "execute_keyword", new=AsyncMock(return_value=launch_response)), \
+    with patch.object(expose_api.session_manager, "create_session", side_effect=create_session), \
+            patch.object(expose_api, "execute_keyword", side_effect=launch_app), \
             patch.object(expose_api, "reconfigure_logging"), \
             pytest.warns(DeprecationWarning):
         resp = client.post(
@@ -589,6 +601,7 @@ def test_create_session_success_and_deprecation(client):
     body = resp.json()
     assert body["session_id"] == "sess-abc"
     assert body["driver_id"] == "driver-123"
+    assert create_thread_id != event_loop_thread_id
 
 
 def test_delete_session_success_and_hash_cleanup(client):


### PR DESCRIPTION
## What changed

`optics serve` no longer runs blocking driver/Appium work on its asyncio event-loop thread:

- session construction, including the Appium new-session handshake, runs in a worker thread;
- individual keyword calls run in a worker thread;
- an `asyncio.Lock` serializes keyword execution per Optics session, preserving the existing one-command-at-a-time WebDriver semantics.

## Why

Synchronous Appium I/O could starve the serve loop long enough for `/` and `/health` to time out. In Kubernetes this made a live worker look dead to readiness/liveness probes; in the fleet deployment it could also trigger an unnecessary gateway reattach.

The normal `optics execute` batch and dry-run flows are unaffected: they use `BatchExecutor`/`TestRunner`, not `KeywordExecutor`.

## Validation

- Added a regression test proving serve keyword work runs outside the event-loop thread and concurrent requests to one session remain serialized.
- Extended the session-start endpoint test to prove driver construction is offloaded from the API loop.
- `pytest tests/units -q` (pass; one existing Playwright-dependent skip and two existing expected failures).
- `pre-commit run --files ...` (ruff, bandit, whitespace, EOF, secret scan all pass).