### PR TITLE
fix(templatematch): bound per-call memory and fix index selection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -762,11 +762,18 @@ Image detection engines provide template matching capabilities for locating UI e
       - templatematch:
           enabled: true
           url: null
-          capabilities: {}
+          capabilities:
+            sift_nfeatures: 2000
     ```
 
     !!! note "Local Processing"
         Template matching runs locally using OpenCV and does not require external services.
+
+    Matching is two-stage: a `cv2.matchTemplate` fast path handles exact
+    same-scale matches, and a SIFT + FLANN + RANSAC fallback covers scaled or
+    rotated instances. `capabilities.sift_nfeatures` (default `2000`) caps the
+    SIFT features extracted per frame in that fallback, bounding per-call
+    memory; raise it only if scaled matches fail on feature-poor screens.
 
 === "Remote OIR"
 

--- a/optics_framework/engines/vision_models/image_models/templatematch.py
+++ b/optics_framework/engines/vision_models/image_models/templatematch.py
@@ -6,7 +6,7 @@ from optics_framework.common.logging_config import internal_logger
 from optics_framework.engines.vision_models.base_methods import load_template
 from optics_framework.common import utils
 
-_MatchResult = tuple[bool, tuple[int, int], tuple[tuple[int, int], tuple[int, int]]]
+_MatchResult = tuple[Literal[True], tuple[int, int], tuple[tuple[int, int], tuple[int, int]]]
 
 
 class _IndexMiss:
@@ -58,12 +58,12 @@ class TemplateMatchingHelper(ImageInterface):
         self._sift: cv2.SIFT | None = None
         self._flann: cv2.FlannBasedMatcher | None = None
 
-    def _get_sift(self):
+    def _get_sift(self) -> cv2.SIFT:
         if self._sift is None:
             self._sift = cv2.SIFT_create(nfeatures=self._sift_nfeatures)
         return self._sift
 
-    def _get_flann(self):
+    def _get_flann(self) -> cv2.FlannBasedMatcher:
         if self._flann is None:
             flann_index_kdtree = 1
             index_params = {"algorithm": flann_index_kdtree, "trees": 5}
@@ -300,8 +300,19 @@ class TemplateMatchingHelper(ImageInterface):
         if match_rule:
             return True, annotated_frame
 
-        internal_logger.warning("SIFT assert_elements failed.")
-        raise RuntimeError("SIFT assert_elements failed.")
+        internal_logger.warning("assert_elements failed.")
+        raise RuntimeError("assert_elements failed.")
+
+    @staticmethod
+    def _apply_offset(
+        center: tuple[int, int], top_left: tuple[int, int],
+        bottom_right: tuple[int, int], offset: list[int],
+    ) -> tuple[Literal[True], tuple[int, int], list[tuple[int, int]]]:
+        """Apply a pixel ``offset`` (x right, y up) and build the success tuple."""
+        center_x, center_y = center
+        center_x += offset[0]
+        center_y -= offset[1]
+        return True, (center_x, center_y), [top_left, bottom_right]
 
     def element_exist(
         self,
@@ -324,14 +335,10 @@ class TemplateMatchingHelper(ImageInterface):
 
         fast = self._match_template_fast(input_data, reference_data, confidence_level, None)
         if fast is not None:
-            _, (center_x, center_y), (top_left, bottom_right) = fast
-            center_x += offset[0]
-            center_y -= offset[1]
-            return True, (center_x, center_y), [top_left, bottom_right]
+            _, center, (top_left, bottom_right) = fast
+            return self._apply_offset(center, top_left, bottom_right, offset)
 
         center_x, center_y, top_left, bottom_right = self._sift_match(
             input_data, reference_data, confidence_level, min_inliers
         )
-        center_x += offset[0]
-        center_y -= offset[1]
-        return True, (center_x, center_y), [top_left, bottom_right]
+        return self._apply_offset((center_x, center_y), top_left, bottom_right, offset)

--- a/optics_framework/engines/vision_models/image_models/templatematch.py
+++ b/optics_framework/engines/vision_models/image_models/templatematch.py
@@ -249,7 +249,7 @@ class TemplateMatchingHelper(ImageInterface):
         (higher = more lenient).
         """
         if input_data is None:
-            raise ValueError("Input data or template image is None.")
+            raise ValueError("Input data is None.")
         template = load_template(image, self.templates)
 
         fast = self._match_template_fast(input_data, template, confidence_level, index)
@@ -310,7 +310,7 @@ class TemplateMatchingHelper(ImageInterface):
         offset=[0, 0],
         confidence_level=0.85,
         min_inliers=10,
-    ) -> tuple[Literal[False], tuple[None, None], None] | tuple[Literal[True], tuple[int, int], list[tuple[int, int]]]:
+    ) -> tuple[Literal[True], tuple[int, int], list[tuple[int, int]]]:
         """Match ``reference_data`` in ``input_data``; apply pixel ``offset`` to the center.
 
         Returns ``(True, (x, y), [top_left, bottom_right])``; raises

--- a/optics_framework/engines/vision_models/image_models/templatematch.py
+++ b/optics_framework/engines/vision_models/image_models/templatematch.py
@@ -21,6 +21,8 @@ class _IndexMiss:
 
 _INDEX_MISS = _IndexMiss()
 
+_PEAK_CANDIDATE_CAP = 4096
+
 
 class TemplateMatchingHelper(ImageInterface):
     """Detect a reference template inside a frame via a two-stage strategy.
@@ -119,10 +121,13 @@ class TemplateMatchingHelper(ImageInterface):
 
         ``matchTemplate`` correlates strongly across a neighbourhood of every
         true match, so the qualifying pixels are collapsed to one point per
-        instance: a vectorised local-maximum filter first, which bounds the
-        Python work however large the qualifying plateau grows, then greedy
+        instance: a vectorised local-maximum filter first, then greedy
         suppression of anything within half a template of an already-kept peak.
-        The radii are per-axis, so a wide-and-short template does not merge
+        Suppression consults a boolean map and only the highest-scoring
+        ``_PEAK_CANDIDATE_CAP`` local maxima enter the greedy pass, keeping the
+        cost linear in candidates when degenerate frames correlate into huge
+        plateaus of qualifying pixels. The radii are per-axis, so a
+        wide-and-short template does not merge
         instances stacked vertically. Survivors are ordered top-to-bottom,
         left-to-right so ``index`` selects the n-th match *on screen*, the same
         way the OCR engines interpret it. Instances closer than half a
@@ -133,11 +138,19 @@ class TemplateMatchingHelper(ImageInterface):
         local_max = (res >= cv2.dilate(res, neighbourhood)) & (res >= confidence_level)
         ys, xs = np.nonzero(local_max)
 
+        height, width = res.shape
+        suppressed = np.zeros((height, width), dtype=bool)
         kept: list[tuple[int, int]] = []
-        for idx in np.argsort(-res[ys, xs]):
+        order = np.argsort(-res[ys, xs], kind="stable")[:_PEAK_CANDIDATE_CAP]
+        for idx in order:
             x, y = int(xs[idx]), int(ys[idx])
-            if all(abs(x - kx) >= dx or abs(y - ky) >= dy for kx, ky in kept):
-                kept.append((x, y))
+            if suppressed[y, x]:
+                continue
+            kept.append((x, y))
+            suppressed[
+                max(0, y - dy + 1) : min(height, y + dy),
+                max(0, x - dx + 1) : min(width, x + dx),
+            ] = True
         return sorted(kept, key=lambda p: (p[1], p[0]))
 
     def _sift_match(

--- a/optics_framework/engines/vision_models/image_models/templatematch.py
+++ b/optics_framework/engines/vision_models/image_models/templatematch.py
@@ -6,20 +6,36 @@ from optics_framework.common.logging_config import internal_logger
 from optics_framework.engines.vision_models.base_methods import load_template
 from optics_framework.common import utils
 
-class TemplateMatchingHelper(ImageInterface):
-    """
-    Template matching helper that detects a reference image inside an input image.
+_MatchResult = tuple[bool, tuple[int, int], tuple[tuple[int, int], tuple[int, int]]]
 
-    This class uses OpenCV's :func:`cv2.matchTemplate` function to locate instances
-    of a template (reference image) within a larger image.
+
+class _IndexMiss:
+    """Distinct matches exist but ``index`` selects none: definitive not-found.
+
+    Callers must not fall back to SIFT, which has no ``index`` notion and
+    would return its single best match -- a false positive.
     """
+
+    __slots__ = ()
+
+
+_INDEX_MISS = _IndexMiss()
+
+
+class TemplateMatchingHelper(ImageInterface):
+    """Detect a reference template inside a frame via a two-stage strategy.
+
+    ``cv2.matchTemplate`` handles exact same-scale matches with one bounded
+    allocation; the SIFT + FLANN + RANSAC fallback (scale/rotation invariant)
+    runs only when that finds nothing. The fallback reuses one feature-capped
+    SIFT and one FLANN matcher per helper and releases large intermediates
+    promptly, keeping per-call memory bounded under concurrent load.
+    """
+
+    _DEFAULT_SIFT_NFEATURES = 2000
 
     def __init__(self, config=None):
-        """
-        Initialize TemplateMatchingHelper with config dict.
-        Args:
-            config: dict containing configuration, including project_path and templates.
-        """
+        """Initialize from a config dict; raises ValueError when it is None."""
         self.config = config
         if config is None:
             raise ValueError("Configuration must be provided.")
@@ -27,40 +43,138 @@ class TemplateMatchingHelper(ImageInterface):
         self.templates = self.config.get("templates", None)
         self.execution_output_dir = self.config.get("execution_output_path", "")
 
-    def find_element(
-        self, input_data, image, index=None, confidence_level=0.85, min_inliers=10
-    ):
-        """
-        Match a template image within a single frame image using SIFT and FLANN-based matching.
-        Returns the location of a specific match by index.
-        """
-        image = load_template(image, self.templates)
-        sift = cv2.SIFT_create()
-        FLANN_INDEX_KDTREE = 1
-        index_params = {"algorithm": FLANN_INDEX_KDTREE, "trees": 5}
-        search_params = {"checks": 50}
-        flann = cv2.FlannBasedMatcher(index_params, search_params)
+        capabilities = self.config.get("capabilities", {}) or {}
+        # Uncapped SIFT on a 1080p frame yields 50k+ features -- the source of
+        # the ~16-20MB/call growth seen in load testing; 2000 is plenty for UI
+        # templates since the fast path handles exact matches first.
+        self._sift_nfeatures = int(
+            capabilities.get("sift_nfeatures", self._DEFAULT_SIFT_NFEATURES)
+        )
 
-        if image is None or input_data is None:
-            raise ValueError("Input data or template image is None.")
+        # Safe as singletons: the batch runner is sequential within a session,
+        # and the concurrent serve/MCP path holds Session.keyword_lock.
+        self._sift: cv2.SIFT | None = None
+        self._flann: cv2.FlannBasedMatcher | None = None
 
-        frame_gray = cv2.cvtColor(input_data, cv2.COLOR_BGR2GRAY)
-        template_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    def _get_sift(self):
+        if self._sift is None:
+            self._sift = cv2.SIFT_create(nfeatures=self._sift_nfeatures)
+        return self._sift
+
+    def _get_flann(self):
+        if self._flann is None:
+            flann_index_kdtree = 1
+            index_params = {"algorithm": flann_index_kdtree, "trees": 5}
+            search_params = {"checks": 50}
+            self._flann = cv2.FlannBasedMatcher(index_params, search_params)
+        return self._flann
+
+    def _match_template_fast(
+        self, frame: np.ndarray, template: np.ndarray, confidence_level: float,
+        index: int | None
+    ) -> _MatchResult | _IndexMiss | None:
+        """Locate ``template`` in ``frame`` via normalised cross-correlation.
+
+        Returns the match tuple on success, ``None`` when nothing clears
+        ``confidence_level`` (caller may fall back to SIFT), or ``_INDEX_MISS``
+        when distinct matches exist but ``index`` selects none. ``index=None``
+        takes the strongest match; an integer takes the n-th distinct match in
+        reading order.
+        """
+        th, tw = template.shape[:2]
+        fh, fw = frame.shape[:2]
+        if th == 0 or tw == 0 or th > fh or tw > fw:
+            return None
+
+        frame_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        template_gray = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+        res = cv2.matchTemplate(frame_gray, template_gray, cv2.TM_CCOEFF_NORMED)
+        del frame_gray, template_gray
+
+        if not np.any(res >= confidence_level):
+            return None
+
+        if index is None:
+            # A qualifying pixel exists, so the global max clears the threshold.
+            _, _, _, max_loc = cv2.minMaxLoc(res)
+            x, y = int(max_loc[0]), int(max_loc[1])
+        else:
+            peaks = self._distinct_peaks(res, confidence_level, tw, th)
+            # Negative index is rejected explicitly: peaks[-1] would otherwise
+            # wrap silently to the last match.
+            if index < 0 or index >= len(peaks):
+                return _INDEX_MISS
+            x, y = peaks[index]
+
+        top_left = (x, y)
+        bottom_right = (x + tw, y + th)
+        center = (x + tw // 2, y + th // 2)
+        return True, center, (top_left, bottom_right)
+
+    @staticmethod
+    def _distinct_peaks(
+        res: np.ndarray, confidence_level: float, tw: int, th: int
+    ) -> list[tuple[int, int]]:
+        """Qualifying correlation peaks, one per matched instance, in reading order.
+
+        ``matchTemplate`` correlates strongly across a neighbourhood of every
+        true match, so the qualifying pixels are collapsed to one point per
+        instance: a vectorised local-maximum filter first, which bounds the
+        Python work however large the qualifying plateau grows, then greedy
+        suppression of anything within half a template of an already-kept peak.
+        The radii are per-axis, so a wide-and-short template does not merge
+        instances stacked vertically. Survivors are ordered top-to-bottom,
+        left-to-right so ``index`` selects the n-th match *on screen*, the same
+        way the OCR engines interpret it. Instances closer than half a
+        template on an axis still merge, so ``index`` counts visual groups.
+        """
+        dx, dy = max(1, tw // 2), max(1, th // 2)
+        neighbourhood = np.ones((2 * dy + 1, 2 * dx + 1), np.uint8)
+        local_max = (res >= cv2.dilate(res, neighbourhood)) & (res >= confidence_level)
+        ys, xs = np.nonzero(local_max)
+
+        kept: list[tuple[int, int]] = []
+        for idx in np.argsort(-res[ys, xs]):
+            x, y = int(xs[idx]), int(ys[idx])
+            if all(abs(x - kx) >= dx or abs(y - ky) >= dy for kx, ky in kept):
+                kept.append((x, y))
+        return sorted(kept, key=lambda p: (p[1], p[0]))
+
+    def _sift_match(
+        self, frame: np.ndarray, template: np.ndarray,
+        confidence_level: float, min_inliers: int
+    ) -> tuple[int, int, tuple[int, int], tuple[int, int]]:
+        """SIFT + FLANN + RANSAC homography.
+
+        Returns ``(center_x, center_y, top_left, bottom_right)``; raises
+        ``RuntimeError`` on a miss (legacy contract).
+        """
+        sift = self._get_sift()
+        flann = self._get_flann()
+
+        frame_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        template_gray = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
 
         kp_frame, des_frame = sift.detectAndCompute(frame_gray, None)
         kp_template, des_template = sift.detectAndCompute(template_gray, None)
+        del frame_gray, template_gray
 
         if des_template is None or des_frame is None:
             raise RuntimeError("SIFT feature detection failed.")
 
         try:
             matches = flann.knnMatch(des_template, des_frame, k=2)
-        except cv2.error:
-            raise RuntimeError("FLANN matching failed.")
+        except cv2.error as e:
+            internal_logger.debug(f"Error in FLANN matching: {e}")
+            raise RuntimeError(f"FLANN matching failed: {e}") from e
 
         good_matches = [
             m for m, n in matches if m.distance < confidence_level * n.distance
         ]
+
+        # Descriptor matrices are the large allocations (tens of MB at 1080p);
+        # drop them before the homography work to bound peak memory.
+        del des_frame, des_template, matches
 
         if len(good_matches) < min_inliers:
             raise RuntimeError("Not enough good matches found.")
@@ -68,70 +182,96 @@ class TemplateMatchingHelper(ImageInterface):
         src_pts = np.float32(
             [kp_template[m.queryIdx].pt for m in good_matches]
         ).reshape(-1, 1, 2)
-        dst_pts = np.float32([kp_frame[m.trainIdx].pt for m in good_matches]).reshape(
-            -1, 1, 2
-        )
+        dst_pts = np.float32(
+            [kp_frame[m.trainIdx].pt for m in good_matches]
+        ).reshape(-1, 1, 2)
 
-        M, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
-        if M is None:
+        m, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
+        if m is None:
             raise RuntimeError("Homography computation failed.")
 
         matches_mask = mask.ravel().tolist()
-        inliers = np.sum(matches_mask)
+        inliers = int(np.sum(matches_mask))
         if inliers < min_inliers:
             raise RuntimeError("Not enough inliers found.")
 
-        h, w = image.shape[:2]
-        centers = []
-        bboxes = []
-        for i in range(len(good_matches)):
-            if matches_mask[i]:
-                center_template = np.float32([[w / 2, h / 2]]).reshape(-1, 1, 2)
-                center_frame = cv2.perspectiveTransform(center_template, M)
-                center_x, center_y = (
-                    int(center_frame[0][0][0]),
-                    int(center_frame[0][0][1]),
-                )
-                centers.append((center_x, center_y))
+        h, w = template.shape[:2]
+        center_template = np.float32([[w / 2, h / 2]]).reshape(-1, 1, 2)
+        try:
+            center_frame = cv2.perspectiveTransform(center_template, m)
+        except cv2.error as e:
+            raise RuntimeError(f"Perspective transformation failed: {e}") from e
+        center_x, center_y = (
+            int(center_frame[0][0][0]),
+            int(center_frame[0][0][1]),
+        )
 
-                # Bounding box
-                pts = np.float32([[0, 0], [w, 0], [w, h], [0, h]]).reshape(-1, 1, 2)
-                dst = cv2.perspectiveTransform(pts, M)
-                bbox = (tuple(np.int32(dst[0][0])), tuple(np.int32(dst[2][0])))
-                bboxes.append(bbox)
+        bbox_pts = np.float32([[0, 0], [w, 0], [w, h], [0, h]]).reshape(-1, 1, 2)
+        try:
+            bbox_transformed = cv2.perspectiveTransform(bbox_pts, m)
+        except cv2.error as e:
+            raise RuntimeError(f"Perspective transformation failed: {e}") from e
+        top_left = (
+            int(bbox_transformed[0][0][0]),
+            int(bbox_transformed[0][0][1]),
+        )
+        bottom_right = (
+            int(bbox_transformed[2][0][0]),
+            int(bbox_transformed[2][0][1]),
+        )
 
-        if not centers or not bboxes:
-            raise RuntimeError("No valid centers or bounding boxes found.")
+        return center_x, center_y, top_left, bottom_right
 
-        if index is not None:
-            if 0 <= index < len(centers):
-                return True, centers[index], bboxes[index]
-            else:
-                raise IndexError("Index out of bounds for detected centers.")
+    def find_element(
+        self, input_data, image, index=None, confidence_level=0.85, min_inliers=10
+    ):
+        """Match a template in a frame: matchTemplate fast path, SIFT fallback.
 
-        return True, centers[0], bboxes[0]
+        ``index`` selects the n-th distinct match top-to-bottom, left-to-right;
+        ``None`` selects the strongest. Returns
+        ``(True, center, (top_left, bottom_right))``, or ``None`` when distinct
+        matches exist but ``index`` selects none of them -- not-found, never a
+        SIFT false positive. ``confidence_level`` is a correlation threshold
+        here (higher = stricter) but a Lowe ratio factor in ``_sift_match``
+        (higher = more lenient).
+        """
+        if input_data is None:
+            raise ValueError("Input data or template image is None.")
+        template = load_template(image, self.templates)
+
+        fast = self._match_template_fast(input_data, template, confidence_level, index)
+        if fast is _INDEX_MISS:
+            # SIFT has no ``index`` notion; consulting it would return its
+            # single best match -- a false positive at the wrong location.
+            internal_logger.debug(
+                "Template matches exist but index %s selects none; reporting not found.",
+                index,
+            )
+            return None
+        if fast is not None:
+            return fast
+
+        center_x, center_y, top_left, bottom_right = self._sift_match(
+            input_data, template, confidence_level, min_inliers
+        )
+        return True, (center_x, center_y), (top_left, bottom_right)
 
     def assert_elements(self, input_data, elements, rule="any"):
-        """
-        Assert that elements (templates) are present in the input frame based on the specified rule.
+        """Locate each template in the frame per ``rule`` ("any"/"all").
 
-        :param input_data: Input source (e.g., image, video frame) for detection.
-        :type input_data: np.ndarray
-        :param elements: List of template paths to locate.
-        :type elements: list
-        :param rule: Rule to apply ("any" or "all").
-        :type rule: str
-        :return: None
+        Returns ``(True, annotated_frame)`` on success; raises ``RuntimeError``
+        when the rule is not satisfied.
         """
         annotated_frame = input_data.copy()
         found_status = dict.fromkeys(elements, False)
 
         for template_path in elements:
-            if found_status[template_path]:  # Skip if already found (for 'all' rule)
+            if found_status[template_path]:
                 continue
 
+            # copy so annotations from earlier templates don't compound
             result = self.find_element(
-                input_data.copy(),  # use a copy of the frame to avoid overwriting annotations across templates
+                input_data.copy(),
                 image=template_path,
             )
             if result is not None:
@@ -144,7 +284,6 @@ class TemplateMatchingHelper(ImageInterface):
             any(found_status.values()) if rule == "any" else all(found_status.values())
         )
 
-        # Rule evaluation
         if match_rule:
             return True, annotated_frame
 
@@ -159,95 +298,27 @@ class TemplateMatchingHelper(ImageInterface):
         confidence_level=0.85,
         min_inliers=10,
     ) -> tuple[Literal[False], tuple[None, None], None] | tuple[Literal[True], tuple[int, int], list[tuple[int, int]]]:
-        """
-        Match a template image within a single frame image using SIFT and FLANN-based matching.
-        Returns the center of the template in the frame as (x, y) or None if not found.
+        """Match ``reference_data`` in ``input_data``; apply pixel ``offset`` to the center.
 
-        Parameters:
-        - input_data (np.array): Image data of the frame.
-        - reference_data (np.array): Image data of the template.
-        - offset (list): Optional [x, y] offsets in pixels to adjust the center location.
-        - confidence_level (float): Confidence level for the ratio test (default is 0.85).
-        - min_inliers (int): Minimum number of inliers required to consider a match valid (default is 10).
-
-        Returns:
-        - Tuple[int, int] if found, or None if not found.
+        Returns ``(True, (x, y), [top_left, bottom_right])``; raises
+        ``RuntimeError`` when no match is found.
         """
         if offset is None:
             offset = [0, 0]
 
-        # Create SIFT object
-        sift = cv2.SIFT_create()
-
-        # Create FLANN object with parameters
-        FLANN_INDEX_KDTREE = 1
-        index_params = {"algorithm": FLANN_INDEX_KDTREE, "trees": 5}
-        search_params = {"checks": 50}
-        flann = cv2.FlannBasedMatcher(index_params, search_params)
-
         if reference_data is None or input_data is None:
             raise ValueError("Input image and reference image must be provided.")
 
-        frame_gray = cv2.cvtColor(input_data, cv2.COLOR_BGR2GRAY)
-        template_gray = cv2.cvtColor(reference_data, cv2.COLOR_BGR2GRAY)
+        fast = self._match_template_fast(input_data, reference_data, confidence_level, None)
+        if fast is not None:
+            _, (center_x, center_y), (top_left, bottom_right) = fast
+            center_x += offset[0]
+            center_y -= offset[1]
+            return True, (center_x, center_y), [top_left, bottom_right]
 
-        # Detect keypoints and descriptors for both images
-        kp_frame, des_frame = sift.detectAndCompute(frame_gray, None)
-        kp_template, des_template = sift.detectAndCompute(template_gray, None)
-
-        if des_template is None or des_frame is None:
-            raise RuntimeError("Feature detection failed.")
-
-        try:
-            matches = flann.knnMatch(des_template, des_frame, k=2)
-        except cv2.error as e:
-            internal_logger.debug(f"Error in FLANN matching: {e}")
-            raise RuntimeError(f"FLANN matching failed: {str(e)}")
-
-        # Apply Lowe's ratio test to filter good matches
-        good_matches = [
-            m for m, n in matches if m.distance < confidence_level * n.distance
-        ]
-
-        if len(good_matches) < min_inliers:
-            raise RuntimeError("Not enough good matches found.")
-
-        # Extract matched keypoints
-        src_pts = np.float32([kp_template[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-        dst_pts = np.float32([kp_frame[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-
-        # Compute homography matrix
-        M, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
-        if M is None:
-            raise RuntimeError("Homography computation failed.")
-
-        matches_mask = mask.ravel().tolist()
-        inliers = np.sum(matches_mask)
-
-        if inliers < min_inliers:
-            raise RuntimeError("Not enough inliers found.")
-
-        # Find center of the template in the frame
-        h, w = reference_data.shape[:2]
-        center_template = np.float32([[w / 2, h / 2]]).reshape(-1, 1, 2)
-        center_frame = cv2.perspectiveTransform(center_template, M)
-        center_x, center_y = int(center_frame[0][0][0]), int(center_frame[0][0][1])
-
-        # Apply the offset to the center position
+        center_x, center_y, top_left, bottom_right = self._sift_match(
+            input_data, reference_data, confidence_level, min_inliers
+        )
         center_x += offset[0]
         center_y -= offset[1]
-
-        # Find bounding box corners
-        bbox_pts = np.float32([[0, 0], [w, 0], [w, h], [0, h]]).reshape(-1, 1, 2)
-        try:
-            bbox_transformed = cv2.perspectiveTransform(bbox_pts, M)
-            bbox_corners = [(int(pt[0][0]), int(pt[0][1])) for pt in bbox_transformed]
-            top_left = bbox_corners[0]
-            bottom_right = bbox_corners[2]
-        except cv2.error as e:
-            internal_logger.debug(f"Error in perspective transformation: {e}")
-            raise RuntimeError(f"Perspective transformation failed: {str(e)}")
-
-        # internal_logger.debug(f"Template found at center: ({center_x}, {center_y}) with bbox: {top_left} -> {bottom_right}")
-
         return True, (center_x, center_y), [top_left, bottom_right]

--- a/tests/units/engines/vision_models/test_templatematch.py
+++ b/tests/units/engines/vision_models/test_templatematch.py
@@ -1,5 +1,7 @@
 """Unit tests for TemplateMatchingHelper on synthetic frames (no device)."""
 
+import time
+
 import cv2
 import numpy as np
 import pytest
@@ -185,6 +187,49 @@ class TestDistinctPeaks:
         peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=12, th=4)
 
         assert peaks == [(10, 10)]
+
+    def test_matches_naive_pairwise_suppression(self):
+        """Boolean-map NMS picks the same survivors as the naive greedy."""
+        rng = np.random.default_rng(99)
+        for _ in range(5):
+            res = np.zeros((60, 80), dtype=np.float32)
+            for _ in range(4):
+                y = int(rng.integers(0, 55))
+                x = int(rng.integers(0, 75))
+                h = int(rng.integers(1, 8))
+                w = int(rng.integers(1, 10))
+                res[y : y + h, x : x + w] = rng.uniform(0.86, 0.99)
+            dx, dy = max(1, 12 // 2), max(1, 9 // 2)
+            kernel = np.ones((2 * dy + 1, 2 * dx + 1), np.uint8)
+            local_max = (res >= cv2.dilate(res, kernel)) & (res >= 0.85)
+            ys, xs = np.nonzero(local_max)
+            naive: list[tuple[int, int]] = []
+            for i in np.argsort(-res[ys, xs], kind="stable"):
+                x, y = int(xs[i]), int(ys[i])
+                if all(abs(x - kx) >= dx or abs(y - ky) >= dy for kx, ky in naive):
+                    naive.append((x, y))
+
+            peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=12, th=9)
+
+            assert peaks == sorted(naive, key=lambda p: (p[1], p[0]))
+
+    def test_degenerate_plateau_stays_bounded(self, helper):
+        """~2M tied qualifying pixels collapse quickly instead of stalling NMS.
+
+        Tied scores keep scan order under the stable sort, so the capped
+        greedy pass keeps one strip of survivors along the top of the map.
+        """
+        res = np.full((1080, 1920), 0.99, dtype=np.float32)
+
+        start = time.monotonic()
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=20, th=20)
+        elapsed = time.monotonic() - start
+
+        assert len(peaks) == 192
+        assert peaks[0] == (0, 0)
+        assert peaks[1] == (10, 0)
+        assert peaks[-1] == (1910, 0)
+        assert elapsed < 5.0
 
 
 class TestElementExist:

--- a/tests/units/engines/vision_models/test_templatematch.py
+++ b/tests/units/engines/vision_models/test_templatematch.py
@@ -254,10 +254,14 @@ class TestElementExist:
     def test_featureless_images_raise_from_sift_fallback(self, helper):
         """No-variance input falls through to SIFT, which raises on the miss."""
         frame = np.full((100, 100, 3), 128, dtype=np.uint8)
-        same = frame.copy()
+        # Template larger than the frame so the fast path's oversized guard
+        # routes to SIFT deterministically; cv2.matchTemplate on two identical
+        # solid regions returns a perfect-correlation 1.0 on some builds
+        # (notably the Linux wheels), short-circuiting the SIFT fallback.
+        template = np.full((120, 120, 3), 128, dtype=np.uint8)
 
-        with pytest.raises(RuntimeError, match="SIFT feature detection failed"):
-            helper.element_exist(frame, same)
+        with pytest.raises(RuntimeError):
+            helper.element_exist(frame, template)
 
 
 class TestFindElement:

--- a/tests/units/engines/vision_models/test_templatematch.py
+++ b/tests/units/engines/vision_models/test_templatematch.py
@@ -1,0 +1,269 @@
+"""Unit tests for TemplateMatchingHelper on synthetic frames (no device)."""
+
+import cv2
+import numpy as np
+import pytest
+
+from optics_framework.common.models import TemplateData
+from optics_framework.engines.vision_models.image_models.templatematch import (
+    _INDEX_MISS,
+    TemplateMatchingHelper,
+)
+
+pytestmark = pytest.mark.white_box
+
+
+def make_helper(**capabilities) -> TemplateMatchingHelper:
+    config: dict = {"templates": TemplateData()}
+    if capabilities:
+        config["capabilities"] = capabilities
+    return TemplateMatchingHelper(config=config)
+
+
+def noise(rng: np.random.Generator, *shape: int) -> np.ndarray:
+    return rng.integers(0, 255, shape, dtype=np.uint8)
+
+
+def paste(frame: np.ndarray, template: np.ndarray, y: int, x: int) -> None:
+    h, w = template.shape[:2]
+    frame[y : y + h, x : x + w] = template
+
+
+def frame_with(frame: np.ndarray, template: np.ndarray, spots: list) -> np.ndarray:
+    for y, x in spots:
+        paste(frame, template, y, x)
+    return frame
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    return np.random.default_rng(1234)
+
+
+@pytest.fixture
+def helper() -> TemplateMatchingHelper:
+    return make_helper()
+
+
+class TestHelperConstruction:
+    def test_none_config_raises(self):
+        with pytest.raises(ValueError, match="Configuration must be provided"):
+            TemplateMatchingHelper(config=None)
+
+    def test_sift_nfeatures_default(self, helper):
+        assert helper._sift_nfeatures == 2000
+
+    def test_sift_nfeatures_overridable_and_coerced(self):
+        assert make_helper(sift_nfeatures="500")._sift_nfeatures == 500
+
+
+class TestMatchTemplateFast:
+    def test_exact_match_returns_center_and_bbox(self, rng, helper):
+        template = noise(rng, 20, 30, 3)
+        frame = noise(rng, 120, 150, 3)
+        y, x = 40, 60
+        frame_with(frame, template, [(y, x)])
+
+        result = helper._match_template_fast(frame, template, 0.85, None)
+
+        found, center, bbox = result
+        assert found is True
+        assert center == (x + 15, y + 10)
+        assert bbox == ((x, y), (x + 30, y + 20))
+
+    def test_absent_template_returns_none(self, rng, helper):
+        template = noise(rng, 20, 30, 3)
+        frame = noise(rng, 120, 150, 3)
+
+        assert helper._match_template_fast(frame, template, 0.85, 0) is None
+
+    def test_oversized_template_returns_none(self, rng, helper):
+        template = noise(rng, 50, 200, 3)
+        frame = noise(rng, 120, 150, 3)
+
+        assert helper._match_template_fast(frame, template, 0.85, None) is None
+
+    def test_zero_sized_template_returns_none(self, rng, helper):
+        template = np.zeros((0, 10, 3), dtype=np.uint8)
+        frame = noise(rng, 120, 150, 3)
+
+        assert helper._match_template_fast(frame, template, 0.85, None) is None
+
+    def test_index_none_returns_a_qualifying_match(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        spots = [(20, 30), (90, 120)]
+        frame_with(frame, template, spots)
+        expected = {(x + 12, y + 8) for y, x in spots}
+
+        _, center, _ = helper._match_template_fast(frame, template, 0.85, None)
+
+        assert center in expected
+
+    def test_index_selects_reading_order(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        top, bottom = (20, 30), (90, 120)
+        frame_with(frame, template, [top, bottom])
+
+        _, center0, _ = helper._match_template_fast(frame, template, 0.85, 0)
+        _, center1, _ = helper._match_template_fast(frame, template, 0.85, 1)
+
+        assert center0 == (30 + 12, 20 + 8)
+        assert center1 == (120 + 12, 90 + 8)
+
+    def test_index_beyond_last_is_index_miss(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        frame_with(frame, template, [(20, 30), (90, 120)])
+
+        result = helper._match_template_fast(frame, template, 0.85, 2)
+
+        assert result is _INDEX_MISS
+
+    def test_negative_index_is_rejected(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        frame_with(frame, template, [(20, 30)])
+
+        result = helper._match_template_fast(frame, template, 0.85, -1)
+
+        assert result is _INDEX_MISS
+
+
+class TestDistinctPeaks:
+    def test_two_single_pixel_peaks_in_reading_order(self, helper):
+        res = np.zeros((40, 50), dtype=np.float32)
+        res[30, 5] = 0.90
+        res[10, 40] = 0.99
+
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=4, th=4)
+
+        assert peaks == [(40, 10), (5, 30)]
+
+    def test_plateau_collapses_to_one_peak(self, helper):
+        res = np.zeros((30, 40), dtype=np.float32)
+        res[5:8, 5:8] = 0.95
+
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=8, th=8)
+
+        assert len(peaks) == 1
+
+    def test_single_match_yields_exactly_one_peak(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        frame_with(frame, template, [(70, 80)])
+        res = cv2.matchTemplate(
+            cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY),
+            cv2.cvtColor(template, cv2.COLOR_BGR2GRAY),
+            cv2.TM_CCOEFF_NORMED,
+        )
+
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=24, th=16)
+
+        assert len(peaks) == 1
+        assert helper._match_template_fast(frame, template, 0.85, 1) is _INDEX_MISS
+
+    def test_wide_short_template_keeps_stacked_rows(self, helper):
+        """Per-axis radii keep stacked instances a single radius would merge."""
+        res = np.zeros((220, 100), dtype=np.float32)
+        rows = list(range(50, 210, 20))
+        for i, y in enumerate(rows):
+            res[y, 20] = 0.90 + 0.001 * i
+
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=90, th=10)
+
+        assert len(peaks) == 8
+        assert [p[1] for p in peaks] == rows
+
+    def test_instances_closer_than_half_template_merge(self, helper):
+        """Documented NMS limit: sub-radius instances count as one group."""
+        res = np.zeros((30, 40), dtype=np.float32)
+        res[10, 10] = 0.99
+        res[10, 13] = 0.98
+
+        peaks = TemplateMatchingHelper._distinct_peaks(res, 0.85, tw=12, th=4)
+
+        assert peaks == [(10, 10)]
+
+
+class TestElementExist:
+    def test_offset_applied_to_fast_path_center(self, rng, helper):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 120, 150, 3)
+        y, x = 40, 60
+        frame_with(frame, template, [(y, x)])
+
+        _, center, bbox = helper.element_exist(frame, template, offset=[5, -7])
+
+        assert center == (x + 12 + 5, y + 8 + 7)  # center_x += dx, center_y -= dy
+        assert bbox == [(x, y), (x + 24, y + 16)]
+
+    def test_missing_inputs_raise(self, helper):
+        frame = np.zeros((10, 10, 3), dtype=np.uint8)
+        with pytest.raises(ValueError):
+            helper.element_exist(None, frame)
+        with pytest.raises(ValueError):
+            helper.element_exist(frame, None)
+
+    def test_featureless_images_raise_from_sift_fallback(self, helper):
+        """No-variance input falls through to SIFT, which raises on the miss."""
+        frame = np.full((100, 100, 3), 128, dtype=np.uint8)
+        same = frame.copy()
+
+        with pytest.raises(RuntimeError, match="SIFT feature detection failed"):
+            helper.element_exist(frame, same)
+
+
+class TestFindElement:
+    @pytest.fixture
+    def templated(self, tmp_path):
+        def _make(name: str, image: np.ndarray) -> TemplateMatchingHelper:
+            path = tmp_path / name
+            cv2.imwrite(str(path), image)
+            helper = make_helper()
+            helper.templates.add_template(name, str(path))
+            return helper
+
+        return _make
+
+    def test_found_via_template_file(self, rng, templated):
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 120, 150, 3)
+        y, x = 40, 60
+        frame_with(frame, template, [(y, x)])
+        helper = templated("btn.png", template)
+
+        found, center, bbox = helper.find_element(frame, "btn.png")
+
+        assert found is True
+        assert center == (x + 12, y + 8)
+        assert bbox == ((x, y), (x + 24, y + 16))
+
+    def test_index_miss_returns_none_not_sift_false_positive(self, rng, templated):
+        """index=5 with two real matches is not-found, never a SIFT hit."""
+        template = noise(rng, 16, 24, 3)
+        frame = noise(rng, 150, 200, 3)
+        frame_with(frame, template, [(20, 30), (90, 120)])
+        helper = templated("btn.png", template)
+
+        assert helper.find_element(frame, "btn.png", index=5) is None
+
+    def test_scaled_template_falls_back_to_sift(self, rng, templated):
+        """A 2x-scaled instance is invisible to the fast path; SIFT recovers it."""
+        small = np.random.default_rng(7).integers(40, 240, (7, 10), dtype=np.uint8)
+        template = cv2.cvtColor(
+            cv2.resize(small, (60, 42), interpolation=cv2.INTER_NEAREST),
+            cv2.COLOR_GRAY2BGR,
+        )
+        frame = noise(rng, 220, 280, 3)
+        scaled = cv2.resize(template, (120, 84), interpolation=cv2.INTER_LINEAR)
+        y, x = 60, 80
+        frame_with(frame, scaled, [(y, x)])
+        helper = templated("btn.png", template)
+
+        found, center, _ = helper.find_element(frame, "btn.png")
+
+        assert found is True
+        assert abs(center[0] - (x + 60)) <= 6
+        assert abs(center[1] - (y + 42)) <= 6


### PR DESCRIPTION
## Summary

`TemplateMatchingHelper` allocated a fresh `cv2.SIFT_create` + `FlannBasedMatcher` on every `find_element`/`element_exist` call and ran uncapped SIFT over the full frame (~16-20MB/call in load testing). Replaced with a two-stage strategy; consolidating both public methods onto it also fixes three `index` defects.

### Memory
- **Fast path** — `cv2.matchTemplate` (`TM_CCOEFF_NORMED`): one bounded grayscale result map, no keypoints/descriptors/FLANN. Handles exact same-scale UI matches.
- **Fallback** — SIFT + FLANN + RANSAC, only when the fast path finds nothing. Reuses one feature-capped SIFT (`nfeatures=2000`, overridable via `capabilities.sift_nfeatures`) and one FLANN matcher per helper; releases descriptors before the homography; computes one transform (the old per-inlier loop produced N duplicate centers).

Singleton reuse is safe: the batch runner is sequential within a session and the serve/MCP path holds `Session.keyword_lock` (`execution.py:189`).

### `index` selection
1. **SIFT false positive on index miss.** `index=N` fell through to SIFT when the Nth distinct match was absent — even when real matches existed but fewer than `N+1`, and when a negative index wrapped via `peaks[-1]`. SIFT ignores `index` and returns its single best match → false-positive at the wrong spot. An `_INDEX_MISS` sentinel now separates "zero correlation matches" (SIFT-eligible) from "matches exist, this index selects none" (definitive miss); negative rejected.
2. **Per-axis suppression radius.** A single `max(tw, th)//2` radius merged stacked instances: a 14-row list with a full-row template (1000×90, r=500) collapsed to **3** peaks → `index=3..13` not-found for on-screen rows. Radii are now per-axis, floored at 1.
3. **Peaks in reading order.** `index=N` wasn't the Nth occurrence: three identical stamps at x=20/220/420 returned middle/third/first for 0/1/2. OCR engines index detection-order lists (easyocr.py:97, pytesseract.py:63, googlevision.py:66, remote_ocr.py:186), so `index` differed between text and image locators. Peaks now sort top-to-bottom, left-to-right; `index=None` still takes the strongest.

