### PR TITLE
fix(common): share one `rich` `Console` between tree and logging output in `optics execute` output

### DIFF
--- a/optics_framework/common/error.py
+++ b/optics_framework/common/error.py
@@ -14,7 +14,7 @@ import logging
 from enum import Enum
 from typing import Dict, Optional, Any
 from pydantic import BaseModel
-from rich.console import Console
+from rich import get_console
 from rich.panel import Panel
 from rich.text import Text
 from optics_framework.common.logging_config import internal_logger
@@ -429,7 +429,7 @@ class OpticsError(Exception):
 
     def _print_rich(self, log_msg, code_prefix):
         try:
-            console = Console()
+            console = get_console()
             payload = self.to_payload(include_status=True)
             code_color = "red" if code_prefix in ("E", "X") else "yellow"
             header = Text(f"❌ {payload['code']}", style=f"bold {code_color}")

--- a/optics_framework/common/runner/printers.py
+++ b/optics_framework/common/runner/printers.py
@@ -8,7 +8,8 @@ from rich.tree import Tree
 from rich.text import Text
 from rich.panel import Panel
 from rich.progress import Progress, TaskID
-from rich.console import Console, Group
+from rich.console import Group
+from rich import get_console
 
 
 class TestCaseResult(BaseModel):
@@ -233,8 +234,10 @@ class TreeResultPrinter(IResultPrinter):
 
     def start_live(self) -> None:
         if not self._live:
+            console = get_console()
+            console.force_terminal = True
             self._live = Live(self._render_tree(
-            ), refresh_per_second=10, console=Console(force_terminal=True) )
+            ), refresh_per_second=10, console=console)
             self._live.start()
 
     def stop_live(self) -> None:


### PR DESCRIPTION
This pr fixes the progress bar interrupting the tree output of `optics execute`