### PR TITLE
perf(engines): index XPath uniqueness to stop element extraction stalling health checks

### DIFF
--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -875,9 +875,27 @@ class StrategyManager:
         internal_logger.debug("No pagesource captured.")
         raise OpticsError(Code.E0403, message="No pagesource captured using available strategies.")
 
+    @staticmethod
+    def _can_strategy_get_interactive_elements(strategy: "PagesourceStrategy") -> bool:
+        """Whether this strategy's source implements interactive-element extraction.
+
+        A source belongs in ``pagesource_strategies`` if it can return a page source,
+        which is a weaker capability than extracting elements from one: AppiumFindElement
+        supports the former and unconditionally raises on the latter. Screening those out
+        up front keeps the extraction path from paying for -- and logging -- a failure
+        that is knowable from the source itself, rather than discovering it per call.
+        """
+        return LocatorStrategy._is_method_implemented(
+            strategy.element_source, "get_interactive_elements"
+        )
+
     def get_interactive_elements(self, filter_config: Optional[List[str]] = None) -> List[dict]:
         """Retrieve interactive elements from the element source."""
-        for strategy in self.pagesource_strategies:
+        applicable_strategies = [
+            s for s in self.pagesource_strategies
+            if self._can_strategy_get_interactive_elements(s)
+        ]
+        for strategy in applicable_strategies:
             try:
                 return strategy.get_interactive_elements(filter_config)
             except Exception as e:

--- a/optics_framework/engines/drivers/appium_UI_helper.py
+++ b/optics_framework/engines/drivers/appium_UI_helper.py
@@ -1,4 +1,5 @@
 import re
+from bisect import bisect_left
 from typing import Any, List, Dict, Tuple, Optional, Union, cast
 from fuzzywuzzy import fuzz
 from lxml import etree
@@ -12,6 +13,88 @@ XPATH_UNIQUE_ATTRIBUTES = [
     "name", "content-desc", "id", "resource-id", "accessibility-id",
 ]
 XPATH_MAYBE_UNIQUE_ATTRIBUTES = ["label", "text", "value"]
+
+# The only attributes get_xpath ever probes, so the only ones worth indexing.
+XPATH_INDEXED_ATTRIBUTES = (*XPATH_UNIQUE_ATTRIBUTES, *XPATH_MAYBE_UNIQUE_ATTRIBUTES)
+
+
+class XPathUniquenessIndex:
+    """Document-order posting lists answering "how many nodes match this probe?".
+
+    ``get_xpath`` decides between an attribute-based and a hierarchical XPath by
+    asking, for each candidate attribute, whether ``//tag[@attr=value]`` matches
+    exactly one node. Evaluating that with a real ``xpath()`` call rescans the whole
+    document once per probe, so labelling a whole hierarchy costs O(nodes x probes)
+    full-document scans -- seconds of CPU on a large iOS tree, which is enough to
+    trip an external health checker watching the same process. One indexing pass
+    answers every probe from a dict instead, keeping the walk linear in tree size.
+
+    Match sets are kept in document order because callers position a non-unique node
+    among its peers (``(xpath)[n]``), which must agree with what XPath itself would
+    have returned.
+    """
+
+    __slots__ = ("_by_tag", "_by_tag_attr", "_doc_pos", "_multi_cache", "xpath_cache")
+
+    def __init__(self, root: Any):
+        self._by_tag: Dict[str, List[Any]] = {}
+        self._by_tag_attr: Dict[Tuple[str, str, str], List[Any]] = {}
+        self._doc_pos: Dict[Any, int] = {}
+        self._multi_cache: Dict[Tuple[Any, ...], List[Any]] = {}
+        self.xpath_cache: Dict[Any, str] = {}
+        for position, node in enumerate(root.iter()):
+            tag = node.tag
+            if not isinstance(tag, str):
+                continue  # comments and processing instructions carry a callable tag
+            if "{" in tag:
+                # lxml reports a namespaced tag in Clark notation ("{uri}local"), which
+                # is not valid XPath: every probe built from one fails to parse. Leaving
+                # these nodes unindexed keeps their probes empty, so they fall through to
+                # the hierarchical builder -- where evaluating the probe always sent them.
+                continue
+            self._doc_pos[node] = position
+            self._by_tag.setdefault(tag, []).append(node)
+            attrib = node.attrib
+            for attr in XPATH_INDEXED_ATTRIBUTES:
+                val = attrib.get(attr)
+                if val:
+                    self._by_tag_attr.setdefault((tag, attr, val), []).append(node)
+
+    def matches(self, tag: str, conditions: Tuple[Tuple[str, str], ...]) -> List[Any]:
+        """Nodes matching ``//tag[@a=v and ...]``, in document order."""
+        if not conditions:
+            return self._by_tag.get(tag, [])
+        if len(conditions) == 1:
+            attr, val = conditions[0]
+            return self._by_tag_attr.get((tag, attr, val), [])
+        # Filtering the shortest posting list keeps a multi-attribute probe off a
+        # per-pair index, but costs that list's length. Sibling rows sharing a label
+        # issue byte-identical probes, so without this memo the same intersection is
+        # recomputed once per row -- the quadratic this index exists to remove. Trees
+        # with distinct values resolve on one attribute and never reach here.
+        cache_key = (tag, conditions)
+        cached = self._multi_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        postings = [self._by_tag_attr.get((tag, a, v), []) for a, v in conditions]
+        shortest = min(postings, key=len)
+        result = [n for n in shortest if all(n.attrib.get(a) == v for a, v in conditions)]
+        self._multi_cache[cache_key] = result
+        return result
+
+    def position_of(self, matches: List[Any], node: Any) -> int:
+        """0-based position of ``node`` within a document-ordered match list.
+
+        A list where every row repeats one label puts every row in the same match
+        list, so scanning it per node would reintroduce the quadratic cost this index
+        exists to remove. Both sequences are ordered by document position, so a binary
+        search answers it in log time.
+        """
+        pos = self._doc_pos.get(node)
+        if pos is None:
+            return 0
+        found = bisect_left(matches, pos, key=lambda n: self._doc_pos[n])
+        return found if found < len(matches) and matches[found] is node else 0
 
 
 class UIHelper:
