### PR TITLE
fix(logging): truncate oversized log messages to head and tail

### DIFF
--- a/optics_framework/common/logging_config.py
+++ b/optics_framework/common/logging_config.py
@@ -110,12 +110,45 @@ class LoggingManager:
         self.execution_listener = None
         self.junit_handler = None
 
+# Bound the size of a single log message. Oversized payloads — a full page-source
+# XML dump, or a base64-encoded screenshot emitted by selenium/urllib3/appium at
+# DEBUG (these bubble through Optics' handlers once ``optics serve`` raises the root
+# logger to DEBUG) — otherwise flood the console and log files. We keep the head and
+# tail, which is enough to tell what was logged, and elide the middle.
+LOG_MESSAGE_HEAD_CHARS = 200
+LOG_MESSAGE_TAIL_CHARS = 200
+# Only truncate when doing so actually shortens the message; below this the elision
+# marker would cost more than it saves.
+LOG_MESSAGE_MAX_CHARS = LOG_MESSAGE_HEAD_CHARS + LOG_MESSAGE_TAIL_CHARS + 64
+
+
+def truncate_log_message(message: str) -> str:
+    """Trim an over-long log message to its head and tail, eliding the middle.
+
+    Messages at or under :data:`LOG_MESSAGE_MAX_CHARS` are returned unchanged.
+    """
+    if len(message) <= LOG_MESSAGE_MAX_CHARS:
+        return message
+    omitted = len(message) - LOG_MESSAGE_HEAD_CHARS - LOG_MESSAGE_TAIL_CHARS
+    head = message[:LOG_MESSAGE_HEAD_CHARS]
+    tail = message[-LOG_MESSAGE_TAIL_CHARS:]
+    return f"{head} … [{omitted} characters truncated] … {tail}"
+
+
 class SensitiveDataFormatter(logging.Formatter):
     def format(self, record):
         if isinstance(record.msg, str):
             record.msg = self._sanitize(record.msg)
         elif hasattr(record, "args") and record.args:
             record.args = tuple(self._sanitize(str(arg)) for arg in record.args)
+        # Merge msg % args into the final message and bound its size. Reassigning
+        # the merged string (with args cleared) keeps any traceback appended by the
+        # base formatter intact — only the message body is trimmed, never the stack.
+        message = record.getMessage()
+        truncated = truncate_log_message(message)
+        if truncated != message:
+            record.msg = truncated
+            record.args = None
         return super().format(record)
 
     def _sanitize(self, message: str) -> str:
@@ -282,4 +315,5 @@ def reconfigure_logging(config):
 
 
 __all__ = ["internal_logger","execution_logger",
-           "reconfigure_logging", "LoggerContext", "SessionLoggerAdapter"]
+           "reconfigure_logging", "LoggerContext", "SessionLoggerAdapter",
+           "SensitiveDataFormatter", "truncate_log_message"]


### PR DESCRIPTION
## Problem

The logs dump entire payloads verbatim — a full page-source XML tree, or a base64-encoded screenshot — which buries the useful lines and bloats log files. These giant strings originate from third-party `selenium` / `urllib3` / `appium` DEBUG logging, which bubbles through Optics' own log handlers once `optics serve` raises the **root** logger to `DEBUG` (`helper/serve.py:47-49` attaches Optics' handlers to root and sets it to `DEBUG`). Every one of those records flows through `SensitiveDataFormatter`.

## Fix

`SensitiveDataFormatter` is the single chokepoint every Optics log record passes through (console + file handlers). Bound each message there:

- Keep the **first 200** and **last 200** characters, elide the middle with a `… [N characters truncated] …` marker.
- Messages at or under `head + tail + 64` chars are left completely untouched, so normal log lines are unaffected — only genuine dumps get trimmed.
- Truncation runs on the merged `msg % args` string (the payload is usually in `args`, e.g. `logger.debug("%s", blob)`), and leaves any traceback appended by the base formatter intact, so **stack traces are never chopped**.

Thresholds live in named module constants (`LOG_MESSAGE_HEAD_CHARS`, `LOG_MESSAGE_TAIL_CHARS`, `LOG_MESSAGE_MAX_CHARS`) for easy tuning.

## Notes

- No behaviour change for anything but oversized messages; the existing sensitive-data sanitisation is preserved and runs first.
- Idempotent across the multiple handlers that share a record (console then file): the second pass sees an already-short message and no-ops.