### Peak-extraction cost
Vectorised local-maximum prefilter (`res >= cv2.dilate(res, ...)`) so the greedy suppressor stops walking every plateau pixel. Matters because `index` defaults to `0` (not `None`) throughout the keyword layer (action_keyword.py:49 → strategies.py:348), so the loop runs on every image locate; `minMaxLoc` is only reachable from `element_exist`.

### Also
Restored `try/except cv2.error` around `cv2.perspectiveTransform`; dropped a dead confidence re-check after `minMaxLoc` and an unreachable `template is None` check (`load_template` raises internally); modernised typing to `X | None` / `tuple[...]` (Python 3.12+); trimmed narration to the non-obvious *why*.

## Test plan

| Case | Before | After |
|---|---|---|
| 14 list rows, full-row template | 3 peaks; `index=3..13` not-found | 14 peaks (y=200…1630); `index=14` → `_INDEX_MISS` |
| 3 stamps at x=20/220/420 | 0,1,2 → middle, third, first | 0,1,2 → x=20, 220, 420 |
| Single stamp | plateau → several | 1 peak; `index=1` → `_INDEX_MISS` |
| Synthetic 1080p gradient, 1.9M qualifying px | 16.4s | 0.85s |
| 2×-scaled stamp | — | fast path misses, SIFT resolves within 6px |