@@ -823,6 +906,9 @@ class UIHelper:
             etree.fromstring(page_source.encode("utf-8"))
         ).getroot()
         elements = root.xpath(".//*")
+        # One index for the whole tree: every node's XPath is derived from the same
+        # document, so the uniqueness probes are shared rather than rescanned per node.
+        index = XPathUniquenessIndex(root)
         results = []
 
         for node in elements:
@@ -839,7 +925,7 @@ class UIHelper:
                 # If no text-like attribute, use tag name
                 text, used_key = node.tag, None
 
-            xpath = self.get_xpath(node)
+            xpath = self.get_xpath(node, index)
             extra = self._build_extra_metadata(node.attrib, used_key, node.tag)
 
             results.append(
@@ -935,45 +1021,32 @@ class UIHelper:
         extra["tag"] = tag  # e.g., XCUIElementTypeButton or android.widget.Button
         return extra
 
-    def _xpath_determine_uniqueness(
-        self, node: etree.Element, doc_tree: Any, xpath: str
-    ) -> Tuple[bool, Optional[int]]:
-        """Return (True, None) if xpath matches exactly one node, else (False, index or None)."""
-        try:
-            matches = doc_tree.xpath(xpath)
-        except (etree.XPathError, ValueError, TypeError):
-            return False, None
-        if not matches:
-            return False, None
-        if len(matches) > 1:
-            try:
-                idx = matches.index(node)
-            except ValueError:
-                idx = 0
-            return False, idx
-        return True, None
-
     def _xpath_from_single_attr(
         self, node: etree.Element, attr_name: str, tag_for_xpath: str
-    ) -> Optional[str]:
+    ) -> Optional[Tuple[str, Tuple[Tuple[str, str], ...]]]:
+        """Return the ``//tag[@attr=value]`` probe and the conditions it encodes."""
         val = node.attrib.get(attr_name)
         if not val:
             return None
         lit = self._escape_for_xpath_literal(val)
-        return f"//{tag_for_xpath}[@{attr_name}={lit}]"
+        return f"//{tag_for_xpath}[@{attr_name}={lit}]", ((attr_name, val),)
 
     def _xpath_from_attr_pair(
         self, node: etree.Element, attr_pair: Tuple[str, str], tag_for_xpath: str
-    ) -> Optional[str]:
+    ) -> Optional[Tuple[str, Tuple[Tuple[str, str], ...]]]:
+        """Return the two-attribute probe and the conditions it encodes."""
         a1, a2 = attr_pair
         v1, v2 = node.attrib.get(a1), node.attrib.get(a2)
         if not v1 or not v2:
             return None
         lit1, lit2 = self._escape_for_xpath_literal(v1), self._escape_for_xpath_literal(v2)
