### PR TITLE
docs: reference demo GIF by absolute URL so PyPI renders it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ One keyword engine. Six ways to drive it: CSV/YAML files, a Python SDK, Robot Fr
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=mozarkai_optics-framework&metric=coverage)](https://sonarcloud.io/summary/new_code?id=mozarkai_optics-framework)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10842/badge)](https://www.bestpractices.dev/projects/10842)
 
-![Optics demo](.github/assets/optics-demo.gif)
+![Optics demo](https://raw.githubusercontent.com/mozarkai/optics-framework/main/.github/assets/optics-demo.gif)
 
 [Documentation](https://mozarkai.github.io/optics-framework/) · [Install](https://mozarkai.github.io/optics-framework/prerequisites/) · [Quick Start](https://mozarkai.github.io/optics-framework/quickstart/) · [Keywords](https://mozarkai.github.io/optics-framework/usage/keyword_usage/) · [Architecture](https://mozarkai.github.io/optics-framework/architecture/)
 


### PR DESCRIPTION
The demo GIF in the README uses a repository-relative path, which GitHub resolves but PyPI cannot: `readme_renderer` sanitises image sources it can't resolve against a base URL, so pypi.org silently drops the image.

Switched to an absolute `raw.githubusercontent.com/main` URL — renders identically on GitHub and on PyPI. No content change otherwise.