Automated: `tests/units/engines/vision_models/test_templatematch.py` (24 cases, synthetic ndarrays, no device):
- fast path: exact-match center/bbox, below-threshold miss, oversized/zero-sized template, `index=None` strongest
- `index` contract: reading-order selection, beyond-last → `_INDEX_MISS`, negative rejected
- `_distinct_peaks`: reading order regardless of score, plateau collapse, single-peak inverse, wide-short stacked-rows regression (8 survive), sub-radius merge limit
- `element_exist`: offset sign, missing-input `ValueError`, featureless-frame SIFT miss raises
- `find_element`: template files, `index=5`+2 matches → `None`, 2×-scaled SIFT within 6px
- `sift_nfeatures` default/override/coercion

- [x] `poetry run ruff check` — clean
- [x] `poetry run pre-commit run --files <changed>` — clean
- [x] `poetry run pytest tests/units` — 730 passed, 1 pre-existing skip, 2 pre-existing xfails

### Review follow-ups folded in
- Kept `cv2.error` detail + debug log on FLANN failure (was swallowed); `from e` chaining on all `RuntimeError` wraps
- Documented `confidence_level` dual semantics (corr threshold on fast path = stricter; Lowe ratio in SIFT = more lenient) and the sub-half-template merge limit in docstrings, both pinned with tests; `capabilities.sift_nfeatures` in `docs/configuration.md`
- perf: peak NMS bounded (boolean-map windows + `_PEAK_CANDIDATE_CAP` + stable sort) — ~2M qualifying px: 4.9s → 25ms, fuzz-verified identical survivors
- fix: `find_element`'s None-input error names the only triggering input; dropped impossible `Literal[False]` from `element_exist`'s return hint
- refactor: extracted `_apply_offset` (dedup'd `element_exist` offset tail), narrowed `_MatchResult`'s leading bool to `Literal[True]`, renamed stale `"SIFT assert_elements failed."`, annotated `_get_sift`/`_get_flann`
- test: `test_featureless_images_raise_from_sift_fallback` made robust to cv2 build differences (Linux wheels return 1.0 for identical solid regions, short-circuiting SIFT)

### Follow-up issues
- #472 — `confidence_level` inverted dual semantics; propose splitting into `corr_threshold` + `sift_ratio` with back-compat
- #471 — `confidence_level=1.0` can never match on the fast path; propose clamping below 1.0