-        return f"//{tag_for_xpath}[@{a1}={lit1} and @{a2}={lit2}]"
+        return f"//{tag_for_xpath}[@{a1}={lit1} and @{a2}={lit2}]", ((a1, v1), (a2, v2))
 
     def _xpath_try_attributes_for_unique(
-        self, node: etree.Element, doc_tree: Any, attrs: List[Union[str, Tuple[str, str]]]
+        self,
+        node: etree.Element,
+        index: XPathUniquenessIndex,
+        attrs: List[Union[str, Tuple[str, str]]],
     ) -> Tuple[Optional[str], bool]:
         tag_for_xpath = node.tag or "*"
         is_pairs = bool(attrs and isinstance(attrs[0], tuple))
@@ -981,39 +1054,39 @@ class UIHelper:
 
         for entry in attrs:
             if is_pairs:
-                xpath = self._xpath_from_attr_pair(node, cast(Tuple[str, str], entry), tag_for_xpath)
+                probe = self._xpath_from_attr_pair(node, cast(Tuple[str, str], entry), tag_for_xpath)
             else:
-                xpath = self._xpath_from_single_attr(node, cast(str, entry), tag_for_xpath)
-            if not xpath:
+                probe = self._xpath_from_single_attr(node, cast(str, entry), tag_for_xpath)
+            if not probe:
                 continue
-            is_unique, idx = self._xpath_determine_uniqueness(node, doc_tree, xpath)
-            if is_unique:
+            xpath, conditions = probe
+            matches = index.matches(tag_for_xpath, conditions)
+            if len(matches) == 1:
                 return xpath, True
-            if semi_unique_xpath is None and idx is not None:
-                semi_unique_xpath = f"({xpath})[{idx + 1}]"
+            if semi_unique_xpath is None and matches:
+                # Position the node among its peers, as `(xpath)[n]` is 1-based.
+                semi_unique_xpath = f"({xpath})[{index.position_of(matches, node) + 1}]"
 
         if semi_unique_xpath:
             return semi_unique_xpath, False
         return None, False
 
     def _xpath_try_node_name(
-        self, node: etree.Element, doc_tree: Any
+        self, node: etree.Element, index: XPathUniquenessIndex
     ) -> Tuple[Optional[str], bool]:
         tag = node.tag or "*"
-        xpath = f"//{tag}"
-        is_unique, _ = self._xpath_determine_uniqueness(node, doc_tree, xpath)
-        if not is_unique:
+        if len(index.matches(tag, ())) != 1:
             return None, False
-        if node.getparent() is None:
-            xpath = f"/{tag}"
-        return xpath, True
+        return (f"/{tag}" if node.getparent() is None else f"//{tag}"), True
 
     def _xpath_attribute_pairs_permutations(
         self, attributes: List[str]
     ) -> List[Tuple[str, str]]:
         return [(v1, v2) for i, v1 in enumerate(attributes) for v2 in attributes[i + 1 :]]
 
