### PR TITLE
refactor(action_keyword): drop located kwarg; explicit locate-and-act runner (#454)

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -1,4 +1,3 @@
-from functools import wraps
 import collections
 import inspect
 import shlex
@@ -39,16 +38,6 @@ def _parse_aoi_param(param: Any, default_value: float) -> float:
     if param is None or str(param).strip() in ('', 'None', 'none'):
         return default_value
     return float(param)
-
-
-def _parse_aoi_from_kwargs(kwargs: dict) -> Tuple[float, float, float, float, int, bool]:
-    aoi_x = _parse_aoi_param(kwargs.pop('aoi_x', '0'), 0)
-    aoi_y = _parse_aoi_param(kwargs.pop('aoi_y', '0'), 0)
-    aoi_width = _parse_aoi_param(kwargs.pop('aoi_width', '100'), 100)
-    aoi_height = _parse_aoi_param(kwargs.pop('aoi_height', '100'), 100)
-    index = int(kwargs.pop('index', 0))
-    is_aoi_used = not (aoi_x == 0 and aoi_y == 0 and aoi_width == 100 and aoi_height == 100)
-    return aoi_x, aoi_y, aoi_width, aoi_height, index, is_aoi_used
 
 
 def _maybe_save_aoi_screenshot(
@@ -110,64 +99,6 @@ def _save_annotated_for_result(
     )
 
 
-def _try_results_until_success(
-    results,
-    func: Callable,
-    self: Any,
-    element: Any,
-    args: tuple,
-    kwargs: dict,
-    screenshot_np: Any,
-    execution_dir: str,
-    func_name: str,
-):
-    last_exception = None
-    result_count = 0
-    locate_error: Optional[OpticsError] = None
-
-    try:
-        results_list = list(results)
-    except OpticsError as e:
-        # The locate generator raises when no strategy yields a result; treat that
-        # as "no results" so self-heal below gets a chance, but keep the original
-        # error as the cause instead of losing it.
-        internal_logger.debug(f"Locate generator raised for '{element}' in '{func_name}': {e}")
-        results_list = []
-        locate_error = e
-
-    for result in results_list:
-        result_count += 1
-        _save_annotated_for_result(result, screenshot_np, execution_dir, func_name)
-        try:
-            ret = func(self, element, located=result.value, *args, **kwargs)
-        except Exception as e:
-            internal_logger.error(
-                f"Action '{func_name}' failed with {result.strategy.__class__.__name__}: {e}")
-            last_exception = e
-            continue
-        # Success: record as a breadcrumb for any later AI self-heal (capture-then-return;
-        # appending after a bare `return` would be unreachable).
-        self._record_successful_step(func_name, element, args)
-        return ret
-    if result_count == 0:
-        if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
-            return None
-        raise OpticsError(
-            Code.E0201,
-            message=f"No valid strategies found for '{element}' in '{func_name}'",
-            cause=locate_error,
-        ) from locate_error
-    if last_exception:
-        if self._ai_self_heal(element, func_name, args, kwargs, screenshot_np):
-            return None
-        raise OpticsError(
-            Code.X0201,
-            message=f"All strategies failed for '{element}' in '{func_name}': {last_exception}",
-            cause=last_exception,
-        )
-    raise OpticsError(Code.E0801, message=f"Unexpected failure: No results or exceptions for '{element}' in '{func_name}'")
-
-
 def _bounds_area(bounds: Optional[dict]) -> int:
     """
     indirect helper for `select_dropdown_option()`
@@ -218,33 +149,6 @@ def _raise_option_not_found(dropdown_element: str, option: str, interactive: Lis
             f"Available options: {available_texts}"
         ),
     )
-
-
-# Action Executor Decorator
-def with_self_healing(func: Callable) -> Callable:
-    @wraps(func)
-    def wrapper(self, element, *args, **kwargs):
-        # Skip self-healing if 'located' is already provided (avoids double healing)
-        if kwargs.get('located') is not None:
-            return func(self, element, *args, **kwargs)
-
-        screenshot_np = self._capture_screenshot_safe()
-        aoi_x, aoi_y, aoi_width, aoi_height, index, is_aoi_used = _parse_aoi_from_kwargs(kwargs)
-        if is_aoi_used and screenshot_np is not None:
-            _maybe_save_aoi_screenshot(
-                screenshot_np, aoi_x, aoi_y, aoi_width, aoi_height,
-                self.execution_dir, func.__name__,
-            )
-        self._save_screenshot_if_available(screenshot_np, f"pre-{func.__name__}")
-        results = _locate_element(
-            self.strategy_manager, element,
-            aoi_x, aoi_y, aoi_width, aoi_height, index, is_aoi_used,
-        )
-        return _try_results_until_success(
-            results, func, self, element, args, kwargs,
-            screenshot_np, self.execution_dir, func.__name__,
-        )
-    return wrapper
 
 
 class _HealProviders:
@@ -327,7 +231,7 @@ class ActionKeyword:
         self._recent_steps.append((func_name, [str(element), *map(str, args)]))
 
     def _ai_self_heal(
-        self, element: Any, func_name: str, args: tuple, kwargs: dict, screenshot_np: Any
+        self, element: Any, func_name: str, intent_args: tuple, screenshot_np: Any
     ) -> bool:
         """Last-resort AI recovery after every locate strategy failed. Returns True if healed.
 
@@ -345,7 +249,7 @@ class ActionKeyword:
         providers = _HealProviders(seed_png, self.strategy_manager)
         ctx = HealContext(
             intent_keyword=func_name,
-            intent_params=[str(a) for a in args],
+            intent_params=[str(a) for a in intent_args],
             element=str(element),
             recent_steps=list(self._recent_steps),
             failed_strategies=sorted(
@@ -361,7 +265,7 @@ class ActionKeyword:
             )
         internal_logger.info("AI self-heal: attempting recovery for '%s' on '%s'", func_name, element)
         result = self._ai_healer.heal(ctx, providers.screenshot, providers.pagesource)
-        self._log_heal_outcome(result, func_name, element, args)
+        self._log_heal_outcome(result, func_name, element, intent_args)
         return result.ok
 
     def _ai_self_heal_ready(self, screenshot_np: Any) -> bool:
@@ -423,8 +327,8 @@ class ActionKeyword:
     def _heal_execute(self, line: str) -> KeywordExecResult:
         """Keyword executor for self-heal: parse and run one keyword, returning a KeywordExecResult.
 
-        Calls the ActionKeyword methods directly but avoids re-triggering self-heal by
-        passing ``located=`` for self-healing-decorated methods or calling non-decorated ones.
+        Dispatches through the same public keyword methods (and therefore the same
+        locate ladder), with self-heal temporarily disabled so a heal cannot recurse.
         """
         try:
             tokens = shlex.split(line, posix=True)
@@ -441,10 +345,8 @@ class ActionKeyword:
             return KeywordExecResult(ok=False, message=f"Unknown keyword: {keyword_name}")
 
         try:
-            # Non-self-healing methods: call directly with params.
-            # Self-healing methods (press_element, enter_text): they will go through
-            # `with_self_healing` decorator, but self-heal is already running, so
-            # we need to temporarily disable it to avoid recursion.
+            # Dispatched keywords go through the same locate ladder; self-heal is
+            # temporarily disabled so a heal cannot recurse into itself.
             original_enabled = self.ai_self_heal_enabled
             self.ai_self_heal_enabled = False
             try:
@@ -475,9 +377,7 @@ class ActionKeyword:
         for pname, param in sig.parameters.items():
             if pname == "self":
                 continue
-            # Skip internal keyword-only params (located, event_name, aoi_*)
-            if param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD):
-                continue
+            # Skip locate-tuning params the healer never supplies (event_name, aoi_*)
             if pname in ("event_name", "aoi_x", "aoi_y", "aoi_width", "aoi_height"):
                 continue
             if param.default is inspect.Parameter.empty:
@@ -499,12 +399,106 @@ class ActionKeyword:
         if screenshot_np is not None:
             utils.save_screenshot(screenshot_np, name, output_dir=self.execution_dir)
 
+    def _locate_and_act(
+        self,
+        element: Any,
+        func_name: str,
+        act: Callable[[Any], Any],
+        intent_args: tuple = (),
+        index: str = "0",
+        aoi: Tuple[str, str, str, str] = ("0", "0", "100", "100"),
+    ) -> Any:
+        """Locate ``element`` through the strategy ladder and run ``act`` on it.
+
+        This is fallback level 2, shared by every locate-based keyword. ``act`` receives
+        each successful locate value in strategy-priority order (XPath -> text -> OCR ->
+        image); the first call that returns without raising wins. When no strategy yields
+        a result, or every ``act`` call raises, AI self-heal gets one chance before
+        E0201/X0201 is raised.
+
+        ``intent_args`` are the keyword's action parameters (everything after the
+        element, minus locate-tuning params); they feed the self-heal breadcrumbs.
+        """
+        screenshot_np = self._capture_screenshot_safe()
+        aoi_x = _parse_aoi_param(aoi[0], 0)
+        aoi_y = _parse_aoi_param(aoi[1], 0)
+        aoi_width = _parse_aoi_param(aoi[2], 100)
+        aoi_height = _parse_aoi_param(aoi[3], 100)
+        is_aoi_used = not (aoi_x == 0 and aoi_y == 0 and aoi_width == 100 and aoi_height == 100)
+        if is_aoi_used and screenshot_np is not None:
+            _maybe_save_aoi_screenshot(
+                screenshot_np, aoi_x, aoi_y, aoi_width, aoi_height,
+                self.execution_dir, func_name,
+            )
+        self._save_screenshot_if_available(screenshot_np, f"pre-{func_name}")
+        results = _locate_element(
+            self.strategy_manager, element,
+            aoi_x, aoi_y, aoi_width, aoi_height, int(index), is_aoi_used,
+        )
+        return self._act_until_success(
+            results, act, element, func_name, intent_args, screenshot_np
+        )
+
+    def _act_until_success(
+        self,
+        results: Any,
+        act: Callable[[Any], Any],
+        element: Any,
+        func_name: str,
+        intent_args: tuple,
+        screenshot_np: Any,
+    ) -> Any:
+        """Run ``act`` on each locate result until one succeeds; heal/wrap on failure."""
+        last_exception: Optional[Exception] = None
+        result_count = 0
+        locate_error: Optional[OpticsError] = None
+
+        try:
+            results_list = list(results)
+        except OpticsError as e:
+            # The locate generator raises when no strategy yields a result; treat that
+            # as "no results" so self-heal below gets a chance, but keep the original
+            # error as the cause instead of losing it.
+            internal_logger.debug(f"Locate generator raised for '{element}' in '{func_name}': {e}")
+            results_list = []
+            locate_error = e
+
+        for result in results_list:
+            result_count += 1
+            _save_annotated_for_result(result, screenshot_np, self.execution_dir, func_name)
+            try:
+                ret = act(result.value)
+            except Exception as e:  # noqa: BLE001 - try the next strategy's result
+                internal_logger.error(
+                    f"Action '{func_name}' failed with {result.strategy.__class__.__name__}: {e}")
+                last_exception = e
+                continue
+            # Success: record as a breadcrumb for any later AI self-heal (capture-then-return;
+            # appending after a bare `return` would be unreachable).
+            self._record_successful_step(func_name, element, intent_args)
+            return ret
+        if result_count == 0:
+            if self._ai_self_heal(element, func_name, intent_args, screenshot_np):
+                return None
+            raise OpticsError(
+                Code.E0201,
+                message=f"No valid strategies found for '{element}' in '{func_name}'",
+                cause=locate_error,
+            ) from locate_error
+        if last_exception:
+            if self._ai_self_heal(element, func_name, intent_args, screenshot_np):
+                return None
+            raise OpticsError(
+                Code.X0201,
+                message=f"All strategies failed for '{element}' in '{func_name}': {last_exception}",
+                cause=last_exception,
+            )
+        raise OpticsError(Code.E0801, message=f"Unexpected failure: No results or exceptions for '{element}' in '{func_name}'")
+
     # Click actions
-    @with_self_healing
     def press_element(
         self, element: str, repeat: str = "1", offset_x: str = "0", offset_y: str = "0", index: str = "0", aoi_x: str = "0",
-        aoi_y: str = "0", aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None,
-        *, located: Any = None
+        aoi_y: str = "0", aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None
         ) -> None:
         """
         Press a specified element.
@@ -520,15 +514,21 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         """
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.info(
-                f"Pressing at coordinates ({x + int(offset_x)}, {y + int(offset_y)}) with offset ({offset_x}, {offset_y})")
-            self.driver.press_coordinates(
-                x + int(offset_x), y + int(offset_y), event_name)
-        else:
-            internal_logger.info(f"Pressing element '{element}'")
-            self.driver.press_element(located, int(repeat), event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.info(
+                    f"Pressing at coordinates ({x + int(offset_x)}, {y + int(offset_y)}) with offset ({offset_x}, {offset_y})")
+                self.driver.press_coordinates(
+                    x + int(offset_x), y + int(offset_y), event_name)
+            else:
+                internal_logger.info(f"Pressing element '{element}'")
+                self.driver.press_element(located, int(repeat), event_name)
+
+        self._locate_and_act(
+            element, "press_element", act, (repeat, offset_x, offset_y),
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     def press_by_percentage(self, percent_x: str, percent_y: str, repeat: str = "1", event_name: Optional[str] = None) -> None:
         """
@@ -580,9 +580,8 @@ class ActionKeyword:
         else:
             internal_logger.info(f'Element {element} not found. Press is not performed.')
 
-    @with_self_healing
     def press_checkbox(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
-                       aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                       aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
         """
         Press a specified checkbox element.
 
@@ -594,14 +593,14 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the press.
+        :param index: Index of the element if multiple matches are found.
         """
         internal_logger.warning("'Press Checkbox' is deprecated; use 'Press Element' instead.")
         self.press_element(element, aoi_x=aoi_x, aoi_y=aoi_y, aoi_width=aoi_width,
-                          aoi_height=aoi_height, event_name=event_name, located=located)
+                          aoi_height=aoi_height, event_name=event_name, index=index)
 
-    @with_self_healing
     def press_radio_button(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
-                           aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                           aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
         """
         Press a specified radio button.
 
@@ -613,10 +612,11 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the press.
+        :param index: Index of the element if multiple matches are found.
         """
         internal_logger.warning("'Press Radio Button' is deprecated; use 'Press Element' instead.")
         self.press_element(element, aoi_x=aoi_x, aoi_y=aoi_y, aoi_width=aoi_width,
-                          aoi_height=aoi_height, event_name=event_name, located=located)
+                          aoi_height=aoi_height, event_name=event_name, index=index)
 
     def select_dropdown_option(self, element: str, option: str, timeout: str = "30",
                                 event_name: Optional[str] = None) -> None:
@@ -822,9 +822,9 @@ class ActionKeyword:
         if not found:
             raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after swiping {direction} for {timeout}s.")
 
-    @with_self_healing
     def swipe_from_element(self, element: str, direction: str, swipe_length: str, aoi_x: str = "0", aoi_y: str = "0",
-                          aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                           aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None,
+                           index: str = "0") -> None:
         """
         Perform a swipe action starting from a specified element.
 
@@ -836,15 +836,22 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the swipe.
+        :param index: Index of the element if multiple matches are found.
         """
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
-            self.driver.swipe(x, y, direction, int(swipe_length), event_name)
-        else:
-            internal_logger.debug(f"Swiping from element '{element}'")
-            self.driver.swipe_element(
-                located, direction, int(swipe_length), event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
+                self.driver.swipe(x, y, direction, int(swipe_length), event_name)
+            else:
+                internal_logger.debug(f"Swiping from element '{element}'")
+                self.driver.swipe_element(
+                    located, direction, int(swipe_length), event_name)
+
+        self._locate_and_act(
+            element, "swipe_from_element", act, (direction, swipe_length),
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     def scroll(self, direction: str, event_name: Optional[str] = None) -> None:
         """
@@ -889,9 +896,9 @@ class ActionKeyword:
         if not found:
             raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after scrolling {direction} for {timeout}s.")
 
-    @with_self_healing
     def scroll_from_element(self, element: str, direction: str, scroll_length: str, aoi_x: str = "0", aoi_y: str = "0",
-                           aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                            aoi_width: str = "100", aoi_height: str = "100", event_name: Optional[str] = None,
+                            index: str = "0") -> None:
         """
         Perform a scroll action starting from a specified element.
 
@@ -903,20 +910,26 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the scroll.
+        :param index: Index of the element if multiple matches are found.
         """
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
-            self.driver.swipe(x, y, direction, int(scroll_length), event_name)
-        else:
-            internal_logger.debug(f"Swiping from element '{element}'")
-            self.driver.swipe_element(
-                located, direction, int(scroll_length), event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
+                self.driver.swipe(x, y, direction, int(scroll_length), event_name)
+            else:
+                internal_logger.debug(f"Swiping from element '{element}'")
+                self.driver.swipe_element(
+                    located, direction, int(scroll_length), event_name)
+
+        self._locate_and_act(
+            element, "scroll_from_element", act, (direction, scroll_length),
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     # Text input actions
-    @with_self_healing
     def enter_text(self, element: str, text: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
-                   aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                   aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
         """
         Enter text into a specified element.
 
@@ -927,20 +940,26 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the input.
+        :param index: Index of the element if multiple matches are found.
         """
-
         parsed = utils.parse_special_key(text)
         if parsed is not None:
             text = parsed
 
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.debug(f"Entering text '{text}' at coordinates ({x}, {y})")
-            self.driver.press_coordinates(x, y, event_name=event_name)
-            self.driver.enter_text(text, event_name)
-        else:
-            internal_logger.debug(f"Entering text '{text}' into element '{element}'")
-            self.driver.enter_text_element(located, text, event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.debug(f"Entering text '{text}' at coordinates ({x}, {y})")
+                self.driver.press_coordinates(x, y, event_name=event_name)
+                self.driver.enter_text(text, event_name)
+            else:
+                internal_logger.debug(f"Entering text '{text}' into element '{element}'")
+                self.driver.enter_text_element(located, text, event_name)
+
+        self._locate_and_act(
+            element, "enter_text", act, (text,),
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     def enter_text_direct(self, text: str, event_name: Optional[str] = None) -> None:
         """
@@ -979,9 +998,8 @@ class ActionKeyword:
         internal_logger.info(f'Entering text using keyboard: {text_input}')
         self.driver.enter_text_using_keyboard(text_input, event_name)
 
-    @with_self_healing
     def enter_number(self, element: str, number: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
-                     aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                     aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
         """
         Enter a specified number into an element.
 
@@ -992,15 +1010,22 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the input.
+        :param index: Index of the element if multiple matches are found.
         """
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.debug(f"Entering number '{number}' at coordinates ({x}, {y})")
-            self.driver.press_coordinates(x, y, event_name=event_name)
-            self.driver.enter_text(str(number), event_name)
-        else:
-            internal_logger.debug(f"Entering number '{number}' into element '{element}'")
-            self.driver.enter_text_element(located, str(number), event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.debug(f"Entering number '{number}' at coordinates ({x}, {y})")
+                self.driver.press_coordinates(x, y, event_name=event_name)
+                self.driver.enter_text(str(number), event_name)
+            else:
+                internal_logger.debug(f"Entering number '{number}' into element '{element}'")
+                self.driver.enter_text_element(located, str(number), event_name)
+
+        self._locate_and_act(
+            element, "enter_number", act, (number,),
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     def press_keycode(self, keycode: str, event_name: Optional[str] = None) -> None:
         """
@@ -1019,9 +1044,8 @@ class ActionKeyword:
         self.driver.press_keycode(keycode, event_name)
 
 
-    @with_self_healing
     def clear_element_text(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
-                          aoi_height: str = "100", event_name: Optional[str] = None, *, located: Any=None) -> None:
+                           aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
         """
         Clear text from a specified element.
 
@@ -1031,32 +1055,50 @@ class ActionKeyword:
         :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
         :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :param event_name: The event triggering the action.
+        :param index: Index of the element if multiple matches are found.
         """
-        if isinstance(located, tuple):
-            x, y = located
-            internal_logger.debug(f"Clearing text at coordinates ({x}, {y})")
-            self.driver.press_coordinates(
-                x, y, event_name=event_name)
-            self.driver.clear_text(event_name)
-        else:
-            internal_logger.debug(f"Clearing text from element '{element}'")
-            self.driver.clear_text_element(located, event_name)
+        def act(located: Any) -> None:
+            if isinstance(located, tuple):
+                x, y = located
+                internal_logger.debug(f"Clearing text at coordinates ({x}, {y})")
+                self.driver.press_coordinates(
+                    x, y, event_name=event_name)
+                self.driver.clear_text(event_name)
+            else:
+                internal_logger.debug(f"Clearing text from element '{element}'")
+                self.driver.clear_text_element(located, event_name)
 
-    @with_self_healing
-    def get_text(self, element: str, *, located=None) -> Optional[str]:
+        self._locate_and_act(
+            element, "clear_element_text", act,
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
+
+    def get_text(self, element: str, index: str = "0", aoi_x: str = "0", aoi_y: str = "0",
+                 aoi_width: str = "100", aoi_height: str = "100") -> Optional[str]:
         """
         Get the text from a specified element.
 
         :param element: The target element (Image template, OCR template, or XPath).
+        :param index: Index of the element if multiple matches are found.
+        :param aoi_x: X percentage of Area of Interest top-left corner (0-100). Default: 0.
+        :param aoi_y: Y percentage of Area of Interest top-left corner (0-100). Default: 0.
+        :param aoi_width: Width percentage of Area of Interest (0-100). Default: 100.
+        :param aoi_height: Height percentage of Area of Interest (0-100). Default: 100.
         :return: The text from the element or None if not supported.
         """
-        if located is None:
-            internal_logger.error('get_text: located is None, element could not be found.')
-            return None
-        if isinstance(located, tuple):
-            internal_logger.error('Get Text is not supported for coordinate-based (vision) results.')
-            return None
-        return self.driver.get_text_element(located)
+        def act(located: Any) -> Optional[str]:
+            if located is None:
+                internal_logger.error('get_text: located is None, element could not be found.')
+                return None
+            if isinstance(located, tuple):
+                internal_logger.error('Get Text is not supported for coordinate-based (vision) results.')
+                return None
+            return self.driver.get_text_element(located)
+
+        return self._locate_and_act(
+            element, "get_text", act,
+            index=index, aoi=(aoi_x, aoi_y, aoi_width, aoi_height),
+        )
 
     def sleep(self, duration: str) -> None:
         """

--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -580,8 +580,7 @@ def _normalize_param_value(name: str, val: Union[str, List[str]], is_list_param:
 
 
 def _resolve_named_to_positional(
-    method: Callable[..., Any],
-    named_params: Dict[str, Union[str, List[str]]]
+    method: Callable[..., Any], named_params: Dict[str, Union[str, List[str]]]
 ) -> List[List[str]]:
     """
     Convert named parameters to positional parameters based on method signature.
@@ -596,8 +595,11 @@ def _resolve_named_to_positional(
     sig = inspect.signature(method)
     param_names = []
     for p in sig.parameters.values():
-        if p.name != "self":
-            param_names.append(p.name)
+        if p.name == "self":
+            continue
+        if p.kind == inspect.Parameter.KEYWORD_ONLY:
+            continue
+        param_names.append(p.name)
 
     normalized_params = []
     for param_name in param_names:
@@ -681,7 +683,11 @@ def _build_named_param_context(
 ) -> _NamedParamsContext:
     """Normalize named params and build context for fallback combos."""
     sig = inspect.signature(method)
-    all_param_names = [p.name for p in sig.parameters.values() if p.name != "self"]
+    all_param_names = [
+        p.name
+        for p in sig.parameters.values()
+        if p.name != "self" and p.kind != inspect.Parameter.KEYWORD_ONLY
+    ]
     normalized_param_lists: List[List[str]] = []
     provided_param_names: List[str] = []
     param_defaults: Dict[str, Any] = {}

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -454,7 +454,8 @@ class LiveController:
         for name, param in sig.parameters.items():
             if name == "self":
                 continue
-            # Skip keyword-only sentinels like ``located`` used by self-healing.
+            # Keywords take plain positional/keyword params; skip variadic kinds
+            # that can't render as a discrete ghost-text token.
             if param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD):
                 continue
             if param.kind == inspect.Parameter.VAR_POSITIONAL:

--- a/optics_framework/helper/mcp_server.py
+++ b/optics_framework/helper/mcp_server.py
@@ -78,10 +78,6 @@ _RESOURCE_ONLY_KEYWORDS = frozenset(
     {"capture_screenshot", "capture_pagesource", "get_screen_elements"}
 )
 
-# Internal params injected by decorators (e.g. `@with_self_healing` fills
-# `located`), never supplied by an MCP client — drop them from tool schemas.
-_EXCLUDED_PARAMS = frozenset({"located"})
-
 _RESULT_KEY = expose_api.KEY_RESULT
 
 
@@ -127,7 +123,6 @@ def _reflect_keyword_params(method: Callable[..., Any]) -> list[inspect.Paramete
         p
         for name, p in sig.parameters.items()
         if name != "self"
-        and name not in _EXCLUDED_PARAMS
         # *args / **kwargs can't be represented as discrete string tool params.
         and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
     ]

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import pytest
 from pathlib import Path
@@ -6,7 +7,8 @@ import tempfile
 import numpy as np
 from optics_framework.common.error import OpticsError, Code
 
-from optics_framework.api.action_keyword import ActionKeyword, _find_dropdown_container
+from optics_framework.api import ActionKeyword, AppManagement, FlowControl, Verifier
+from optics_framework.api.action_keyword import _find_dropdown_container
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.strategies import LocateResult
 
@@ -90,7 +92,7 @@ def action_keyword(mock_dependencies):
 
 
 class TestPressElementWithIndex:
-    """press_element param coercion and located-value dispatch.
+    """press_element param coercion and locate-result dispatch.
 
     ``locate`` is mocked to return a LocateResult, so ``determine_element_type``
     (which only runs *inside* the real locate) is never reached — no need to patch
@@ -159,7 +161,7 @@ class TestScreenshotFailureFallback:
     """Tests for behavior when screenshot capture fails (e.g. secure/protected pages)."""
 
     @patch('optics_framework.common.utils.save_screenshot')
-    def test_with_self_healing_proceeds_when_screenshot_raises(
+    def test_locate_and_act_proceeds_when_screenshot_raises(
         self, mock_save_screenshot, action_keyword, mock_dependencies
     ):
         """Action still executes when capture_screenshot raises (e.g. INTERNAL_SERVER_ERROR)."""
@@ -175,7 +177,7 @@ class TestScreenshotFailureFallback:
         mock_dependencies['driver'].press_coordinates.assert_called_once_with(100, 150, None)
 
     @patch('optics_framework.common.utils.save_screenshot')
-    def test_with_self_healing_skips_save_when_screenshot_raises(
+    def test_locate_and_act_skips_save_when_screenshot_raises(
         self, mock_save_screenshot, action_keyword, mock_dependencies
     ):
         """utils.save_screenshot is not called when capture_screenshot raises."""
@@ -192,7 +194,7 @@ class TestScreenshotFailureFallback:
 
     @patch('optics_framework.common.utils.annotate_aoi_region')
     @patch('optics_framework.common.utils.save_screenshot')
-    def test_with_self_healing_skips_aoi_save_when_screenshot_raises(
+    def test_locate_and_act_skips_aoi_save_when_screenshot_raises(
         self, mock_save_screenshot, mock_annotate_aoi, action_keyword, mock_dependencies
     ):
         """AOI annotation and save are skipped when capture_screenshot raises."""
@@ -214,7 +216,7 @@ class TestScreenshotFailureFallback:
     def test_direct_method_proceeds_when_screenshot_raises(
         self, mock_save_screenshot, action_keyword, mock_dependencies
     ):
-        """Direct methods (not via with_self_healing) still execute when capture_screenshot raises."""
+        """Direct methods (no locate step) still execute when capture_screenshot raises."""
         with patch.object(
             action_keyword.strategy_manager, 'capture_screenshot',
             side_effect=OpticsError(Code.E0303, message="INTERNAL_SERVER_ERROR")
@@ -499,19 +501,81 @@ class TestDeprecatedAliases:
 
     @pytest.mark.parametrize("alias", ["press_checkbox", "press_radio_button"])
     def test_alias_delegates_to_press_element_with_deprecation_log(self, action_keyword, alias):
-        located = MagicMock()
-        with patch.object(
-            action_keyword.strategy_manager, 'locate',
-            return_value=[LocateResult(located, MagicMock())],
-        ), patch.object(action_keyword, 'press_element') as mock_press, patch(
+        with patch.object(action_keyword, 'press_element') as mock_press, patch(
             'optics_framework.api.action_keyword.internal_logger'
         ) as mock_logger:
-            getattr(action_keyword, alias)("box")
+            getattr(action_keyword, alias)("box", aoi_x="10", event_name="evt")
 
-        mock_press.assert_called_once()
-        assert mock_press.call_args.args[0] == "box"
-        assert mock_press.call_args.kwargs.get("located") is located
+        mock_press.assert_called_once_with(
+            "box", aoi_x="10", aoi_y="0", aoi_width="100",
+            aoi_height="100", event_name="evt", index="0",
+        )
         assert any(
             "deprecated" in str(call.args[0]).lower()
             for call in mock_logger.warning.call_args_list
         )
+
+
+class TestKeywordSignatureHygiene:
+    """Public API keywords must not declare keyword-only params.
+
+    Keyword-only (and ``**kwargs``-style) params can't be filled by the
+    string-only named-param dispatch shared by `optics serve` and `optics mcp`
+    (see mozarkai/optics-framework#454): the dispatcher reflects the signature
+    into positional slots, so a keyword-only slot either overflows the call or
+    is silently dropped. Keep this guard so injection-style params (the old
+    ``located`` kwarg) are never reintroduced into keyword signatures.
+    ``FlowControl``'s ``*args`` keywords (Condition, Run Loop) are deliberate
+    variadic contracts and stay allowed.
+    """
+
+    @pytest.mark.parametrize(
+        "cls", [ActionKeyword, AppManagement, Verifier, FlowControl]
+    )
+    def test_public_keywords_have_no_keyword_only_or_var_kwargs_params(self, cls):
+        offenders = []
+        for name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
+            if name.startswith("_") or name.startswith("test"):
+                continue
+            for param in inspect.signature(method).parameters.values():
+                if param.kind in (
+                    inspect.Parameter.KEYWORD_ONLY,
+                    inspect.Parameter.VAR_KEYWORD,
+                ):
+                    offenders.append(f"{cls.__name__}.{name}:{param.name}")
+        assert offenders == []
+
+
+class TestLocateHonorsPositionalParams:
+    """AOI/index must be honored no matter how the keyword was called.
+
+    The MCP/serve dispatch invokes keywords with every parameter positional
+    (it rebuilds a flat positional list from the signature), so locate-tuning
+    values that arrive in positional slots must still reach the locator.
+    Regression for the pre-refactor behavior where only kwargs were read.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_disk_writes(self):
+        with patch('optics_framework.common.utils.save_screenshot'):
+            yield
+
+    def test_positional_aoi_and_index_reach_locate(self, action_keyword):
+        locate_result = LocateResult((7, 7), MagicMock())
+        with patch.object(
+            action_keyword.strategy_manager, 'locate', return_value=[locate_result]
+        ) as mock_locate:
+            # MCP-style all-positional call: repeat, offset_x, offset_y, index,
+            # aoi_x, aoi_y, aoi_width, aoi_height, event_name.
+            action_keyword.press_element("btn", "1", "0", "0", "2", "45", "45", "60", "60", None)
+
+        mock_locate.assert_called_once_with("btn", 45.0, 45.0, 60.0, 60.0, index=2)
+
+    def test_kwarg_aoi_and_index_reach_locate(self, action_keyword):
+        locate_result = LocateResult((7, 7), MagicMock())
+        with patch.object(
+            action_keyword.strategy_manager, 'locate', return_value=[locate_result]
+        ) as mock_locate:
+            action_keyword.enter_text("field", "hello", aoi_x="10", index="3")
+
+        mock_locate.assert_called_once_with("field", 10.0, 0.0, 100.0, 100.0, index=3)

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -474,16 +474,16 @@ class TestActionKeywordWiring:
         assert ak.ai_self_heal_enabled is False
         assert ak._llm is None
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
-        assert ak._ai_self_heal("X", "press_element", (), {}, shot) is False
+        assert ak._ai_self_heal("X", "press_element", (), shot) is False
 
     def test_no_screenshot_inert(self):
         ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
-        assert ak._ai_self_heal("X", "press_element", (), {}, None) is False
+        assert ak._ai_self_heal("X", "press_element", (), None) is False
 
     def test_llm_without_instances_inert(self):
         ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[]))
         shot = np.zeros((10, 10, 3), dtype=np.uint8)
-        assert ak._ai_self_heal("X", "press_element", (), {}, shot) is False
+        assert ak._ai_self_heal("X", "press_element", (), shot) is False
 
     def test_heal_catalog_returns_specs(self):
         ak = _make_action_keyword(ai_self_heal=True, llm=MagicMock(instances=[object()]))
@@ -511,20 +511,20 @@ class TestActionKeywordWiring:
         ak.strategy_manager.capture_screenshot = MagicMock(return_value=shot)
         ak.strategy_manager.capture_pagesource = MagicMock(return_value=None)
 
-        # scroll is non-self-healing, so `_heal_execute` calls the real method; let it
+        # scroll is non-locating, so `_heal_execute` calls the real method; let it
         # run against the mocked `ak.driver` and assert the call reached the driver
         # with the parsed params (`_heal_dispatch` binds the real method at __init__,
         # so reassigning `ak.scroll` here would never be consulted — see press_element
-        # below for the correct way to intercept a self-healing-decorated method).
-        # press_element goes through `with_self_healing` decorator, which needs a
-        # working strategy_manager.locate; mock it to return a located result.
+        # below for the correct way to intercept a locating keyword).
+        # press_element runs `_locate_and_act`, which needs a working
+        # strategy_manager.locate; mock it to return a located result.
         mock_result = MagicMock()
         mock_result.is_coordinates = False
         mock_result.value = MagicMock()
         mock_result.strategy = MagicMock()
         ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
 
-        assert ak._ai_self_heal("Login", "press_element", (), {}, shot) is True
+        assert ak._ai_self_heal("Login", "press_element", (), shot) is True
         ak.driver.scroll.assert_called_once_with("down", 1000, None)
         # Healed keyword is recorded as a breadcrumb (may appear more than once —
         # the inner press_element records one, and _log_heal_outcome records another).
@@ -626,7 +626,7 @@ class TestSuggestedStepsWiring:
         mock_result.strategy = MagicMock()
         ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
 
-        assert ak._ai_self_heal("Login", "press_element", (), {}, shot) is True
+        assert ak._ai_self_heal("Login", "press_element", (), shot) is True
         info = ak._pop_last_heal_info()
         assert info is not None
         assert info["suggested_steps"] == [{"keyword": "press_element", "params": ["Login"]}]

--- a/tests/units/common/test_expose_api.py
+++ b/tests/units/common/test_expose_api.py
@@ -14,6 +14,7 @@ Source under test: optics_framework/common/expose_api.py
 """
 import asyncio
 import base64
+import inspect
 import json
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -407,6 +408,53 @@ def test_fallback_named_params_fold_in_defaults():
     assert result == "ok"
     # The defaulted param is folded into the positional args in signature order.
     assert engine.execute.await_args.args[0].params == ["x", "0"]
+
+
+def test_fallback_named_params_exclude_keyword_only_located():
+    def method(self, element: str, text: str = "", repeat: str = "1", *, located=None):
+        pass
+
+    engine = MagicMock()
+    engine.execute = AsyncMock(return_value="ok")
+    result = _run(
+        expose_api._execute_keyword_with_fallback(
+            engine, "sess", "enter_text", {"element": "x", "text": "hi"}, method, MagicMock()
+        )
+    )
+    assert result == "ok"
+    params = engine.execute.await_args.args[0].params
+    assert params == ["x", "hi", "1"]
+    assert "None" not in params[-1:]
+
+
+def test_build_named_param_context_skips_keyword_only():
+    def method(self, element: str, repeat: str = "1", *, located=None):
+        pass
+
+    ctx = expose_api._build_named_param_context(method, {"element": "x"})
+    assert ctx.all_param_names == ["element", "repeat"]
+    assert "located" not in ctx.param_defaults
+    assert ctx.provided_param_names == ["element"]
+
+
+def test_build_named_param_context_real_enter_text_signature():
+    from optics_framework.api.action_keyword import ActionKeyword
+
+    method = ActionKeyword.enter_text
+    ctx = expose_api._build_named_param_context(
+        method, {"element": "//Search", "text": "shawarma"}
+    )
+    assert "located" not in ctx.all_param_names
+    combo_args = expose_api._combo_to_positional_named(("//Search", "shawarma"), ctx)
+    inspect.signature(method).bind(None, *combo_args)
+
+
+def test_resolve_named_to_positional_skips_keyword_only():
+    def method(self, element: str, repeat: str = "1", *, located=None):
+        pass
+
+    out = expose_api._resolve_named_to_positional(method, {"element": "x"})
+    assert out == [["x"]]
 
 
 def test_fallback_no_params_wraps_engine_failure():

--- a/tests/units/common/test_mcp_server.py
+++ b/tests/units/common/test_mcp_server.py
@@ -2,17 +2,18 @@
 
 No device/driver: `expose_api.execute_keyword` / `create_session` /
 `run_keyword_endpoint` are mocked. Covers dynamic per-keyword tool registration
-(str-typed schemas with an injected session_id, internal `located` excluded),
-the read-only observers being surfaced as resources instead of tools, param
-stringification at the ExecuteRequest boundary, error translation to ToolError,
-and the screenshot resource returning raw image bytes.
+(str-typed schemas with an injected session_id), the read-only observers being
+surfaced as resources instead of tools, param stringification at the
+ExecuteRequest boundary, error translation to ToolError, and the screenshot
+resource returning raw image bytes.
 
 `fastmcp` is an optional extra; the whole module skips when it is absent.
 """
 import asyncio
 import base64
+import inspect
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -87,7 +88,7 @@ def test_keyword_tool_schema_is_string_typed_with_session_id():
     # session_id is injected and required alongside the keyword's required args.
     assert "session_id" in props
     assert set(press.parameters["required"]) >= {"session_id", "element"}
-    # Internal self-healing param must not be exposed.
+    # Only declared keyword params are exposed (no injection plumbing).
     assert "located" not in props
     # Every property is a string (optional ones are anyOf[string, null]).
     for name, schema in props.items():
@@ -144,6 +145,73 @@ def test_stringify_params_helper():
         {"a": 1, "b": None, "c": ["x", 2], "d": True}
     )
     assert out == {"a": "1", "c": ["x", "2"], "d": "True"}  # None dropped
+
+
+# --- deep dispatch: real named-param path (regression for #454) ------------
+
+_SELF_HEALING_KEYWORDS = [
+    ("press_element", {"element": "X"}),
+    ("press_checkbox", {"element": "X"}),
+    ("press_radio_button", {"element": "X"}),
+    ("swipe_from_element", {"element": "X", "direction": "up", "swipe_length": "50"}),
+    ("scroll_from_element", {"element": "X", "direction": "down", "scroll_length": "50"}),
+    ("enter_text", {"element": "X", "text": "T"}),
+    ("enter_number", {"element": "X", "number": "5"}),
+    ("clear_element_text", {"element": "X"}),
+    ("get_text", {"element": "X"}),
+]
+
+
+@pytest.mark.parametrize("slug, params", _SELF_HEALING_KEYWORDS)
+def test_mcp_dispatch_binds_real_self_healing_signatures(slug, params):
+    from optics_framework.api.action_keyword import ActionKeyword
+    from optics_framework.common import expose_api
+
+    method = getattr(ActionKeyword, slug)
+    engine = MagicMock()
+    engine.execute = AsyncMock(return_value=_exec_response("ok"))
+    _run(expose_api._execute_keyword_with_fallback(
+        engine, "sess", slug, params, method, MagicMock()
+    ))
+    built = engine.execute.await_args.args[0].params
+    assert "located" not in built
+    inspect.signature(method).bind(None, *built)
+
+
+@pytest.mark.parametrize("slug, params", _SELF_HEALING_KEYWORDS)
+def test_mcp_tool_to_dispatch_binds_real_signatures(slug, params):
+    server = mcp_server.build_server()
+    engine = MagicMock()
+    engine.execute = AsyncMock(return_value=_exec_response("ok"))
+
+    session = MagicMock()
+    session.event_queue.put = AsyncMock()
+    session.request_template_overrides = {}
+    from optics_framework.api.action_keyword import ActionKeyword
+
+    session.optics.build = MagicMock(return_value=MagicMock())
+
+    class _RealRegistry:
+        def __init__(self):
+            self.keyword_map = {slug: getattr(ActionKeyword, slug)}
+
+        def register(self, instance):
+            pass
+
+    real_registry = _RealRegistry()
+
+    with patch.object(expose_api.session_manager, "get_session", return_value=session), \
+            patch.object(expose_api, "KeywordRegistry", return_value=real_registry), \
+            patch.object(expose_api, "FlowControl", return_value=MagicMock()), \
+            patch.object(expose_api, "ExecutionEngine", return_value=engine):
+        async def go():
+            async with Client(server) as client:
+                await client.call_tool(slug, {"session_id": "s1", **params})
+
+        _run(go())
+
+    built = engine.execute.await_args.args[0].params
+    inspect.signature(getattr(ActionKeyword, slug)).bind(None, *built)
 
 
 # --- error translation -----------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #454 — at the root, not the symptom.

Element-interaction keywords (`press_element`, `enter_text`, `get_text`, …) failed with `TypeError: … takes from N to M positional arguments but M+1 were given` through the **named-params dispatch path** (`optics mcp` tools and `optics serve`'s `/v1/sessions/{id}/action`) whenever a locate strategy **succeeded**. This PR removes the cause of that failure class entirely: the decorator-injected keyword-only `located` parameter is gone from every public keyword signature, replaced by an explicit locate-and-act runner.

## Root cause

Every locate-based keyword carried a `*, located: Any = None` tail param that only `@with_self_healing`'s wrapper ever supplied (it injected the located element/coordinates into the body). Because it sat in the public signature:

- the named-params dispatch in `expose_api.py` reflected it into a positional slot; `_combo_to_positional_named` stringified its `None` default into the args list, overflowing the bound call exactly when the element was found;
- `helper/mcp_server.py` needed a name-based `_EXCLUDED_PARAMS = {"located"}` filter to keep it out of tool schemas;
- `live.py` and `_heal_keyword_signature` each carried their own keyword-only skips;
- `/v1/keywords` still advertised it to HTTP clients;
- the wrapper's `located=` bypass existed solely so the deprecated `press_checkbox`/`press_radio_button` aliases could forward a located value without double-locating;
- AOI/index were read from kwargs only, so the all-positional convention MCP/serve uses silently ignored positional AOI values (confirmed empirically before this change).

Review feedback on the first iteration of this PR called the `located` design out: *a simple function can do it better*. Agreed — this PR implements that.

## What changed

**`optics_framework/api/action_keyword.py`**
- `@with_self_healing` deleted. Each locate-based keyword now builds an `act(located)` closure and calls the new `ActionKeyword._locate_and_act(element, func_name, act, intent_args, index, aoi)` runner.
- `_locate_and_act` + `_act_until_success` preserve the previous semantics exactly: screenshot capture → AOI parse/annotate → strategy ladder (XPath → text → OCR → image) → run `act` per result until one returns without raising → AI self-heal → `E0201`/`X0201` wrapping. Breadcrumbs (`_recent_steps`) unchanged.
- The 9 keywords (`press_element`, `press_checkbox`, `press_radio_button`, `swipe_from_element`, `scroll_from_element`, `enter_text`, `enter_number`, `clear_element_text`, `get_text`) have clean signatures. The two deprecated aliases plain-delegate to `press_element`.
- `index` is now an explicit parameter on the keywords that previously only accepted it via hidden wrapper kwargs; `get_text` gains explicit `index`/AOI params. **Behavior fix:** AOI/index are honored regardless of call convention — positional (MCP/serve) included.
- `_ai_self_heal` drops its unused `kwargs` parameter; stale comments updated.

**`optics_framework/helper/mcp_server.py`** — `_EXCLUDED_PARAMS` removed (dead once no signature carries `located`).

**`optics_framework/common/expose_api.py`** *(second commit, defense in depth)* — `_build_named_param_context` / `_resolve_named_to_positional` exclude `KEYWORD_ONLY` by kind, so the dispatch contract ("named params map to positional slots only") holds even if a future callable reintroduces a keyword-only param.

**Tests**
- New `TestKeywordSignatureHygiene`: no public API keyword on `ActionKeyword`/`AppManagement`/`Verifier`/`FlowControl` may declare `KEYWORD_ONLY`/`VAR_KEYWORD` params — the guard that would have caught #454's root cause at review time. (`FlowControl`'s deliberate `*args` keywords stay allowed.)
- New `TestLocateHonorsPositionalParams`: AOI/index reach the locator from both all-positional (MCP-style) and kwarg calls.
- Alias-delegation test rewritten for plain delegation; self-heal wiring tests updated to the new `_ai_self_heal` signature; MCP end-to-end tests bind all real self-healing signatures through both the dispatch path and actual MCP tool invocation.

## Verification

```
$ python -m pytest tests/ --no-cov -p no:warnings
736 passed, 1 skipped (pre-existing, playwright), 2 xfailed (pre-existing, #385)

$ ruff check optics_framework/ tests/
All checks passed!

$ pre-commit run --files <changed>
ruff/bandit/trailing-whitespace/end-of-file/check-json/gitleaks: Passed
```

## Impact

- Fixes #454 structurally: there is no keyword-only param left to mis-dispatch, for any entry point (MCP, serve, live, runner).
- MCP tool schemas and `/v1/keywords` now list only real, caller-suppliable parameters.
- AOI/index work over MCP/serve for the first time (previously silently ignored when sent positionally).
- No CSV/YAML/Robot-facing keyword names or existing positional call sites change; new params are appended with defaults, so existing callers are unaffected.
