### PR TITLE
fix(logging): trim page-source and base64 dumps to head and tail

### DIFF
--- a/optics_framework/common/logging_config.py
+++ b/optics_framework/common/logging_config.py
@@ -110,13 +110,69 @@ class LoggingManager:
         self.execution_listener = None
         self.junit_handler = None
 
+# Loggers whose DEBUG records embed full HTTP payloads. Selenium's remote
+# connection logs the complete response body (``Remote response: ... data=...``)
+# and urllib3 logs request/response bodies, so a ``GET /source`` call dumps the
+# entire page-source XML tree and a ``GET /screenshot`` call dumps the whole
+# base64-encoded image. These bubble through Optics' handlers once
+# ``optics serve`` raises the root logger to DEBUG (``helper/serve.py``).
+# Only records from these loggers are trimmed; every other log line is left
+# byte-for-byte untouched.
+PAYLOAD_DUMPING_LOGGER_PREFIXES = (
+    "selenium.webdriver.remote.remote_connection",
+    "urllib3",
+)
+
+# Bound the size of a single log message for the payload-dumping loggers above:
+# keep the head and tail, which is enough to tell what was logged, and elide
+# the middle with a marker.
+LOG_MESSAGE_HEAD_CHARS = 200
+LOG_MESSAGE_TAIL_CHARS = 200
+# Only truncate when doing so actually shortens the message; below this the
+# elision marker would cost more than it saves.
+LOG_MESSAGE_MAX_CHARS = LOG_MESSAGE_HEAD_CHARS + LOG_MESSAGE_TAIL_CHARS + 64
+
+
+def truncate_log_message(message: str) -> str:
+    """Trim an over-long log message to its head and tail, eliding the middle.
+
+    Messages at or under :data:`LOG_MESSAGE_MAX_CHARS` are returned unchanged.
+    """
+    if len(message) <= LOG_MESSAGE_MAX_CHARS:
+        return message
+    omitted = len(message) - LOG_MESSAGE_HEAD_CHARS - LOG_MESSAGE_TAIL_CHARS
+    head = message[:LOG_MESSAGE_HEAD_CHARS]
+    tail = message[-LOG_MESSAGE_TAIL_CHARS:]
+    return f"{head} … [{omitted} characters truncated] … {tail}"
+
+
 class SensitiveDataFormatter(logging.Formatter):
     def format(self, record):
         if isinstance(record.msg, str):
             record.msg = self._sanitize(record.msg)
         elif hasattr(record, "args") and record.args:
             record.args = tuple(self._sanitize(str(arg)) for arg in record.args)
+        if record.name.startswith(PAYLOAD_DUMPING_LOGGER_PREFIXES):
+            self._trim_payload_dump(record)
         return super().format(record)
+
+    @staticmethod
+    def _trim_payload_dump(record) -> None:
+        """Trim a record from a payload-dumping logger to its head and tail.
+
+        The trim runs on the merged ``msg % args`` string (the payload usually
+        arrives in ``args``, e.g. ``logger.debug("%s", blob)``). Reassigning the
+        merged string with args cleared keeps any traceback appended by the base
+        formatter intact — only the message body is bounded, never the stack.
+        """
+        try:
+            merged = record.getMessage()
+        except (TypeError, ValueError):
+            return
+        truncated = truncate_log_message(merged)
+        if truncated != merged:
+            record.msg = truncated
+            record.args = None
 
     def _sanitize(self, message: str) -> str:
         # Remove duplicate characters in regex character class
@@ -282,4 +338,5 @@ def reconfigure_logging(config):
 
 
 __all__ = ["internal_logger","execution_logger",
-           "reconfigure_logging", "LoggerContext", "SessionLoggerAdapter"]
+           "reconfigure_logging", "LoggerContext", "SessionLoggerAdapter",
+           "SensitiveDataFormatter", "truncate_log_message"]