-    def _xpath_try_cases_for_unique(self, node: etree.Element, doc_tree: Any) -> Optional[str]:
+    def _xpath_try_cases_for_unique(
+        self, node: etree.Element, index: XPathUniquenessIndex
+    ) -> Optional[str]:
         all_attrs = [*XPATH_UNIQUE_ATTRIBUTES, *XPATH_MAYBE_UNIQUE_ATTRIBUTES]
         cases: List[Any] = [
             XPATH_UNIQUE_ATTRIBUTES,
@@ -1024,16 +1097,18 @@ class UIHelper:
         semi_unique: Optional[str] = None
         for attrs in cases:
             if len(attrs) == 0:
-                xpath, is_unique = self._xpath_try_node_name(node, doc_tree)
+                xpath, is_unique = self._xpath_try_node_name(node, index)
             else:
-                xpath, is_unique = self._xpath_try_attributes_for_unique(node, doc_tree, attrs)
+                xpath, is_unique = self._xpath_try_attributes_for_unique(node, index, attrs)
             if is_unique and xpath:
                 return xpath
             if semi_unique is None and xpath:
                 semi_unique = xpath
         return semi_unique
 
-    def _xpath_build_hierarchical(self, node: etree.Element) -> str:
+    def _xpath_build_hierarchical(
+        self, node: etree.Element, index: XPathUniquenessIndex
+    ) -> str:
         tag = node.tag
         if not tag:
             return ""
@@ -1045,23 +1120,35 @@ class UIHelper:
                 idx = siblings_same_tag.index(node) + 1
                 segment += f"[{idx}]"
         if parent is not None and hasattr(parent, "tag"):
-            return f"{self.get_xpath(parent)}{segment}"
+            return f"{self.get_xpath(parent, index)}{segment}"
         return segment
 
-    def get_xpath(self, node: etree.Element) -> str:
+    def get_xpath(
+        self, node: etree.Element, index: Optional[XPathUniquenessIndex] = None
+    ) -> str:
         """
         Generate an optimal XPath for a given node using attribute-based
         uniqueness checks and semi-unique indexing, falling back to a
         hierarchical path when required. Mirrors the behavior of the
         provided getOptimalXPath logic.
+
+        ``index`` lets a caller labelling many nodes of one tree share a single
+        uniqueness index; it is built for this document when omitted. Results are
+        memoised on the index because the hierarchical fallback re-derives every
+        ancestor's XPath on the way up.
         """
         if node is None or not hasattr(node, "tag"):
             return ""
-        doc_tree = node.getroottree()
-        candidate = self._xpath_try_cases_for_unique(node, doc_tree)
-        if candidate:
-            return candidate
-        return self._xpath_build_hierarchical(node) or self._build_structural_xpath(node)
+        if index is None:
+            index = XPathUniquenessIndex(node.getroottree().getroot())
+        cached = index.xpath_cache.get(node)
+        if cached is not None:
+            return cached
+        candidate = self._xpath_try_cases_for_unique(node, index)
+        if not candidate:
+            candidate = self._xpath_build_hierarchical(node, index) or self._build_structural_xpath(node)
+        index.xpath_cache[node] = candidate
+        return candidate
 
     def _escape_for_xpath_literal(self, s: str) -> str:
         """

--- a/optics_framework/engines/elementsources/appium_find_element.py
+++ b/optics_framework/engines/elementsources/appium_find_element.py
@@ -78,7 +78,10 @@ class AppiumFindElement(ElementSourceInterface):
         Returns:
             list: A list of interactive elements (buttons, links, etc.) found in the page source.
         """
-        internal_logger.exception(
+        # Debug, not exception: the strategy chain screens this source out of the
+        # extraction path by capability, so reaching here is a caller's direct use --
+        # not a failure worth an ERROR-level traceback on a per-call hot path.
+        internal_logger.debug(
             'Appium Find Element does not support getting interactive elements. Please use AppiumPageSource for this functionality.'
         )
         raise NotImplementedError(

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -20,6 +20,7 @@ from optics_framework.common.base_factory import InstanceFallback
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.error import Code, OpticsError
 from optics_framework.common.strategies import (
+    LocatorStrategy,
     StrategyManager,
     TextDetectionStrategy,
     LocateResult,
@@ -569,3 +570,58 @@ class TestAllocTimeForStrategy:
         result = _sm(MagicMock())._alloc_time_for_strategy(1000.4, 1, [1, 2])
         assert result is not None
         assert result[0] == 0
+
+
+# --- StrategyManager.get_interactive_elements() strategy screening ---
+
+
+class TestGetInteractiveElementsStrategyScreening:
+    """Only sources that actually implement extraction should be tried.
+
+    A source qualifies as a pagesource strategy by returning a page source, which is a
+    weaker capability than extracting elements from one -- AppiumFindElement supports
+    the first and unconditionally raises on the second. Trying it anyway burned work
+    and logged a traceback on every call to a hot path (mozarkai/optics-framework#455).
+    """
+
+    @staticmethod
+    def _strategy(supports_extraction: bool, elements=None):
+        source = MagicMock()
+        if supports_extraction:
+            source.get_interactive_elements = MagicMock(return_value=elements or [])
+        else:
+            def _unsupported(filter_config=None):
+                raise NotImplementedError("does not support getting interactive elements")
+            source.get_interactive_elements = _unsupported
+
+        strategy = MagicMock()
+        strategy.element_source = source
+        strategy.get_interactive_elements = MagicMock(
+            side_effect=lambda fc=None: source.get_interactive_elements(fc)
+        )
+        return strategy
+
+    def test_unsupported_source_is_never_called(self, monkeypatch):
+        capable = self._strategy(True, [{"text": "OK"}])
+        incapable = self._strategy(False)
+        monkeypatch.setattr(
+            LocatorStrategy,
+            "_is_method_implemented",
+            staticmethod(lambda src, name: src is capable.element_source),
+        )
+        manager = _sm(MagicMock())
+        manager.pagesource_strategies = [incapable, capable]
+
+        assert manager.get_interactive_elements() == [{"text": "OK"}]
+        incapable.get_interactive_elements.assert_not_called()
+
+    def test_no_capable_strategy_raises_rather_than_returning_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            LocatorStrategy, "_is_method_implemented", staticmethod(lambda src, name: False)
+        )
+        manager = _sm(MagicMock())
+        manager.pagesource_strategies = [self._strategy(False)]
+
+        with pytest.raises(OpticsError) as exc_info:
+            manager.get_interactive_elements()
+        assert exc_info.value.code == Code.E0202

--- a/tests/units/engines/drivers/test_appium_ui_helper_xpath.py
+++ b/tests/units/engines/drivers/test_appium_ui_helper_xpath.py
@@ -1,0 +1,263 @@
+"""XPath labelling contracts for UIHelper.get_interactive_elements.
+
+Regression cover for mozarkai/optics-framework#455: labelling every node used to
+answer "is this XPath unique?" with a fresh full-document ``xpath()`` scan, making
+extraction quadratic in tree size (~22 CPU-seconds on a 10k-node iOS hierarchy).
+That is enough sustained CPU to blow an external health checker's budget and get a
+live ``optics serve`` worker declared dead. The uniqueness index must answer the
+same question from one pass -- keeping the XPaths byte-identical while the cost
+stays linear.
+"""
+import time
+
+import pytest
+from lxml import etree
+
+from optics_framework.engines.drivers.appium_UI_helper import (
+    UIHelper,
+    XPathUniquenessIndex,
+)
+
+pytestmark = pytest.mark.white_box
+
+
+def _helper(page_source: str) -> UIHelper:
+    """A UIHelper wired to a fixed page source, with no Appium driver behind it."""
+    helper = UIHelper.__new__(UIHelper)
+    helper.driver = None
+    helper.tree = None
+    helper.root = None
+    helper.prev_hash = None
+    helper.get_page_source = lambda: (page_source, "ts")
+    return helper
+
+
+def _ios_tree(cells: int) -> str:
+    """An iOS-shaped hierarchy: repeated cells whose labels collide across cells, so
+    single-attribute probes are mostly non-unique -- the case that drove the cost."""
+    parts = [
+        '<XCUIElementTypeApplication type="XCUIElementTypeApplication" name="App" '
+        'label="App" x="0" y="0" width="390" height="844">'
+    ]
+    for i in range(cells):
+        parts.append(
+            f'<XCUIElementTypeCell type="XCUIElementTypeCell" name="" label="Row" '
+            f'x="0" y="{i * 60}" width="390" height="60">'
+            f'<XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="Title" '
+            f'label="Title" value="{i}" x="8" y="{i * 60}" width="200" height="20"/>'
+            f'<XCUIElementTypeButton type="XCUIElementTypeButton" name="Buy" label="Buy" '
+            f'x="300" y="{i * 60}" width="60" height="20"/>'
+            f"</XCUIElementTypeCell>"
+        )
+    parts.append("</XCUIElementTypeApplication>")
+    return "".join(parts)
+
+
+ANDROID_TREE = (
+    '<hierarchy rotation="0">'
+    '<android.widget.FrameLayout class="android.widget.FrameLayout" text="" '
+    'resource-id="com.app:id/root" bounds="[0,0][1080,2400]">'
+    '<android.widget.Button class="android.widget.Button" text="OK" '
+    'resource-id="com.app:id/ok" content-desc="Confirm" bounds="[10,20][110,80]"/>'
+    '<android.widget.TextView class="android.widget.TextView" text="Repeated" '
+    'bounds="[10,100][300,140]"/>'
+    '<android.widget.TextView class="android.widget.TextView" text="Repeated" '
+    'bounds="[10,150][300,190]"/>'
+    "</android.widget.FrameLayout>"
+    "</hierarchy>"
+)
+
+
+class _FullScanIndex:
+    """Stand-in index that answers every probe with a real full-document ``xpath()``.
+
+    Reproduces the pre-fix behaviour -- including its ``matches.index(node)``
+    positioning -- so the real index is held to what XPath itself reports rather than
+    to hard-coded expected strings.
+    """
+
+    def __init__(self, helper: UIHelper, doc_tree):
+        self._helper = helper
+        self._doc_tree = doc_tree
+        self.xpath_cache: dict = {}
+
+    def matches(self, tag, conditions):
+        if conditions:
+            predicate = " and ".join(
+                f"@{a}={self._helper._escape_for_xpath_literal(v)}" for a, v in conditions
+            )
+            query = f"//{tag}[{predicate}]"
+        else:
+            query = f"//{tag}"
+        try:
+            return self._doc_tree.xpath(query)
+        except (etree.XPathError, ValueError, TypeError):
+            return []
+
+    def position_of(self, matches, node):
+        try:
+            return matches.index(node)
+        except ValueError:
+            return 0
+
+
+def _xpath_by_full_scan(helper: UIHelper, node) -> str:
+    return helper.get_xpath(node, _FullScanIndex(helper, node.getroottree()))
+
+
+class TestXPathEquivalence:
+    """Indexed uniqueness must agree with real XPath evaluation, node for node."""
+
+    @pytest.mark.parametrize(
+        "page_source",
+        [ANDROID_TREE, _ios_tree(3), _ios_tree(25)],
+        ids=["android", "ios-small", "ios-repeated-labels"],
+    )
+    def test_indexed_xpath_matches_full_document_scan(self, page_source):
+        helper = _helper(page_source)
+        root = etree.fromstring(page_source.encode("utf-8"))
+        index = XPathUniquenessIndex(root)
+
+        for node in root.xpath(".//*"):
+            assert helper.get_xpath(node, index) == _xpath_by_full_scan(helper, node)
+
+    def test_every_generated_xpath_resolves_to_its_own_node(self):
+        """A returned XPath is only useful if it actually selects the node it labels."""
+        page_source = _ios_tree(12)
+        helper = _helper(page_source)
+        root = etree.fromstring(page_source.encode("utf-8"))
+        tree = root.getroottree()
+
+        for element in helper.get_interactive_elements(None):
+            matched = tree.xpath(element["xpath"])
+            assert len(matched) == 1, f"{element['xpath']} matched {len(matched)} nodes"
+
+    def test_repeated_labels_are_positionally_disambiguated(self):
+        """Nodes sharing a label fall back to ``(probe)[n]`` -- and n must be the
+        node's own 1-based position among the matches, in document order."""
+        helper = _helper(ANDROID_TREE)
+        root = etree.fromstring(ANDROID_TREE.encode("utf-8"))
+        tree = root.getroottree()
+        repeated = root.xpath('.//android.widget.TextView[@text="Repeated"]')
+
+        xpaths = [helper.get_xpath(n, XPathUniquenessIndex(root)) for n in repeated]
+
+        assert len(set(xpaths)) == len(repeated), "duplicate XPaths for distinct nodes"
+        for node, xpath in zip(repeated, xpaths):
+            assert tree.xpath(xpath) == [node]
+
+
+class TestNamespacedTags:
+    """Namespaced tags must reach the hierarchical builder, as they always did.
+
+    lxml reports a namespaced tag in Clark notation (``{uri}local``), which is not
+    valid XPath. The pre-fix code discovered that by *evaluating* each probe and
+    swallowing the parse error as "not unique"; an index that answers from a dict
+    would instead hand back an attribute probe that no XPath engine can parse.
+    """
+
+    NS_TREES = {
+        "prefixed": (
+            '<root xmlns:foo="http://example.com">'
+            '<foo:bar id="1" bounds="[0,0][10,10]"/></root>'
+        ),
+        "default-on-every-node": (
+            '<root xmlns="http://ex.com">'
+            '<child resource-id="a" bounds="[0,0][5,5]"/>'
+            '<child resource-id="a" bounds="[0,6][5,9]"/></root>'
+        ),
+        "mixed-with-plain": (
+            '<root xmlns:n="http://e.com">'
+            '<n:x id="1" bounds="[0,0][2,2]"/>'
+            '<plain id="1" bounds="[0,3][2,5]"/>'
+            '<plain id="2" bounds="[0,6][2,8]"/></root>'
+        ),
+    }
+
+    @pytest.mark.parametrize("page_source", NS_TREES.values(), ids=NS_TREES.keys())
+    def test_namespaced_nodes_match_full_document_scan(self, page_source):
+        helper = _helper(page_source)
+        root = etree.fromstring(page_source.encode("utf-8"))
+        index = XPathUniquenessIndex(root)
+
+        for node in root.xpath(".//*"):
+            assert helper.get_xpath(node, index) == _xpath_by_full_scan(helper, node)
+
+    def test_plain_siblings_still_get_attribute_xpaths(self):
+        """The guard must skip only the namespaced nodes, not poison the document."""
+        page_source = self.NS_TREES["mixed-with-plain"]
+        xpaths = [e["xpath"] for e in _helper(page_source).get_interactive_elements(None)]
+
+        assert xpaths == [
+            "/root/{http://e.com}x",
+            '//plain[@id="1"]',
+            '//plain[@id="2"]',
+        ]
+
+
+class TestXPathIndex:
+    """The index answers the probes get_xpath issues, in document order."""
+
+    def test_matches_single_attribute_and_pair(self):
+        root = etree.fromstring(ANDROID_TREE.encode("utf-8"))
+        index = XPathUniquenessIndex(root)
+
+        assert len(index.matches("android.widget.Button", (("text", "OK"),))) == 1
+        assert len(index.matches("android.widget.TextView", (("text", "Repeated"),))) == 2
+        # A pair narrows to the node carrying both values.
+        assert len(
+            index.matches(
+                "android.widget.Button", (("text", "OK"), ("content-desc", "Confirm"))
+            )
+        ) == 1
+        # A pair no node satisfies matches nothing.
+        assert index.matches(
+            "android.widget.Button", (("text", "OK"), ("content-desc", "Nope"))
+        ) == []
+
+    def test_matches_are_in_document_order(self):
+        root = etree.fromstring(ANDROID_TREE.encode("utf-8"))
+        expected = root.xpath('.//android.widget.TextView[@text="Repeated"]')
+
+        assert XPathUniquenessIndex(root).matches(
+            "android.widget.TextView", (("text", "Repeated"),)
+        ) == expected
+
+    def test_tag_only_probe_includes_the_root_element(self):
+        """``//tag`` is evaluated from the document root, so the root itself counts."""
+        root = etree.fromstring(ANDROID_TREE.encode("utf-8"))
+
+        assert XPathUniquenessIndex(root).matches("hierarchy", ()) == [root]
+
+    def test_comments_are_not_indexed(self):
+        """Comments and processing instructions carry a callable tag, not a name."""
+        source = '<root><!-- note --><child name="a"/></root>'
+        root = etree.fromstring(source.encode("utf-8"))
+
+        index = XPathUniquenessIndex(root)
+
+        assert index.matches("child", (("name", "a"),)) == root.xpath('.//child')
+
+
+class TestExtractionCost:
+    """Extraction must stay linear in tree size -- the actual subject of #455."""
+
+    def test_cost_growth_is_linear_not_quadratic(self):
+        """Quadrupling the node count must not multiply the cost by ~16.
+
+        The pre-fix implementation grew as O(nodes x probes) full-document scans; the
+        bound here is loose enough to absorb timing noise on shared CI while still
+        failing outright if per-node full-document scanning comes back.
+        """
+        small, large = _ios_tree(50), _ios_tree(200)
+
+        def _elapsed(page_source: str) -> float:
+            helper = _helper(page_source)
+            helper.get_interactive_elements(None)  # warm import/parse paths
+            start = time.perf_counter()
+            helper.get_interactive_elements(None)
+            return time.perf_counter() - start
+
+        ratio = _elapsed(large) / max(_elapsed(small), 1e-6)
+
+        assert ratio < 8, f"4x the nodes cost {ratio:.1f}x the time -- superlinear"


### PR DESCRIPTION
Fixes #455

## What was actually wrong

The issue attributed the stalls to GIL contention inside `asyncio.to_thread` and suggested moving the work to a `ProcessPoolExecutor`. Profiling says otherwise, and the real cause is cheaper to fix.

`UIHelper.get_xpath` picks an "optimal" XPath per node by testing candidates for uniqueness — and answered each test by evaluating the candidate against the **whole document**. That is one full scan per candidate attribute, per node, so extraction is quadratic in tree size. `cProfile` puts `_xpath_determine_uniqueness` at **91% of runtime** (1.166s of 1.284s), with CPU time equal to wall time.

| iOS page-source nodes | CPU-seconds for ONE `get_interactive_elements` |
| --- | --- |
| 3,000 | 1.28s |
| 6,000 | 6.26s |
| 10,000 | **20.65s** |

Two measurements rule out the GIL as the binding constraint:

- Six concurrent sessions gave ~2.6x parallel speedup with event-loop lag under 50ms — **lxml releases the GIL during XPath evaluation**.
- A `ProcessPoolExecutor` would not have helped regardless: cgroup CPU limits apply to the whole container, so a second process adds no CPU.

The production mechanism is **CPU-quota saturation**. On a 1.5-core worker pod running 3 sessions, `3 x 20.65 / 1.5` is roughly **41 seconds** of full saturation, during which every thread in the process is throttled — including the event loop serving `/`. That is the multi-second health stall that lets a supervisor declare a live worker dead.

## The fix

`XPathUniquenessIndex` builds document-ordered posting lists in a single pass, so each uniqueness probe becomes a dict lookup instead of a document scan.

| nodes | before | after | factor |
| --- | --- | --- | --- |
| 1,000 | 0.13s | 0.021s | 6x |
| 3,000 | 1.28s | 0.064s | 20x |
| 6,000 | 6.26s | 0.161s | 39x |
| 10,000 | 20.65s | 0.274s | **75x** |

Cost is now linear rather than quadratic. Peak memory rises by ~4 MB on a 10k-node tree.

The second commit stops the extraction path trying `AppiumFindElement`, which qualifies as a pagesource strategy by implementing `get_page_source` but unconditionally raises on `get_interactive_elements`. It was tried on every call and logged an ERROR-level traceback each time. The existing `_is_method_implemented` capability check already reports this statically, so strategies are screened by it — the same way `_can_strategy_assert_elements` gates visibility calls.

## Verification

Output is unchanged. Behaviour was held byte-identical against the previous full-scan implementation, not against hand-written expectations:

- **2,522 generated trees / 20,161 tree-and-filter combinations — 0 mismatches.** Covers quote and backslash and unicode and RTL and zero-width values, empty and whitespace-only attributes, duplicate groups up to 1,200 siblings (including non-contiguous across parents), fully-unique trees, no-indexable-attribute trees, depth 80 and width 300, Android and iOS and mixed attribute styles, XPath-keyword-like tag names, comments and processing instructions.
- A captured real Android hierarchy plus iOS fixtures up to 3,000 nodes, across 8 filter combinations.
- **705 passed**, 1 skipped, 2 xfailed. 16 tests added; each commit is green on its own.
- End-to-end through real uvicorn with the real event loop and `to_thread` hop: a single 10k-node call went from **36s to 1.1s**, with all element calls returning 200.

Two traps found while building this, both covered by tests:

- Sibling rows sharing a label build identical multi-attribute probes; without memoising the intersection the quadratic comes straight back on exactly the list-shaped screens this targets.
- lxml reports namespaced tags in Clark notation (`{uri}local`), which is never valid XPath. The old code learned that by catching the parse error and falling through to the hierarchical builder; an index answering from a dict would instead return an unparseable probe. Fuzzing caught this as a genuine divergence, and those nodes are now left unindexed to preserve the original result.

## Follow-ups, not in this PR

- `playwright_page_source.get_xpath` has the **identical quadratic** (78 pair probes per node). Not touched here: playwright is not installed in this environment, so equivalence could not be verified to the same standard.
- Namespaced elements never receive a usable XPath in **either** implementation — pre-existing, unchanged here, and irrelevant to Appium page sources, which do not use namespaces.
- `pagesource_strategies` is a `set`, so ordering is non-deterministic. The capability screen makes the Appium extraction path deterministic as a side effect, but `capture_pagesource` still is not.
