### PR TITLE
fix: reject fuzzy/partial xpath matches in presence assertions

### DIFF
--- a/optics_framework/engines/drivers/appium_UI_helper.py
+++ b/optics_framework/engines/drivers/appium_UI_helper.py
@@ -160,7 +160,7 @@ class UIHelper:
             return xpath
         return None
 
-    def find_xpath(self, xpath):
+    def find_xpath(self, xpath, strict: bool = False):
         """
         Process the given XPath and return the exact path from the UI tree after applying various matching strategies.
         """
@@ -193,27 +193,28 @@ class UIHelper:
                     f"Error in relative match for XPath '{xpath}': {str(e)}"
                 )
 
-            # 3. Partial Match
-            try:
-                found_xpath = self.find_partial(xpath)
-                if found_xpath:
-                    internal_logger.debug("Xpath found using partial match")
-                    return found_xpath, time_stamp
-            except Exception as e:
-                internal_logger.debug(
-                    f"Error in partial match for XPath '{xpath}': {str(e)}"
-                )
+            if not strict:
+                # 3. Partial Match
+                try:
+                    found_xpath = self.find_partial(xpath)
+                    if found_xpath:
+                        internal_logger.debug("Xpath found using partial match")
+                        return found_xpath, time_stamp
+                except Exception as e:
+                    internal_logger.debug(
+                        f"Error in partial match for XPath '{xpath}': {str(e)}"
+                    )
 
-            # 4. Attribute Match with Fuzzy Prefix and Suffix Handling
-            try:
-                found_xpath = self.find_attribute_match(xpath)
-                if found_xpath:
-                    internal_logger.debug("Xpath found using attribute match")
-                    return found_xpath, time_stamp
-            except Exception as e:
-                internal_logger.debug(
-                    f"Error in attribute match for XPath '{xpath}': {str(e)}"
-                )
+                # 4. Attribute Match with Fuzzy Prefix and Suffix Handling
+                try:
+                    found_xpath = self.find_attribute_match(xpath)
+                    if found_xpath:
+                        internal_logger.debug("Xpath found using attribute match")
+                        return found_xpath, time_stamp
+                except Exception as e:
+                    internal_logger.debug(
+                        f"Error in attribute match for XPath '{xpath}': {str(e)}"
+                    )
 
             # If no match is found
             internal_logger.debug(

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -217,7 +217,7 @@ class AppiumPageSource(ElementSourceInterface):
 
             # Check XPath-based elements
             if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None and xpaths:
-                xpath_results = [self.driver.ui_helper.find_xpath(xpath)[0] for xpath in xpaths]
+                xpath_results = [self.driver.ui_helper.find_xpath(xpath, strict=True)[0] for xpath in xpaths]
             else:
                 xpath_results = [rule == "all"]
             xpath_found = (all(xpath_results) if rule == "all" else any(xpath_results))


### PR DESCRIPTION
Fixes #374

## Summary

- `UIHelper.find_xpath` gains a `strict` flag: when set, resolution stops after the exact and relative (structure-only) stages, skipping the partial-`contains()` and fuzzy-attribute stages that loosen attribute-value comparison.
- `AppiumPageSource.assert_elements` (which backs `assert_presence` / visibility assertions) now resolves XPaths with `strict=True`, so an XPath whose attribute values are only partially or fuzzily matched on screen no longer reports the element as present.
- Interaction paths (`_locate_by_xpath`, `get_view_locator`) keep the default tolerant resolution, so click/tap self-healing behaviour is unchanged.

## Test plan

- [x] `poetry run pytest tests/units` — 718 passed
- [x] `poetry run ruff check` and pre-commit hooks pass on the touched files
- [x] Verified locally with `appium_page_source` enabled: asserting presence of `//android.widget.TextView[@content-desc="TRAI MySpeed"]` while only `content-desc="TRAI MySpeed Dashboard"` is on screen now times out instead of returning found; exact XPaths still assert successfully; `locate()` still resolves through partial/fuzzy matches so press/enter-text self-healing is unaffected.