### PR TITLE
ci: run pytest suite on every PR and post-merge push

### DIFF
--- a/.github/workflows/precommit_main.yml
+++ b/.github/workflows/precommit_main.yml
@@ -23,7 +23,9 @@ jobs:
           python-version: '3.x'
 
       - name: Install Pre-Commit
-        run: pip install pre-commit
+        run: |
+          eval "$(python3 scripts/lock_pins.py)"
+          pip install --no-cache-dir --only-binary=:all: "pre-commit==$PRE_COMMIT_VERSION"
 
       - name: Determine Changed Files or Full Scan
         id: changed-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: |
+          pip install --no-cache-dir --only-binary=:all: poetry==2.4.1
+      - name: Install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ':all:'
+          POETRY_INSTALLER_NO_BINARY: 'csscompressor,jsmin'
+        run: poetry install --with test --extras appium --extras selenium --extras google-vision
+      - name: Run tests
+        run: poetry run pytest -c pytest.toml --no-cov -q

--- a/poetry.lock
+++ b/poetry.lock
@@ -46,11 +46,12 @@ version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
 ]
+markers = {test = "sys_platform != \"emscripten\""}
 
 [package.dependencies]
 idna = ">=2.8"
@@ -1672,11 +1673,12 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+markers = {test = "sys_platform != \"emscripten\""}
 
 [[package]]
 name = "htmlmin2"
@@ -1711,6 +1713,29 @@ asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+markers = "sys_platform != \"emscripten\""
+files = [
+    {file = "httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb"},
+    {file = "httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.33.0,<1.0)"]
 
 [[package]]
 name = "httpx"
@@ -1752,6 +1777,47 @@ files = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.12.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36"},
+    {file = "httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf"},
+]
+
+[package.dependencies]
+anyio = {version = ">=4.10", markers = "sys_platform != \"emscripten\""}
+httpcore2 = {version = "2.12.0", markers = "sys_platform != \"emscripten\""}
+httpx2-jsfetch = {version = "*", markers = "sys_platform == \"emscripten\" and python_version >= \"3.12\""}
+idna = ">=3.18"
+truststore = {version = ">=0.10", markers = "sys_platform != \"emscripten\""}
+typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
+cli = ["click (>=8.4.2)", "pygments (==2.*)", "rich (>=10,<16)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+ws = ["wsproto (>=1.2)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version <= \"3.13\""]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+description = "httpx2 transports for Emscripten/Pyodide, backed by the JavaScript fetch API."
+optional = false
+python-versions = ">=3.12"
+groups = ["test"]
+markers = "sys_platform == \"emscripten\""
+files = [
+    {file = "httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32"},
+    {file = "httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60"},
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 description = "File identification library for Python"
@@ -1768,18 +1834,18 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
-groups = ["main", "docs"]
+python-versions = ">=3.9"
+groups = ["main", "docs", "test"]
 files = [
-    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
-    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
+    {file = "idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4"},
+    {file = "idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15"},
 ]
 
 [package.extras]
-all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["coverage (>=7.10.0)", "hypothesis (>=6.141.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.16.0)", "ty (>=0.0.37)"]
 
 [[package]]
 name = "imageio"
@@ -5749,6 +5815,19 @@ tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked"
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+markers = "sys_platform != \"emscripten\""
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -6277,4 +6356,4 @@ web = ["playwright", "selenium"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "ca5fac2a181c3254fd44bf98e8b05fcc29cf310f98fd27680413272f24422188"
+content-hash = "de2abf09b5048d13af7a868071819a16ddb4d3e1f0e975e5a729312800707396"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ pytest = "^9.0.0"
 pytest-cov = ">=6.0,<7.1"
 pytest-mock = ">=3.14,<3.16"
 pytest-asyncio = ">=1.0,<2.0"
+httpx2 = ">=2.12,<3"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.6.11"

--- a/scripts/lock_pins.py
+++ b/scripts/lock_pins.py
@@ -21,6 +21,7 @@ PINS = {
     "MKDOCSTRINGS_PYTHON_VERSION": "mkdocstrings-python",
     "MKDOCS_MINIFY_PLUGIN_VERSION": "mkdocs-minify-plugin",
     "UVICORN_VERSION": "uvicorn",
+    "PRE_COMMIT_VERSION": "pre-commit",
 }
 
 for var, pkg in PINS.items():

--- a/tests/units/test_optics.py
+++ b/tests/units/test_optics.py
@@ -7,9 +7,16 @@ wiring check that setup → keyword → teardown holds together.
 import csv
 import os
 
+import pytest
 import yaml
 
 from optics_framework.optics import Optics
+
+# The bundled contact sample enables the easyocr text-detection engine in its
+# config.yaml, so every setup()-driven test below instantiates it. Skip the
+# module when easyocr isn't installed (mirrors the guarded skip in
+# test_mcp_server.py); avoids pulling the multi-GB torch stack into CI.
+pytest.importorskip("easyocr", reason="contact sample config enables the easyocr engine")
 
 CONTACT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), '../../optics_framework/samples/contact/config.yaml')
 ELEMENTS_CSV_PATH = os.path.join(os.path.dirname(__file__), '../../optics_framework/samples/contact/test_data/elements.csv')