--- a/tests/units/common/test_log_truncation.py
+++ b/tests/units/common/test_log_truncation.py
@@ -1,0 +1,121 @@
+"""Unit tests for targeted truncation of oversized payload dumps in log records.
+
+Only records emitted by the third-party loggers that embed full HTTP payloads
+(selenium's remote connection and urllib3 — page-source XML and base64
+screenshots) are trimmed to head + tail. Every other log line must pass
+through byte-for-byte untouched.
+"""
+import logging
+import sys
+
+import pytest
+
+from optics_framework.common.logging_config import (
+    LOG_MESSAGE_HEAD_CHARS,
+    LOG_MESSAGE_MAX_CHARS,
+    LOG_MESSAGE_TAIL_CHARS,
+    SensitiveDataFormatter,
+    truncate_log_message,
+)
+
+pytestmark = pytest.mark.white_box
+
+_SELENIUM_LOGGER = "selenium.webdriver.remote.remote_connection"
+_URLLIB3_LOGGER = "urllib3.connectionpool"
+
+
+def _record(logger_name, message, args=()):
+    return logging.LogRecord(
+        name=logger_name,
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=args,
+        exc_info=None,
+    )
+
+
+def _page_source_dump(size=20_000):
+    xml = '<hierarchy rotation="0">' + "".join(
+        f'<node index="{i}" text="item-{i}" />' for i in range(size)
+    ) + "</hierarchy>"
+    return f"Remote response: status=200 | data={xml} | headers={{'Content-Type': 'text/xml'}}"
+
+
+def _base64_dump(size=20_000):
+    return f"Remote response: status=200 | data={'iVBORw0KGgoAAAANSUhEUg==' * (size // 24)} | headers={{'Content-Type': 'image/png'}}"
+
+
+class TestTruncateLogMessage:
+    def test_short_message_is_unchanged(self):
+        message = "a normal sized log line"
+        assert truncate_log_message(message) == message
+
+    def test_oversized_message_keeps_head_and_tail(self):
+        message = "A" * 10_000
+        out = truncate_log_message(message)
+        assert out.startswith("A" * LOG_MESSAGE_HEAD_CHARS)
+        assert out.endswith("A" * LOG_MESSAGE_TAIL_CHARS)
+        expected_omitted = 10_000 - LOG_MESSAGE_HEAD_CHARS - LOG_MESSAGE_TAIL_CHARS
+        assert f"[{expected_omitted} characters truncated]" in out
+
+
+class TestPayloadDumpTruncation:
+    def test_selenium_page_source_dump_is_trimmed(self):
+        record = _record(_SELENIUM_LOGGER, _page_source_dump())
+        out = SensitiveDataFormatter().format(record)
+        assert len(out) <= LOG_MESSAGE_MAX_CHARS
+        assert out.startswith(_page_source_dump()[:LOG_MESSAGE_HEAD_CHARS])
+        assert out.endswith(_page_source_dump()[-LOG_MESSAGE_TAIL_CHARS:])
+        assert "characters truncated" in out
+
+    def test_selenium_base64_screenshot_dump_is_trimmed(self):
+        record = _record(_SELENIUM_LOGGER, _base64_dump())
+        out = SensitiveDataFormatter().format(record)
+        assert len(out) <= LOG_MESSAGE_MAX_CHARS
+        assert "characters truncated" in out
+
+    def test_urllib3_dump_is_trimmed(self):
+        record = _record(_URLLIB3_LOGGER, _base64_dump())
+        out = SensitiveDataFormatter().format(record)
+        assert len(out) <= LOG_MESSAGE_MAX_CHARS
+        assert "characters truncated" in out
+
+    def test_args_carrying_the_payload_are_trimmed(self):
+        # selenium logs the body as the first %s arg: logger.debug("Remote
+        # response: status=%s | data=%s | headers=%s", status, data, headers)
+        record = _record(_SELENIUM_LOGGER, "Remote response: status=%s | data=%s | headers=%s",
+                         args=(200, "iVBORw0KGgoAAAANSUhEUg==" * 1000, {"Content-Type": "image/png"}))
+        out = SensitiveDataFormatter().format(record)
+        assert len(out) <= LOG_MESSAGE_MAX_CHARS
+        assert "characters truncated" in out
+
+
+class TestOtherLogsUntouched:
+    def test_optics_internal_log_is_never_truncated(self):
+        big = "x" * 50_000
+        record = _record("optics.internal", f"Large but legitimate payload: {big}")
+        out = SensitiveDataFormatter().format(record)
+        assert big in out
+        assert "characters truncated" not in out
+
+    def test_other_third_party_logger_is_never_truncated(self):
+        big = "x" * 50_000
+        record = _record("requests.packages.urllib3", f"some other library: {big}")
+        out = SensitiveDataFormatter().format(record)
+        assert big in out
+        assert "characters truncated" not in out
+
+
+class TestTracebackPreservation:
+    def test_traceback_is_not_chopped(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            exc_info = sys.exc_info()
+        record = _record(_SELENIUM_LOGGER, _page_source_dump())
+        record.exc_info = exc_info
+        out = SensitiveDataFormatter().format(record)
+        assert "characters truncated" in out
+        assert "ValueError: boom" in out


### PR DESCRIPTION
## Problem

The logs dump entire payloads verbatim — a full page-source XML tree (`GET /source`) or a whole base64-encoded screenshot (`GET /screenshot`) — burying the useful lines and bloating console and log files.

These giant strings are emitted at DEBUG by third-party `selenium` / `urllib3` loggers (`selenium.webdriver.remote.remote_connection` logs `Remote response: status=... | data=<full body> | ...`, and `urllib3` logs request/response bodies). They bubble through Optics' handlers once `optics serve` raises the **root** logger to DEBUG (`helper/serve.py`), so every one of those records flows through `SensitiveDataFormatter`.

## Fix

Scope the trimming to the payload-dumping loggers only — **not every log message**:

- Records from `selenium.webdriver.remote.remote_connection` and `urllib3` are bounded to their **first and last 200 characters**, eliding the middle with a `… [N characters truncated] …` marker.
- Every other log line passes through **byte-for-byte untouched** — Optics' own debug/info logs, including large legitimate messages, are never modified.
- Truncation runs on the merged `msg % args` string (the payload usually arrives in `args`, e.g. `logger.debug("%s", blob)`), and any traceback appended by the base formatter stays intact.
- Messages at or under `200 + 200 + 64` chars from those loggers are left as-is, so only genuine dumps get trimmed.

Thresholds and the logger allowlist live in named module constants (`LOG_MESSAGE_HEAD_CHARS`, `LOG_MESSAGE_TAIL_CHARS`, `PAYLOAD_DUMPING_LOGGER_PREFIXES`) for easy tuning.

## Tests

`tests/units/common/test_log_truncation.py` covers:
- page-source XML and base64 screenshot records from the selenium remote-connection logger are trimmed to head + tail,
- `urllib3` records are trimmed,
- payloads passed via `%s` args are trimmed,
- Optics-internal logs (and other third-party loggers) are **not** truncated even when huge,
- tracebacks are preserved.

All new tests pass; the full `tests/units/common` suite is green (one pre-existing skip: playwright not installed).