### PR DESCRIPTION
## What

Wires `tests/` to GitHub Actions — one new workflow, `.github/workflows/tests.yml`.

- **Triggers:** every `pull_request` (any target branch), every push to `main` (post-merge), plus `workflow_dispatch` for manual runs.
- **Runner:** `ubuntu-latest`. The suite is hermetic (in-process mock API server, mocked drivers), so no devices/emulators/browsers are needed.
- **Cost:** $0 — GitHub Actions is free (unlimited minutes) for public repositories.

```yaml
on:
  pull_request:
  push:
    branches: [main]
  workflow_dispatch:
```

## Non-obvious choices

- **`pytest -c pytest.toml`** — pytest does not auto-discover that filename (only `pytest.ini` / `pyproject.toml` sections etc.), and the repo's markers (`white_box`, …) and `asyncio_mode = auto` live there. Without `-c` the suite runs unconfigured.
- **`httpx2` added to the test group** (`pyproject.toml` + lock): starlette ≥ 1.x `testclient` requires an HTTP client. `httpx` was only locked behind the optional `llm`/`mcp` extras, so a bare `--with test` env crashed `test_expose_api` at collection. `httpx2` is starlette's supported client; the deprecated-`httpx` fallback is not relied on.
- **`--extras appium selenium google-vision`** — three modules import these at module top level and are imported by tests unconditionally: the appium/selenium element sources and the `googlevision` OCR module. All other optional engines are import-guarded already.
- **`tests/units/test_optics.py` skips without easyocr** — every test in that module drives `Optics.setup()` against the bundled contact sample, whose `config.yaml` enables the easyocr engine. Installing the `easyocr` extra would pull torch 2.13 + 18 nvidia CUDA packages into CI for one test module, so the module uses `pytest.importorskip("easyocr")`, mirroring the existing guard in `test_mcp_server.py`. Reviewer note: if full fidelity is preferred over a lean CI, swapping this line for `--extras easyocr` is the alternative.
- **Poetry pinned to 2.4.1** — deterministic installs.
- **Wheels-only, version-locked installs (SonarQube `githubactions:S8541` + `S8544`)** — every install step carries an explicit no-setup-scripts policy: Poetry itself via `pip install --only-binary=:all: poetry==2.4.1`, dependencies via `POETRY_INSTALLER_ONLY_BINARY=:all:` with `POETRY_INSTALLER_NO_BINARY=csscompressor,jsmin` scoped to the only two sdist-only packages in the lock (docs-group transitives of `mkdocs-minify-plugin`, never installed by this job). Without naming them, Poetry's whole-lockfile policy validation refuses to run. `precommit_main.yml` now pins `pre-commit` to the version from `poetry.lock` via `scripts/lock_pins.py` (new `PRE_COMMIT_VERSION` pin) — same single-source-of-truth pattern as `publish_docs.yml`. SonarCloud quality gate: **OK, 0 open issues** on this PR.

Files in this PR carry no inline comments; rationale lives here and in the commit message instead.

## Validation

From-scratch Poetry environment with exactly the CI install command:

```
695 passed, 3 skipped (easyocr / fastmcp / playwright guards), 2 xfailed
```

identical to a full local dev install. First CI run on this PR went red on 5 collection errors (the gaps fixed above); current run is green with `pytest` completing in ~50s.

## Follow-ups

- Branch protection: require the `tests / pytest` status check on `main` (needs an admin).
- Dependabot reports 39 vulnerable dependency alerts on `main` — tracked separately.
