### PR TITLE
feat: onboarding overhaul (quickstart, doctor, project-scoped configure) + QA hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One keyword engine. Six ways to drive it: CSV/YAML files, a Python SDK, Robot Fr
 
 ![Optics demo](https://raw.githubusercontent.com/mozarkai/optics-framework/main/.github/assets/optics-demo.gif)
 
-[Documentation](https://mozarkai.github.io/optics-framework/) · [Install](https://mozarkai.github.io/optics-framework/prerequisites/) · [Quick Start](https://mozarkai.github.io/optics-framework/quickstart/) · [Keywords](https://mozarkai.github.io/optics-framework/usage/keyword_usage/) · [Architecture](https://mozarkai.github.io/optics-framework/architecture/)
+[Documentation](https://mozarkai.github.io/optics-framework/) · [Install](https://mozarkai.github.io/optics-framework/prerequisites/) · [Getting Started](https://mozarkai.github.io/optics-framework/getting-started/) · [Keywords](https://mozarkai.github.io/optics-framework/usage/keyword_usage/) · [Architecture](https://mozarkai.github.io/optics-framework/architecture/)
 
 </div>
 
@@ -64,7 +64,7 @@ Most extra names match the `config.yaml` source keys, so the word you install is
 | **AI** | `llm` (natural-language mode + self-heal) · `mcp` (MCP server) |
 | **Bundles** | `mobile` · `web` · `vision` · `all` |
 
-`optics setup` installs the drivers, OCR and LLM engines above (and the bundles) by name — pinned to your installed Optics version — and bare `optics setup` opens a TUI picker:
+`optics setup` installs the drivers, OCR and LLM engines above (and the bundles) by name — pinned to your installed Optics version — and bare `optics setup` opens a TUI picker. `optics quickstart` goes one step further and offers the right extras for the platform you pick:
 
 ```bash
 optics setup --list
@@ -75,15 +75,26 @@ optics setup --install appium easyocr
 > The `mcp` server extra is **pip-only** (it isn't an engine backend `optics setup` manages): `pip install "optics-framework[mcp]"`.
 
 > [!IMPORTANT]
-> Some extras need system tooling beyond the Python package. A driver extra installs only the **Python client** — mobile testing also needs the Appium server, a device/emulator, and platform tooling (Node.js, Android SDK/`adb`, JDK). `pytesseract` needs the Tesseract binary; `playwright` needs its browsers (`playwright install`). See the [Installation & Prerequisites guide](https://mozarkai.github.io/optics-framework/prerequisites/).
+> Some extras need system tooling beyond the Python package. A driver extra installs only the **Python client** — mobile testing also needs the Appium server, a device/emulator, and platform tooling (Node.js, Android SDK/`adb`, JDK). `pytesseract` needs the Tesseract binary; `playwright` needs its browsers (`playwright install`). See the [Installation guide](https://mozarkai.github.io/optics-framework/prerequisites/).
 
 > [!WARNING]
 > Conda is not supported for `easyocr` + `optics-framework` together (conflicting NumPy 1.x/2.x requirements). Use a standard `venv`.
 
 ## Quickstart
 
+From a fresh install to a running test with **one guided command**:
+
 ```bash
-optics init --name my_test_project --template contact
+pip install optics-framework
+optics quickstart
+```
+
+`optics quickstart` asks what you want to automate, installs the matching engine, scaffolds the project, writes a platform-correct `config.yaml`, and runs an `optics doctor` check — then prints your next steps. Every prompt has a default, so pressing Enter throughout yields a runnable project.
+
+Prefer to drive each step yourself?
+
+```bash
+optics init my_test_project --template contact
 # point my_test_project/config.yaml at your device/app, start the Appium server, then:
 optics dry_run my_test_project    # validate keywords, elements and module refs — no device (but the config's engines must be installed)
 optics execute my_test_project
@@ -96,7 +107,7 @@ optics execute my_test_project
 - `gmail_web` — Selenium → `[selenium,easyocr]`
 - `playwright` — Playwright → `[playwright]` (then `playwright install` for the browsers)
 
-Omit `--template` for an empty scaffold with a commented starter `config.yaml`.
+Omit `--template` for an empty scaffold with a commented starter `config.yaml`. Need only a config for an existing folder? `optics configure <folder>` writes one from a few questions, and `optics doctor [folder] [--check]` verifies engines, tooling, and project config.
 
 ## Write a test as data
 
@@ -219,7 +230,7 @@ Run `optics list` for the live catalogue with signatures, or read the [Keyword U
 
 ## Configure once, in `config.yaml`
 
-Every section is a priority-ordered list and every entry has an `enabled` flag. Enable a second driver and it becomes a fallback.
+Every section is a priority-ordered list and every entry has an `enabled` flag. Enable a second driver and it becomes a fallback. Prefer not to hand-write it? `optics configure <folder>` writes one from a few questions, or `optics quickstart` builds the whole project including the config.
 
 ```yaml
 driver_sources:
@@ -290,7 +301,10 @@ Drop an `error_definitions.csv` into `test_data/` and Optics scans visible text 
 ## CLI reference
 
 ```text
-optics init        Scaffold a new project (--name, --template, --path, --force, --git-init)
+optics init        Scaffold a new project (positional NAME; --template, --path, --force, --git-init)
+optics quickstart  Guided walkthrough: engines + project + config + doctor check
+optics configure   Write/edit a project's config.yaml (guided prompts; --edit opens a TUI)
+optics doctor      Diagnose engines, tooling and a project's config (--check for CI)
 optics setup       Install engine backends (--list, --install); bare command opens a TUI
 optics dry_run     Validate a project without touching a device
 optics execute     Run a project (--runner test_runner|pytest)
@@ -299,7 +313,6 @@ optics generate    Emit pytest or Robot Framework code from a project
 optics list        Print every discoverable keyword
 optics serve       Start the REST API server (--host, --port, --workers)
 optics mcp         Start the MCP server (--transport stdio|http)
-optics config      Manage global configuration (interactive)
 optics completion  Install shell autocompletion
 optics --version   Print the installed version
 ```

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,4 +1,4 @@
-# :material-api: API Reference
+# API Reference
 
 This section provides comprehensive Python API documentation for the Optics Framework, automatically generated from code docstrings.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,5 +270,5 @@ From here you can move from the C4 Level 1 and Level 2 views in this document in
 - [REST API Usage](usage/REST_API_usage.md) - Complete REST API endpoint reference
 - [API Reference](api_reference.md) - Python API documentation
 - [Configuration](configuration.md) - Configuration guide
-- [Quick Start](quickstart.md) - Getting started guide
+- [Getting Started](getting-started.md) - Install, first project, first run
 - [Usage Guide](usage/usage.md) - Usage examples and patterns

--- a/docs/architecture/cli_layer.md
+++ b/docs/architecture/cli_layer.md
@@ -55,14 +55,14 @@ All commands follow a consistent pattern: registration, argument parsing, valida
 
 **Usage:**
 ```bash
-optics init --name my_project --path ./tests --template contact --git-init
+optics init my_project --path ./tests --template contact --git-init
 ```
 
 **Arguments:**
 
-- `--name` (required): Project name
+- `name` (positional, required unless interactive): Project name (`--name` still works but is deprecated)
 - `--path` (optional): Directory where project will be created
-- `--template` (optional): Project template to use
+- `--template` (optional): Project template to use; omitted interactively, a picker is offered
 - `--force` (flag): Override if project exists
 - `--git-init` (flag): Initialize git repository
 
@@ -75,13 +75,13 @@ sequenceDiagram
     participant InitHelper
     participant FileSystem
 
-    User->>CLI: optics init --name project
+    User->>CLI: optics init project
     CLI->>InitHelper: create_project(args)
     InitHelper->>FileSystem: Create project structure
     InitHelper->>FileSystem: Copy template files
     InitHelper->>FileSystem: Initialize git (if requested)
     InitHelper-->>CLI: Project created
-    CLI-->>User: Success message
+    CLI-->>User: Success message + next steps
 ```
 
 ### 2. Execute Command
@@ -115,11 +115,14 @@ sequenceDiagram
     CLI->>ExecuteHelper: execute_main(folder_path)
     ExecuteHelper->>ConfigHandler: Load configuration
     ExecuteHelper->>ExecuteHelper: Load test cases
+    ExecuteHelper->>ExecuteHelper: Driver preflight (server/device reachable)
     ExecuteHelper->>ExecutionEngine: Execute tests
     ExecutionEngine-->>ExecuteHelper: Results
     ExecuteHelper-->>CLI: Execution complete
-    CLI-->>User: Results displayed
+    CLI-->>User: Results displayed (+ failure details when steps failed)
 ```
+
+The preflight aborts with a non-zero exit and fix instructions when the enabled driver's backend is unreachable (Appium server / Android device, Selenium remote URL). `OPTICS_SKIP_PREFLIGHT=1` bypasses it.
 
 ### 3. Dry Run Command
 
@@ -158,7 +161,7 @@ optics setup --list
 - `--list` (flag): List available drivers
 
 **Modes:**
-- **Interactive Mode**: Launches a TUI (Text User Interface) for driver selection
+- **Interactive Mode**: Launches a TUI (Text User Interface) for driver selection (quit with `q`, `Ctrl+C`/`Ctrl+Q`, or the Quit button)
 - **List Mode**: Displays all available drivers
 - **Install Mode**: Installs specified drivers via package manager
 
@@ -224,20 +227,52 @@ optics list
 
 **Behavior:** Scans the framework API package and displays all available keywords that can be used in test cases, along with their parameters and descriptions.
 
-### 8. Config Command
+### 8. Configure Command
 
-**Command:** `optics config`
+**Command:** `optics configure [folder] [--edit]`
 
-**Purpose:** Manage framework configuration
+**Purpose:** Write or edit a project's `config.yaml` (configuration is project-specific; there is no global config)
 
 **Usage:**
 ```bash
-optics config
+optics configure myproject          # guided Q&A → rendered config.yaml
+optics configure myproject --edit   # full-field Textual editor
 ```
 
-**Behavior:** Launches an interactive configuration manager that allows users to view, edit, and validate framework configuration files.
+**Behavior:** The default path first confirms overwrite when a `config.yaml` already exists (declining aborts before any question is asked), then walks the user through platform questions and writes the rendered, commented `config.yaml`. `--edit` launches the interactive configuration manager over every config field of that project.
 
-### 9. Completion Command
+!!! note "Deprecated alias"
+    `optics config` prints a deprecation notice and forwards to the editor for the current directory.
+
+### 9. Doctor Command
+
+**Command:** `optics doctor [folder] [--check]`
+
+**Purpose:** Diagnose the environment (Python, engines, adb/Appium, browsers) and, when a folder is given, validate that project's `config.yaml`
+
+**Usage:**
+```bash
+optics doctor                     # environment only
+optics doctor myproject           # environment + project config
+optics doctor myproject --check   # exit non-zero if a project check fails (CI)
+```
+
+**Behavior:** Prints a ✅/⚠️/❌ table with a fix command for each row. Environment gaps are warnings; project-config problems are failures. Run without a project folder, it adds a ⚠️ row pointing you to `optics quickstart` instead of staying silent about the missing config. When the enabled driver's own requirements are unmet (e.g. Appium server unreachable or no device attached), the closing line lists exactly those blockers instead of the all-clear reassurance. Parses `config.yaml` with `yaml.safe_load` only — it never mutates the project it inspects. `--check` exits non-zero when any project-config row fails.
+
+### 10. Quickstart Command
+
+**Command:** `optics quickstart`
+
+**Purpose:** Guided, end-to-end walkthrough for a first project
+
+**Usage:**
+```bash
+optics quickstart
+```
+
+**Behavior:** Prints the welcome banner, asks what you want to automate, offers to install the matching engine, scaffolds a project, generates a platform-correct `config.yaml` from a short Q&A, runs `doctor` to verify, and prints the next steps. It never runs your tests itself.
+
+### 11. Completion Command
 
 **Command:** `optics completion`
 
@@ -248,7 +283,7 @@ optics config
 optics completion
 ```
 
-**Behavior:** Updates shell RC files (`.bashrc`, `.zshrc`) to enable command and argument autocompletion for the CLI.
+**Behavior:** Generates the completion scripts under `~/.optics/`, then asks for confirmation before appending the `source` line to the shell RC file (`.bashrc`, `.zshrc`). On decline — or without an interactive terminal — it prints the line to add manually and leaves RC files untouched.
 
 ## Helper Modules
 
@@ -351,7 +386,7 @@ Test execution commands use the `ExecutionEngine` to orchestrate test runs. The 
 
 ### Configuration Loading
 
-Commands load configuration through `ConfigHandler`, which supports hierarchical configuration (default, global, project) with proper precedence and merging.
+Commands load configuration from the project's own `config.yaml` through `ConfigHandler`. There is no global config layer — each project directory is self-contained.
 
 ## Command Execution Flow
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -754,38 +754,22 @@ class DependencyConfig(BaseModel):
 
 #### Configuration Hierarchy
 
-Configuration is loaded from multiple sources with precedence:
+Configuration is project-specific: the runner loads a project's own
+`config.yaml` over the framework defaults.
 
 ```mermaid
 graph TB
-    A[Default Config] --> B[Global Config]
-    B --> C[Project Config]
+    A[Default Config] --> C[Project Config]
     C --> D[Final Config]
 
     A1[Hardcoded Defaults] --> A
-    B1[~/.optics/global_config.yaml] --> B
     C1[Project config.yaml] --> C
 ```
 
 **Precedence Order (highest to lowest):**
 
-1. **Project Config** - Project-specific configuration
-2. **Global Config** - User's global configuration (`~/.optics/global_config.yaml`)
-3. **Default Config** - Framework defaults
-
-#### Configuration Loading
-
-```python
-def load(self) -> Config:
-    default_config = Config()  # Framework defaults
-    global_config = self._load_yaml(self.global_config_path)  # Global config
-    project_config = self.config  # Project config
-
-    # Merge with precedence: project > global > default
-    merged = deep_merge(default_config, global_config)
-    self.config = deep_merge(merged, project_config)
-    return self.config
-```
+1. **Project Config** - Project-specific configuration (`config.yaml`)
+2. **Default Config** - Framework defaults
 
 #### Configuration Merging
 
@@ -796,6 +780,7 @@ def deep_merge(c1: Config, c2: Config) -> Config:
     """Merge c2 into c1, with c2 taking precedence."""
     # Recursively merge dictionaries
     # c2 values override c1 values
+    # List values are REPLACED wholesale, not merged item-by-item
 ```
 
 **Merge Rules:**
@@ -974,20 +959,11 @@ max_attempts: 5
 halt_duration: 0.2
 ```
 
-#### Environment-Specific Configuration
+#### Project-Specific Configuration
 
-Use global config for environment-specific settings:
-
-**Global Config (`~/.optics/global_config.yaml`):**
-```yaml
-# Development environment
-log_level: "DEBUG"
-file_log: true
-
-# Production environment
-# log_level: "INFO"
-# file_log: false
-```
+All configuration lives in the project's `config.yaml` — there is no global
+config layer. Per-environment or per-project differences are handled by giving
+each project its own file (scaffold one with `optics configure <folder>`).
 
 **Project Config:**
 ```yaml
@@ -996,6 +972,9 @@ driver_sources:
   - appium:
       enabled: true
       url: "http://localhost:4723"
+
+log_level: "DEBUG"
+file_log: true
 ```
 
 #### Configuration Precedence Examples
@@ -1003,23 +982,14 @@ driver_sources:
 **Example 1: Log Level**
 
 - Default: `INFO`
-- Global: `DEBUG`
 - Project: `WARNING`
 - **Result:** `WARNING` (project overrides)
 
 **Example 2: Driver URL**
 
 - Default: `None`
-- Global: `http://localhost:4723`
 - Project: `http://remote:4723`
-- **Result:** `http://remote:4723` (project overrides)
-
-**Example 3: Capabilities Merge**
-
-- Default: `{}`
-- Global: `{platformName: "Android"}`
-- Project: `{deviceName: "emulator"}`
-- **Result:** `{platformName: "Android", deviceName: "emulator"}` (merged)
+- **Result:** `http://remote:4723` (project supplies it)
 
 #### Configuration Validation Rules
 
@@ -1030,11 +1000,10 @@ driver_sources:
 
 #### Best Practices
 
-1. **Use Global Config for Environment Settings**: Store environment-specific settings in global config
-2. **Use Project Config for Project Settings**: Store project-specific settings in project config
-3. **Enable Only Needed Dependencies**: Disable unused dependencies for better performance
-4. **Use Capabilities for Driver Settings**: Store driver-specific settings in capabilities
-5. **Validate Configuration Early**: Check configuration during initialization
+1. **Keep Each Project Self-Contained**: Every setting a run needs belongs in that project's `config.yaml`
+2. **Enable Only Needed Dependencies**: Disable unused dependencies for better performance
+3. **Use Capabilities for Driver Settings**: Store driver-specific settings in capabilities
+4. **Validate Configuration Early**: Run `optics doctor <folder>` to check a project before executing
 
 #### Troubleshooting
 
@@ -1052,7 +1021,7 @@ driver_sources:
 
 **Configuration Not Applied:**
 
-- Check precedence order (project > global > default)
+- Check precedence order (project config.yaml > built-in defaults)
 - Verify configuration was saved
 - Check for merge conflicts
 

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -1221,7 +1221,7 @@ sequenceDiagram
     participant Builder
 
     CLI->>Helper: execute(project)
-    Helper->>Helper: load_config()
+    Helper->>Helper: load_project_config()
     Helper->>Helper: load_test_cases()
     Helper->>SessionMgr: create_session()
     SessionMgr->>Session: new Session()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,13 +4,163 @@ This document provides comprehensive documentation for all configuration options
 
 ## Overview
 
-There are two configuration files:
+Configuration is **project-specific**: the one file that matters is `config.yaml` in your project directory. It is what `optics execute <folder>` / `optics dry_run <folder>` actually read, and built-in defaults fill in any field you omit.
 
-1. **Project Configuration** — `config.yaml` in your project directory. This is the config `optics execute <folder>` / `optics dry_run <folder>` actually read. Built-in defaults fill in any field you omit.
-2. **Global Configuration** — `~/.optics/global_config.yaml`, edited by the interactive `optics config` command.
+!!! tip "Writing a project config"
+    Run `optics configure <folder>` to answer a few questions and generate the file, or `optics quickstart` for the full guided setup (project + config + environment check via `optics doctor`).
 
-!!! warning "The runner reads the project config only"
-    `optics execute`/`optics dry_run` load the target folder's own `config.yaml` and do **not** merge the global file into it. Treat `config.yaml` in each project as the source of truth for that run. The global config is a convenience surface edited via `optics config`; to affect a specific run, edit that project's `config.yaml`.
+## Configuration Examples
+
+=== "Android Mobile App"
+
+    Complete configuration for Android app testing with Appium:
+
+    ```yaml
+    # Core Settings
+    console: true
+    file_log: true
+    log_level: INFO
+    project_path: "./my_android_project"
+    halt_duration: 0.1
+    max_attempts: 3
+
+    # Driver Configuration
+    driver_sources:
+      - appium:
+          enabled: true
+          url: "http://localhost:4723/wd/hub"
+          capabilities:
+            automationName: "UiAutomator2"
+            deviceName: "emulator-5554"
+            platformName: "Android"
+            platformVersion: "13.0"
+            appPackage: "com.example.app"
+            appActivity: "com.example.app.MainActivity"
+
+    # Element Sources
+    elements_sources:
+      - appium_find_element:
+          enabled: true
+          url: null
+          capabilities: {}
+      - appium_screenshot:
+          enabled: true
+          url: null
+          capabilities: {}
+
+    # Text Detection
+    text_detection:
+      - easyocr:
+          enabled: true
+          url: null
+          capabilities: {}
+
+    # Image Detection
+    image_detection:
+      - templatematch:
+          enabled: true
+          url: null
+          capabilities: {}
+    ```
+
+=== "Web Application (Playwright)"
+
+    Configuration for web testing using Playwright:
+
+    ```yaml
+    # Core Settings
+    console: true
+    file_log: true
+    json_log: true
+    log_level: INFO
+    project_path: "./web_test_project"
+    halt_duration: 0.2
+    max_attempts: 5
+
+    # Driver Configuration
+    driver_sources:
+      - playwright:
+          enabled: true
+          url: null
+          capabilities:
+            browser: "chromium"
+            headless: false
+            viewport:
+              width: 1920
+              height: 1080
+
+    # Element Sources
+    elements_sources:
+      - playwright_find_element:
+          enabled: true
+          url: null
+          capabilities: {}
+      - playwright_screenshot:
+          enabled: true
+          url: null
+          capabilities: {}
+
+    # Text Detection
+    text_detection:
+      - pytesseract:
+          enabled: true
+          url: null
+          capabilities: {}
+
+    # Image Detection
+    image_detection:
+      - templatematch:
+          enabled: true
+          url: null
+          capabilities: {}
+    ```
+
+=== "Mixed Driver Configuration"
+
+    Example with multiple drivers for fallback support:
+
+    ```yaml
+    driver_sources:
+      - appium:
+          enabled: true
+          url: "http://localhost:4723/wd/hub"
+          capabilities:
+            automationName: "UiAutomator2"
+            deviceName: "emulator-5554"
+            platformName: "Android"
+      - selenium:
+          enabled: true
+          url: "http://localhost:4444/wd/hub"
+          capabilities:
+            browserName: "chrome"
+
+    elements_sources:
+      - appium_find_element:
+          enabled: true
+          url: null
+          capabilities: {}
+      - selenium_find_element:
+          enabled: true
+          url: null
+          capabilities: {}
+    ```
+
+=== "Full Logging Configuration"
+
+    Example with comprehensive logging setup:
+
+    ```yaml
+    console: true
+    file_log: true
+    json_log: true
+    log_level: DEBUG
+    log_path: "./logs/execution.log"
+    json_path: "./logs/execution.json"
+    project_path: "./test_project"
+    execution_output_path: "./outputs"
+    ```
+
+---
 
 ## Quick Reference
 
@@ -669,165 +819,9 @@ driver_sources:
 
 ---
 
-## Configuration Examples
-
-=== "Android Mobile App"
-
-    Complete configuration for Android app testing with Appium:
-
-    ```yaml
-    # Core Settings
-    console: true
-    file_log: true
-    log_level: INFO
-    project_path: "./my_android_project"
-    halt_duration: 0.1
-    max_attempts: 3
-
-    # Driver Configuration
-    driver_sources:
-      - appium:
-          enabled: true
-          url: "http://localhost:4723/wd/hub"
-          capabilities:
-            automationName: "UiAutomator2"
-            deviceName: "emulator-5554"
-            platformName: "Android"
-            platformVersion: "13.0"
-            appPackage: "com.example.app"
-            appActivity: "com.example.app.MainActivity"
-
-    # Element Sources
-    elements_sources:
-      - appium_find_element:
-          enabled: true
-          url: null
-          capabilities: {}
-      - appium_screenshot:
-          enabled: true
-          url: null
-          capabilities: {}
-
-    # Text Detection
-    text_detection:
-      - easyocr:
-          enabled: true
-          url: null
-          capabilities: {}
-
-    # Image Detection
-    image_detection:
-      - templatematch:
-          enabled: true
-          url: null
-          capabilities: {}
-    ```
-
-=== "Web Application (Playwright)"
-
-    Configuration for web testing using Playwright:
-
-    ```yaml
-    # Core Settings
-    console: true
-    file_log: true
-    json_log: true
-    log_level: INFO
-    project_path: "./web_test_project"
-    halt_duration: 0.2
-    max_attempts: 5
-
-    # Driver Configuration
-    driver_sources:
-      - playwright:
-          enabled: true
-          url: null
-          capabilities:
-            browser: "chromium"
-            headless: false
-            viewport:
-              width: 1920
-              height: 1080
-
-    # Element Sources
-    elements_sources:
-      - playwright_find_element:
-          enabled: true
-          url: null
-          capabilities: {}
-      - playwright_screenshot:
-          enabled: true
-          url: null
-          capabilities: {}
-
-    # Text Detection
-    text_detection:
-      - pytesseract:
-          enabled: true
-          url: null
-          capabilities: {}
-
-    # Image Detection
-    image_detection:
-      - templatematch:
-          enabled: true
-          url: null
-          capabilities: {}
-    ```
-
-=== "Mixed Driver Configuration"
-
-    Example with multiple drivers for fallback support:
-
-    ```yaml
-    driver_sources:
-      - appium:
-          enabled: true
-          url: "http://localhost:4723/wd/hub"
-          capabilities:
-            automationName: "UiAutomator2"
-            deviceName: "emulator-5554"
-            platformName: "Android"
-      - selenium:
-          enabled: true
-          url: "http://localhost:4444/wd/hub"
-          capabilities:
-            browserName: "chrome"
-
-    elements_sources:
-      - appium_find_element:
-          enabled: true
-          url: null
-          capabilities: {}
-      - selenium_find_element:
-          enabled: true
-          url: null
-          capabilities: {}
-    ```
-
-=== "Full Logging Configuration"
-
-    Example with comprehensive logging setup:
-
-    ```yaml
-    console: true
-    file_log: true
-    json_log: true
-    log_level: DEBUG
-    log_path: "./logs/execution.log"
-    json_path: "./logs/execution.json"
-    project_path: "./test_project"
-    execution_output_path: "./outputs"
-    ```
-
----
-
 ## How configuration is loaded
 
-When you run `optics execute` or `optics dry_run`, the framework reads the target folder's own `config.yaml`. Any field you leave out falls back to the built-in defaults (for example, every source defaults to `enabled: false`). The global `~/.optics/global_config.yaml` is **not** merged into the run, so a project's `config.yaml` is the single source of truth for that run.
-
-!!! note "Where the global config is used"
-    The global config is the file the interactive `optics config` command edits. It is a convenience for user-wide defaults and is not read by `optics execute`, so editing it has no effect on a run. To change how a specific project runs, edit that project's `config.yaml`.
+When you run `optics execute` or `optics dry_run`, the framework reads the target folder's own `config.yaml`. Any field you leave out falls back to the built-in defaults (for example, every source defaults to `enabled: false`). A project's `config.yaml` is the single source of truth for that run — there is no global config layer to merge.
 
 ---
 
@@ -837,5 +831,5 @@ When you run `optics execute` or `optics dry_run`, the framework reads the targe
 2. **Use Appropriate OCR**: Choose EasyOCR for accuracy, Pytesseract for speed
 3. **Set Log Level Appropriately**: Use DEBUG during development, INFO or WARNING in production
 4. **Configure Execution Paths**: Set `project_path` and `execution_output_path` for organized output
-5. **Keep Each Project's `config.yaml` Self-Contained**: It is the config the runner reads — don't rely on the global config to supply values at run time
+5. **Keep Each Project's `config.yaml` Self-Contained**: It is the only config the runner reads
 6. **Test Configuration Changes**: Verify configurations work correctly before running large test suites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,14 +1,63 @@
-# :material-speedometer: Quick Start Guide
+# Getting Started Guide
 
-This guide will walk you through creating automated tests using Optics Framework.
+This guide walks you through creating automated tests using Optics Framework — from a fresh install to your first executed test.
 
-## :material-rocket: Quick Start
+!!! abstract "A few terms first"
+    - **Engine** — an installable backend that does the work: an action *driver* (Appium, Selenium, Playwright), an OCR engine, or an LLM. Install engines with `optics setup`.
+    - **Element source** — where Optics looks for on-screen elements (the driver's page source, OCR text, or image matching), configured under `elements_sources` in `config.yaml`.
+    - **Locator** — the value that identifies one element: an XPath, a `text=…` string, a CSS selector, or an image filename.
+    - **Element** — a named locator you reference from a module as `${name}`, defined in `elements.csv`.
+
+!!! tip "In a hurry?"
+    Run **`optics quickstart`** — the [guided walkthrough](#optics-quickstart-the-guided-walkthrough) below documents every stage, defaults included. The rest of the page explains each piece and how to do it by hand.
+
+## `optics quickstart`: The Guided Walkthrough
+
+One command takes you from nothing to a runnable project:
+
+```bash
+optics quickstart
+```
+
+It walks through eight stages, in order:
+
+1. Prints the welcome banner and the golden path.
+2. Asks what you want to automate: `mobile` or `web`.
+3. Offers to pip-install the matching engines (Appium for mobile, Selenium + Playwright for web).
+4. Offers starting points: an empty project (recommended) or a packaged sample (`contact`, `youtube`, …). Picking a sample aimed at the other domain asks for confirmation first.
+5. Names the project folder and picks where it lives.
+6. Runs a short config Q&A scoped to your platform choice, then writes a commented, platform-correct `config.yaml`.
+7. Verifies the environment and the fresh project with `optics doctor`.
+8. Prints next steps tailored to your answers.
+
+Every question ships with a default, so pressing Enter throughout yields a runnable project:
+
+| Stage | What it asks | Default (just press Enter) |
+|---|---|---|
+| Target | `mobile` or `web`? | `mobile` |
+| Engines | Install them now? | yes |
+| Starting point | Empty project or a sample? | empty project (recommended) |
+| Project name | Folder name for the new project | `my-optics-project` |
+| Location | Where to create it | current directory |
+| Platform | Android / iOS, or Playwright / Selenium | Android (mobile), Playwright (web) |
+| Details | Device name, app id, server URL, browser, headless | Working examples: `emulator-5554`, `com.example.app`, `http://127.0.0.1:4723`, Chromium, headed |
+| Vision | Find elements by on-screen text (EasyOCR)? | no |
+| Log level | `DEBUG` to `ERROR` | `INFO` |
+
+The defaults are runnable placeholders, not magic: edit the generated `config.yaml` whenever you like, or redo the Q&A with `optics configure <folder>`. Samples ship their own curated `config.yaml`, and the wizard keeps it unless you explicitly agree to overwrite.
+
+!!! info "Prerequisites, the short version"
+    A standard Python 3.12+ virtualenv is all you need to start. Web targets need nothing more (the Playwright engine downloads its own browsers); mobile additionally needs a JDK (17+), Node.js + the Appium server, and the Android platform-tools — the full list lives in [Installation](prerequisites.md). You don't need to settle this up front: the `doctor` check in stage 7 reports each gap with the exact command that fixes it.
+
+The rest of this page explains **what each stage sets up**, so you can also drive every part yourself if you prefer full control.
+
+## Overview: Manual Setup
 
 ### Step 1: Create Python Virtual Environment
 
 ```bash
-mkdir ~/test-code
-cd ~/test-code
+mkdir test-code
+cd test-code
 python3 -m venv venv
 source venv/bin/activate
 pip install optics-framework
@@ -19,7 +68,7 @@ pip install optics-framework
 
 ### Step 2: Install the Engines You Need
 
-The core install has no drivers. Add the ones your test needs — either as pip extras or via `optics setup` (the names match the `config.yaml` source keys):
+The core install has no drivers. Add the ones your test needs — either as pip extras or via `optics setup` (the names match the `config.yaml` source keys). Not sure which ones you need? The [guided walkthrough](#optics-quickstart-the-guided-walkthrough) installs them for you based on your target platform:
 
 ```bash
 optics setup --install appium easyocr
@@ -29,15 +78,18 @@ optics setup --install appium easyocr
 !!! warning "Note"
     Intel-based Macs cannot download easyocr.
 
+!!! info "Mobile needs more than pip"
+    `optics setup` installs the Python engine, but Appium mobile automation also needs system tools it can't install for you — a **JDK (17+)**, **Node.js + the `appium` server**, and the **Android platform-tools** (`adb`). See [Installation](prerequisites.md), and run `optics doctor` any time to see exactly what's still missing (with the command to fix each item).
+
 ### Step 3: Create a New Test Project
 
 ```bash
-optics init --name my_test_project --template contact
+optics init my_test_project --template contact
 ```
 
-This copies the `contact` sample — a complete, runnable project — into `./my_test_project`. Omit `--template` to scaffold an empty project you fill in yourself. Templates: `contact`, `clock`, `calendar`, `youtube`, `gmail_web`, `playwright`.
+This copies the `contact` sample — a complete, runnable project — into `./my_test_project`. Omit `--template` to scaffold an empty project you fill in yourself (or run `optics quickstart` for the fully guided walkthrough: engines + project + config + doctor check). Templates: `contact`, `clock`, `calendar`, `youtube`, `gmail_web`, `playwright`.
 
-## :material-file-tree: Project Structure
+## Project Structure
 
 Your test project uses four main components that work together:
 
@@ -72,9 +124,9 @@ my_test_project/
 
 The API YAML format is different from element files: it defines collections, base URLs, endpoints, request/response, and optional `extract` rules. See the **Invoke Api** and **Add Api** sections in [Keyword Usage](usage/keyword_usage.md), and sample `api.yaml` files
 
-## :material-cog: Step 1: Configure Your Environment
+## Configuring `config.yaml`
 
-The `config.yaml` file tells the framework how to connect to your device and what tools to use for finding elements.
+The `config.yaml` file tells the framework how to connect to your device and what tools to use for finding elements. The quickest way to create it is `optics configure <project>` — a short Q&A writes a platform-correct file for you (or `optics configure <project> --edit` to hand-tune every field in a TUI). You can also edit it directly, as shown below.
 
 ### Driver Connection
 
@@ -98,7 +150,7 @@ driver_sources:
 - `udid`: Your device's unique identifier (find with `adb devices`)
 - `url`: Your Appium server address (usually localhost)
 
-## :material-camera: Step 2: Capture UI Element Screenshots
+## Capturing UI Element Screenshots
 
 Before defining elements in the CSV, you need to capture screenshots of the UI elements you want to interact with.
 
@@ -109,37 +161,38 @@ This folder stores PNG images of buttons, icons, text fields, and other UI eleme
 !!! tip "Best Practice"
     Organize `input_templates/` with subfolders for different screens and name images to match their Element_ID exactly.
 
-## :material-format-list-bulleted: Step 3: Define Your Elements
+## Defining Your Elements
 
 Elements are the UI components you'll interact with – buttons, text fields, tabs, etc.
 
 ### CSV Structure
 
 ```csv
-Element_Name,Element_ID_xpath,Element_ID,Element_ID_Text
+Element_Name,Element_ID
 ```
 
-### Column Explanations
+- **Element_Name**: the name you reference from modules as `${Element_Name}`.
+- **Element_ID**: how to locate it — an XPath, a `text=…` string, a CSS selector, or an image filename from `input_templates/`.
 
-- **Element_Name**: A descriptive name you'll use in modules (e.g., `login_button`)
-- **Element_ID_xpath**: The technical XPath or accessibility ID for finding the element
-- **Element_ID**: The PNG filename from `input_templates/` for visual matching
-- **Element_Text**: The visible text on the element (optional, for verification)
+**Fallbacks.** To give one element several locators (tried in order until one matches), add more columns whose names start with `Element_ID` — e.g. `Element_ID_xpath`, `Element_ID_text`, `Element_ID_image`. Only `Element_Name` and `Element_ID*` columns are read; any other column is ignored.
 
 ### Example `elements.csv`
 
 ```csv
-Element_Name,Element_ID_xpath,Element_ID,Element_Text
+Element_Name,Element_ID_xpath,Element_ID_image,Element_ID_text
 login_button,"//android.widget.Button[@resource-id=""com.app.login:id/btnLogin""]",button_login.png,Login
 ```
 
-### Special Element Types
+Here `login_button` is located by XPath first, then by matching `button_login.png`, then by the on-screen text `Login`.
+
+### Values as Data
+
+An element can also just hold a value your steps consume via `${...}` (e.g. text to type):
 
 ```csv
-Element_Name,Element_ID_xpath,Element_ID,Element_Text
-test_password,,,SecurePass123
-retry_count,,,3
-item_list,"[""Item1"",""Item2"",""Item3""]",,
+Element_Name,Element_ID
+test_password,SecurePass123
+retry_count,3
 ```
 
 ### Finding XPaths
@@ -155,7 +208,7 @@ Use Appium Inspector or your device's UI Automator to find element XPaths:
 !!! tip "Newlines and special characters in CSV"
     XPaths and other locator strings in CSV stay one line per row. To include a newline in a value (e.g. in `@content-desc`), use `\n`; for a tab use `\t`, and for a literal backslash use `\\`. Example: `//android.widget.ImageView[@content-desc="I\nIcici Bank Limited"]` in a cell is read as an XPath whose attribute value contains a real newline between `I` and `Icici Bank Limited`.
 
-## :material-puzzle: Step 4: Create Reusable Modules
+## Creating Reusable Modules
 
 Modules are sequences of actions that accomplish a specific task, such as building blocks.
 
@@ -188,7 +241,7 @@ Launch External App,Launch Other App,com.example.otherapp,,,,
 !!! note "Variable References"
     `${element_name}` references an element from `elements.csv`
 
-## :material-check-circle: Step 5: Build Test Cases
+## Building Test Cases
 
 Test cases combine modules into complete test scenarios.
 
@@ -230,7 +283,7 @@ Verify User Login,User Login
 
 Test cases define **what** to test, modules define **how** to do it. This separation lets you mix and match modules for different test scenarios.
 
-## :material-play: Running Your Tests
+## Running Your Tests
 
 ### Prerequisites
 
@@ -239,7 +292,9 @@ Test cases define **what** to test, modules define **how** to do it. This separa
 - Appium server running: `appium`
 - Android virtual device or physical device connected and verified: `adb devices`
 
-New to Appium or the Android SDK? Install them from their official docs — [Appium](https://appium.io/docs/en/latest/quickstart/) and the [Android platform tools](https://developer.android.com/tools/releases/platform-tools). The [Installation & Prerequisites](prerequisites.md) page lists what Optics itself needs.
+Run `optics doctor my_test_project` to confirm all of the above at once — it reports each engine, tool, and `config.yaml` check as ✅/⚠️/❌ with the command to fix anything missing.
+
+New to Appium or the Android SDK? Install them from their official docs — [Appium](https://appium.io/docs/en/latest/quickstart/) and the [Android platform tools](https://developer.android.com/tools/releases/platform-tools). The [Installation](prerequisites.md) page lists what Optics itself needs.
 
 ### Always Dry Run Test Cases Before Executing
 
@@ -269,7 +324,7 @@ optics execute my_test_project
 5. Executes test cases in order from `test_cases.csv`
 6. Generates a test report with results and logs
 
-## :material-star: Best Practices
+## Best Practices
 
 ### 1. Naming Conventions
 
@@ -330,7 +385,10 @@ my_test_project/
 - Check `input_templates/` images load correctly
 - Verify element names match exactly (case-sensitive)
 
-## :material-format-list-checks: Quick Start Checklist
+## Checklist
+
+!!! tip "Took the guided path?"
+    `optics quickstart` already scaffolds the project, writes `config.yaml`, and verifies your environment and tools via `optics doctor`. Start at *Defining Your Elements* below — the remaining checkboxes are about authoring your first test.
 
 - [ ] Configure `config.yaml` with your device details
 - [ ] Capture screenshots of UI elements
@@ -344,7 +402,7 @@ my_test_project/
 - [ ] Execute tests
 - [ ] Review test results and logs
 
-## :material-alert: Common Pitfalls to Avoid
+## Common Pitfalls to Avoid
 
 !!! failure "Avoid These Mistakes"
     - ❌ **Hardcoding values** - Use variables instead
@@ -358,7 +416,7 @@ my_test_project/
     - ❌ **Outdated screenshots** - Update images when UI changes
     - ❌ **Generic element names** - `button1.png` is less clear than `button_login.png`
 
-## :material-help-circle: Need Help?
+## Need Help?
 
 ### Common Issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hide:
   - toc
 ---
 
-# :material-rocket-launch: Optics Framework
+# Optics Framework
 
 Welcome to the official documentation for the **Optics Framework**, an open-source test automation framework designed to simplify and streamline the creation and execution of automated tests across various platforms. Whether you're testing mobile apps (including DRM-enabled ones), Optics Framework provides a flexible, extensible, and user-friendly solution to meet your testing needs.
 
@@ -13,7 +13,7 @@ Welcome to the official documentation for the **Optics Framework**, an open-sour
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10842/badge)](https://www.bestpractices.dev/projects/10842)
 
-## :material-lightning-bolt: Key Features
+## Key Features
 
 <div class="grid cards" markdown>
 
@@ -45,24 +45,45 @@ Welcome to the official documentation for the **Optics Framework**, an open-sour
 
     Automatic fallback to alternative detection methods when primary fails
 
+-   :material-play-circle: **Live Sessions**
+
+    Drive a live target interactively and record sessions straight into modules. See [Live Usage](usage/live_usage.md).
+
+-   :material-connection: **MCP & Agents**
+
+    Expose every keyword as an MCP tool so AI clients drive a real target. See [MCP Usage](usage/mcp_usage.md).
+
 </div>
 
-## :material-rocket: Quick Start
+## Quick Start
 
-Get started with Optics Framework in minutes:
+From zero to a runnable test project with **one guided command**:
+
+!!! info "Requires Python 3.12 or newer"
+    Check first with `python3 --version`. On an older Python, install 3.12 — see [Installation](prerequisites.md) — then continue.
 
 ```bash
 pip install optics-framework
-optics setup --install appium easyocr        # install the engines you need
-optics init --name my_test_project --template contact
-# edit my_test_project/config.yaml for your device, start Appium + emulator, then:
-optics dry_run my_test_project               # validate without a device
-optics execute my_test_project               # run it
+optics quickstart
 ```
 
-[:material-arrow-right: Read the Quick Start Guide →](quickstart.md) &nbsp;·&nbsp; [Installation & Prerequisites →](prerequisites.md)
+The wizard asks what you want to automate (Android, iOS, web…), installs the matching engine, scaffolds the project, writes a platform-correct `config.yaml`, and runs an environment check before printing your next steps.
 
-## :material-book-open: Explore Documentation
+??? tip "Prefer to drive each step yourself?"
+    ```bash
+    pip install optics-framework
+    optics setup --install appium easyocr        # install the engines you need
+    optics init my_test_project --template contact
+    # edit my_test_project/config.yaml for your device, start Appium + emulator, then:
+    optics dry_run my_test_project               # validate without a device
+    optics execute my_test_project               # run it
+    ```
+
+    The [Getting Started Guide](getting-started.md) explains every step.
+
+[Getting Started Guide](getting-started.md){ .md-button .md-button--primary } &nbsp; [Installation](prerequisites.md){ .md-button }
+
+## Explore Documentation
 
 <div class="grid cards" markdown>
 
@@ -72,11 +93,11 @@ optics execute my_test_project               # run it
 
     [:material-arrow-right: Introduction →](introduction.md)
 
--   :material-speedometer: **Quick Start**
+-   :material-speedometer: **Getting Started**
 
-    Get up and running with your first test in minutes
+    Set up Optics and run your first test in minutes — guided or step by step
 
-    [:material-arrow-right: Quick Start →](quickstart.md)
+    [:material-arrow-right: Getting Started →](getting-started.md)
 
 -   :material-office-building: **Architecture**
 
@@ -128,10 +149,9 @@ optics execute my_test_project               # run it
 
 </div>
 
-## :material-help-circle: Need Help?
+## Need Help?
 
 -   :material-github: [GitHub Issues](https://github.com/mozarkai/optics-framework/issues) - Report bugs or request features
--   :material-book: [Documentation](https://mozarkai.github.io/optics-framework/) - Browse the full documentation
 -   :material-email: [Contact](mailto:lalit@mozark.ai) - Reach out for support
 
 ---

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -104,4 +104,4 @@ The Optics Framework is licensed under the **Apache License 2.0**, which can be 
 
 ## Next Steps
 
-Ready to get started? Check out our [Quick Start Guide](quickstart.md) to create your first test in minutes!
+Ready to get started? Run **`optics quickstart`** for a guided setup, or check out our [Getting Started Guide](getting-started.md) to create your first test in minutes!

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,6 +1,6 @@
-# Installation & Prerequisites
+# Installation
 
-This page is the reference for what to install: the core CLI, the optional **engine extras**, and the **external tooling** each target platform needs. If you just want to try Optics, follow the [Quick Start](quickstart.md) — come back here when you need the full list of extras or the tooling for a specific platform.
+This page is the reference for what to install: the core CLI, the optional **engine extras**, and the **external tooling** each target platform needs. If you just want to try Optics, run `optics quickstart` instead — it picks and installs the right engine extra and verifies your environment for you (see [Getting Started](getting-started.md)). Come back here when you need the full list of extras or the tooling for a specific platform.
 
 ---
 
@@ -22,7 +22,7 @@ optics --version             # confirm the CLI is on your PATH
 
 ## Engine backends (extras)
 
-The core install has **no drivers, OCR, or LLM backends** — they are optional extras. Add them either as pip extras or with `optics setup` (the names match the `config.yaml` source keys):
+The core install has **no drivers, OCR, or LLM backends** — they are optional extras. Add them either as pip extras or with `optics setup` (the names match the `config.yaml` source keys). Not sure which you need? `optics quickstart` offers the right one based on your target platform, and plain `optics setup` opens an interactive picker:
 
 | Extra / `optics setup` name | Installs | Use for |
 |---|---|---|
@@ -66,4 +66,4 @@ Point your project `config.yaml` at the device/browser once the tooling is runni
 
 ## Next steps
 
-With the CLI and the extras you need installed, continue with the [Quick Start](quickstart.md) to create and run your first project.
+With the CLI and the extras you need installed, continue with the [Getting Started](getting-started.md) guide to create and run your first project — or let `optics quickstart` do those steps for you.

--- a/docs/usage/CLI_usage.md
+++ b/docs/usage/CLI_usage.md
@@ -2,6 +2,26 @@
 
 This section describes the available commands for the Optics Framework CLI. The command you run is **`optics`**; the package you install is **`optics-framework`** (e.g. `pip install optics-framework`).
 
+## First run
+
+Run `optics` with no arguments to see a welcome screen and the golden path:
+
+```bash
+optics
+```
+
+It points you at `optics quickstart` (guided setup), `optics doctor` (environment check), and `optics --help`. The first run also writes a marker at `~/.optics/.onboarded` so the greeting introduces itself only once; delete that file to see the first-run greeting again. If `~/.optics/` isn't writable (read-only HOME, containers, CI), set `OPTICS_HOME` to a directory that is — the marker lands there instead.
+
+## Guided Setup: `optics quickstart`
+
+New to Optics? One command walks you from nothing to a runnable project:
+
+```bash
+optics quickstart
+```
+
+It combines the commands below into one guided flow — welcome banner, engine install (`setup`), project scaffold (`init`), config Q&A (`configure`), and a doctor verification — then prints next steps tailored to your choices. See the [Getting Started Guide](../getting-started.md) for what each stage sets up.
+
 ## Setup: install engine backends
 
 The core install ships without drivers, OCR, or LLM backends — they are optional extras. `optics setup` installs them by name (the names match the `config.yaml` source keys, e.g. `appium`, `easyocr`, `google-vision`), pinned to your installed Optics version.
@@ -24,7 +44,7 @@ Install by name:
 optics setup --install appium easyocr
 ```
 
-This is equivalent to `pip install "optics-framework[appium,easyocr]"`. See [Installation & Prerequisites](../prerequisites.md) for the full extras table and the external tooling (Appium server, adb, browsers) each engine needs.
+This is equivalent to `pip install "optics-framework[appium,easyocr]"`. See [Installation](../prerequisites.md) for the full extras table and the external tooling (Appium server, adb, browsers) each engine needs.
 
 Pin a specific version by appending a specifier to any engine (handy for reproducible CI):
 
@@ -33,6 +53,8 @@ optics setup --install appium==5.0.0 "easyocr>=1.7,<2.0"
 ```
 
 The version applies to the engine's main package and is intersected with the extra's supported range, so an out-of-range pin fails loudly instead of silently downgrading. A malformed specifier (e.g. `appium=5.0.0` with a single `=`), two conflicting versions for the same engine, or a specifier on a bundle (e.g. `all==1.0`) are all rejected up front with a clear error.
+
+After a successful install, Optics prints the recommended next steps (`optics init` → `optics configure` → `optics doctor`).
 
 ## Executing Test Cases
 
@@ -49,21 +71,27 @@ optics execute <folder_path> [--runner <runner_name>] [--use-printer | --no-use-
 - `--use-printer` (default): Enable live result printer.
 - `--no-use-printer`: Disable live result printer.
 
+**Preflight check:** before running anything, `optics execute` verifies the enabled driver's backend is actually reachable — the Appium server (plus at least one attached Android device via `adb`) for Appium projects, or the remote WebDriver URL for Selenium projects. If something is missing it stops with the exact fix (e.g. "Start one in another terminal: `appium`") and a non-zero exit code instead of running tests that cannot reach a target. Set `OPTICS_SKIP_PREFLIGHT=1` to bypass this check.
+
+**Failure details:** when any step fails, a *Failure details* panel is printed below the summary with each failing step and its reason; unknown steps include a `Did you mean '…'?` suggestion when a close keyword match exists.
+
 ## Initializing a New Project
 
 Use the following command to initialize a new project:
 
 ```bash
-optics init --name <project_name> --path <directory> --template <sample_name> --git-init
+optics init <project_name> [--path <directory>] [--template <sample_name>] [--git-init] [--force]
 ```
 
-**Options:**
+**Arguments and options:**
 
-- `--name <project_name>`: Name of the project (required).
+- `<project_name>`: Name of the project (positional). `--name <project_name>` still works but is deprecated.
 - `--path <directory>`: Directory to create the project in (default: current directory).
-- `--template <sample_name>`: Copy files from a predefined sample. See [Templates](#templates) below.
+- `--template <sample_name>`: Copy files from a predefined sample. See [Templates](#templates) below. Omitted interactively, you get a picker; with no TTY, a blank project is scaffolded.
 - `--force`: Overwrite an existing project directory if it exists.
 - `--git-init`: Initialize a Git repository in the project.
+
+After scaffolding, Optics prints the next steps (`optics configure`, then `optics dry_run`). Blank projects (no `--template`) also get a pointer to where the first steps go — `test_cases/test_cases.csv` — and to `optics list` for every available step.
 
 ### Templates
 
@@ -115,6 +143,8 @@ optics dry_run <folder_path> [--runner <runner_name>] [--use-printer | --no-use-
 - `--use-printer` (default): Enable live result printer.
 - `--no-use-printer`: Disable live result printer.
 
+Unknown steps and unresolved `${variables}` are flagged per step, with reasons collected in a *Failure details* panel below the summary (`Did you mean '…'?` suggestions included for close keyword matches). `optics dry_run` never touches a device — unlike `optics execute`, no driver preflight runs.
+
 ## Serving the REST API
 
 Start the REST API server (e.g. for programmatic or remote use):
@@ -131,6 +161,30 @@ optics serve [--host <host>] [--port <port>] [--workers <n>]
 
 For endpoint details, request/response formats, and examples, see [REST API Usage](REST_API_usage.md).
 
+## Interactive Live Session
+
+Open an interactive session against a live target (device, browser, or TV) and run keywords as you go:
+
+```bash
+optics live [folder]
+```
+
+With a folder, Optics loads that project's `config.yaml`; without one, session defaults are used. Natural-language instructions are also available when an LLM engine is configured.
+
+For the TUI, `/save` recording, and device commands, see [Live Usage](live_usage.md).
+
+## MCP Server
+
+Expose Optics keywords as Model Context Protocol tools so an LLM client (Claude Desktop, Cursor, ...) can drive sessions:
+
+```bash
+optics mcp [--transport {stdio,http}] [--host <host>] [--port <port>]
+```
+
+Requires the optional extra: `pip install "optics-framework[mcp]"`.
+
+For setup and client configuration, see [MCP Usage](mcp_usage.md).
+
 ## Shell autocompletion
 
 Enable shell autocompletion for the `optics` command:
@@ -139,7 +193,7 @@ Enable shell autocompletion for the `optics` command:
 optics completion
 ```
 
-This updates your shell RC (e.g. `.bashrc`, `.zshrc`) so that commands and arguments are completed when you press Tab.
+The completion scripts are always written under `~/.optics/`. With your confirmation, Optics also appends one `source` line to your shell RC (e.g. `.bashrc`, `.zshrc`) so commands and arguments complete when you press Tab; decline (or run without an interactive terminal) and it prints the line for you to add by hand instead — nothing is modified without an explicit yes.
 
 ## Showing Help Information
 
@@ -149,13 +203,31 @@ Get help for the CLI:
 optics --help
 ```
 
-## Managing Configuration
+## Configuring a Project
+
+Answer a few questions and Optics writes the project's `config.yaml` for you:
 
 ```bash
-optics config
+optics configure [folder]
 ```
 
-This opens an interactive TUI for editing the **global** config at `~/.optics/global_config.yaml` (arrow keys to move, space to edit, `s` to save, `q` to quit). It takes no flags.
+- `[folder]`: Project folder whose `config.yaml` to write (default: current directory).
+
+For power users, `optics configure <folder> --edit` opens an interactive TUI over every config field instead (arrow keys to move, space to edit, `s` to save, `q` to quit). Edits always go to that project's own `config.yaml` — there is no global config file anymore.
+
+!!! note "Deprecated: `optics config`"
+    The old `optics config` command edited a global file the runner never read. It now prints a deprecation notice and forwards to the project editor for the current directory; use `optics configure` instead.
+
+## Checking Your Setup
+
+Diagnose engines, tooling, and a project's `config.yaml`:
+
+```bash
+optics doctor [folder] [--check]
+```
+
+- `[folder]`: Project folder to diagnose (default: current directory). With one, the Appium probe targets that project's configured server URL and its `config.yaml` is validated.
+- `--check`: Non-interactive mode — exit non-zero when a project-config check fails (useful in CI).
 
 ## Checking Version
 

--- a/docs/usage/REST_API_usage.md
+++ b/docs/usage/REST_API_usage.md
@@ -1,16 +1,16 @@
-# :material-api: REST API Usage
+# REST API Usage
 
 The Optics Framework provides a RESTful API for programmatic interaction with the framework. This API allows you to create sessions, execute keywords, capture screenshots, and manage test execution.
 
-## :material-link: Base URL
+## Base URL
 
 The API is served via FastAPI and typically runs on `http://localhost:8000` by default.
 
-## :material-shield-lock: Authentication
+## Authentication
 
 Currently, the API does not require authentication. CORS is enabled for all origins.
 
-## :material-code-json: Response Format
+## Response Format
 
 All endpoints return JSON responses. Error responses follow this format:
 
@@ -20,7 +20,7 @@ All endpoints return JSON responses. Error responses follow this format:
 }
 ```
 
-## :material-database: Models
+## Models
 
 ### SessionConfig
 
@@ -132,7 +132,7 @@ Information about an available keyword.
 }
 ```
 
-## :material-routes: Endpoints
+## Endpoints
 
 ### Health Check
 
@@ -548,7 +548,7 @@ curl -X DELETE "http://localhost:8000/v1/sessions/{session_id}/stop"
     - Automatically executes `close_and_terminate_app` keyword before termination
     - Cleans up all session resources
 
-## :material-alert-circle: Error Handling
+## Error Handling
 
 The API uses standard HTTP status codes:
 
@@ -577,7 +577,7 @@ For Optics-specific errors, the response may include additional fields:
 }
 ```
 
-## :material-routes: Common Workflows
+## Common Workflows
 
 ### Basic Session Workflow
 
@@ -618,7 +618,7 @@ For Optics-specific errors, the response may include additional fields:
    DELETE /v1/sessions/{session_id}/stop
    ```
 
-## :material-information: Notes
+## Notes
 
 - All endpoints that accept `session_id` will return `404` if the session doesn't exist
 - The API supports CORS for all origins

--- a/docs/usage/library_usage.md
+++ b/docs/usage/library_usage.md
@@ -10,7 +10,7 @@ Install the Optics Framework:
 pip install optics-framework
 ```
 
-## Quick Start
+## Basic Example
 
 ### Basic Example
 

--- a/docs/usage/live_usage.md
+++ b/docs/usage/live_usage.md
@@ -27,6 +27,10 @@ If no usable config is found, or the config has no enabled driver / more than on
 enabled driver / no enabled element source, `optics live` exits with a clear message.
 A malformed `config.yaml` reports the actual parse/validation error (not "no config").
 
+Don't have a project yet? `optics quickstart` scaffolds a complete one (config
+included), and `optics configure <folder>` generates a `config.yaml` for an existing
+folder.
+
 See `optics_framework/samples/` for ready-made configs: `contact` (Appium/Android),
 `gmail_web` (Selenium), `playwright` (Playwright). Named elements from the project are
 loaded lazily the first time they are needed.
@@ -80,12 +84,12 @@ sleep 5
 
 | Command          | Description |
 |------------------|-------------|
-| `/save <test_case> <module_name>` | Save the recorded actions as `<module_name>` in `modules/modules.csv` and add a `(<test_case>, <module_name>)` row to `test_cases/test_cases.csv`. A header-only `elements/elements.csv` stub is created if missing. All three files use fixed names and are **appended** to when they already exist, so you can build a suite one module at a time. A successful save **clears the recording buffer**, so the next actions become the next module. If `<module_name>` or `<test_case>` already exists, the save is refused with a prompt — re-run the identical `/save` to append, or pick a different name. Session screenshots/artifacts are also snapshotted to `execution_output/<module_name>/`. |
+| `/save <test_case> <module_name>` | Save the recorded actions as `<module_name>` in `modules/modules.csv` and add a `(<test_case>, <module_name>)` row to `test_cases/test_cases.csv`. Elements are merged into your project's existing elements CSV when one is tracked anywhere (the templates keep it at `test_data/elements.csv`) — only names not already present are appended, so no second `elements/elements.csv` appears; with no elements file, a header-only `elements/elements.csv` stub is created. All three files use fixed names and are **appended** to when they already exist, so you can build a suite one module at a time. A successful save **clears the recording buffer**, so the next actions become the next module. If `<module_name>` or `<test_case>` already exists, the save is refused with a prompt — re-run the identical `/save` to append, or pick a different name. Session screenshots/artifacts are also snapshotted to `execution_output/<module_name>/`. |
 | `/device [id]`   | **Appium sessions only.** List all connected **Android** (`adb`) and **iOS** (`idevice_id`) devices, each labelled by platform; with no argument, pick one to switch the active device's `udid`. The chosen device must match the session's configured platform. For Selenium/Playwright it reports that switching doesn't apply (the target is the configured browser). |
 | `/elements`      | Open a read-only popup of named elements and their locators (Esc closes). |
 | `/screenshot`    | Capture the current device screen to a file and note the path in the history. |
 | `/help`          | Show the command reference (Esc closes). |
-| `/quit`          | End the session, run the normal driver teardown/cleanup, and exit. |
+| `/quit`, `/exit` | End the session, run the normal driver teardown/cleanup, and exit. Typing `quit` or `exit` without the slash does the same, so leaving is never a guessing game. An unknown `/command` prints the available commands instead of failing silently. |
 
 ## Keys
 

--- a/docs/usage/mcp_usage.md
+++ b/docs/usage/mcp_usage.md
@@ -12,9 +12,6 @@ It reuses the in-process keyword machinery from the REST server
 work here too. The driver is chosen at runtime via the `start_session` tool —
 nothing is hard-coded.
 
-> Verified end-to-end against a remote Appium hub on a physical Samsung A53:
-> `start_session` → `screenshot` (rendered PNG) → `swipe` → `terminate_session`.
-
 ---
 
 ## 1. Prerequisites

--- a/docs/usage/robot_usage.md
+++ b/docs/usage/robot_usage.md
@@ -10,7 +10,7 @@ Install the Optics Framework and Robot Framework:
 pip install optics-framework robotframework
 ```
 
-## Quick Start
+## Basic Example
 
 ### Basic Example
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -6,19 +6,52 @@ Below are the primary usage guides, each tailored to a specific aspect of the fr
 
 <div class="grid cards" markdown>
 
-- [CLI Usage](CLI_usage.md)
-Learn how to use the Optics Framework's command-line interface (CLI) to set up the environment, execute test cases, initialize projects, and manage configurations.
+-   :material-console: **CLI Usage**
 
-- [Library Usage](library_usage.md)
-Learn how to use the Optics Framework as a Python library for programmatic test automation, including configuration, element interactions, and session management.
+    Set up the environment, execute test cases, initialize projects, and manage configurations.
 
-- [Robot Usage](robot_usage.md)
-Discover how to use the Optics Framework with Robot Framework, including library import, keyword usage, and test organization patterns.
+    [:material-arrow-right: CLI Usage →](CLI_usage.md)
 
-- [Keyword Usage](keyword_usage.md)
-Explore the available keywords for defining test steps in test modules, including actions, verifications, and flow control operations, with detailed parameter explanations.
+-   :material-play-circle: **Live Usage**
 
-- [REST API Usage](REST_API_usage.md)
-Learn how to use the Optics Framework's REST API for programmatic interaction, including session management, keyword execution, and real-time workspace monitoring.
+    Drive a live target keyword-by-keyword in an interactive session; record straight into modules.
+
+    [:material-arrow-right: Live Usage →](live_usage.md)
+
+-   :material-format-list-bulleted: **Keyword Usage**
+
+    The full keyword catalog: actions, verifications, and flow control for test modules.
+
+    [:material-arrow-right: Keyword Usage →](keyword_usage.md)
+
+-   :material-library: **Library Usage**
+
+    Use Optics as a Python library for programmatic test automation.
+
+    [:material-arrow-right: Library Usage →](library_usage.md)
+
+-   :material-robot: **Robot Framework Usage**
+
+    Use Optics with Robot Framework: library import, keyword usage, and test organization.
+
+    [:material-arrow-right: Robot Framework Usage →](robot_usage.md)
+
+-   :material-api: **REST API Usage**
+
+    Programmatic interaction via REST: session management and real-time monitoring.
+
+    [:material-arrow-right: REST API Usage →](REST_API_usage.md)
+
+-   :material-connection: **MCP Usage**
+
+    Expose every keyword as an MCP tool so an AI client drives a real target.
+
+    [:material-arrow-right: MCP Usage →](mcp_usage.md)
+
+-   :material-alert-circle: **Error Detection**
+
+    Define crash dialogs and network errors; Optics scans visible text and reports to JUnit.
+
+    [:material-arrow-right: Error Detection →](error_detection.md)
 
 </div>

--- a/docs/user_workflow.md
+++ b/docs/user_workflow.md
@@ -1,20 +1,10 @@
 # User Workflow
 
-This guide walks you through the workflow for using the Optics Framework to create and execute automated tests. The framework relies on a CSV-based structure and a YAML configuration file to define test cases, modules, and elements.
+This page traces one concrete project end to end: how its test cases, modules, elements, and `config.yaml` fit together, and how they flow through `dry_run` and `execute`. For installation and first-time setup, see [Getting Started](getting-started.md); for every configuration field, see [Configuration Reference](configuration.md).
 
-## Initial Setup
+## The Worked Example: YouTube
 
-To begin, the Optics Framework requires a YAML configuration file (`config.yaml`) and CSV files to define your tests. You can bootstrap a project using the `optics init` command:
-
-```bash
-optics init --name my_project --template contact
-```
-
-- **--name**: Specifies the project name (required).
-- **--path**: Directory where the project folder is created (default: current directory).
-- **--template**: (Optional) Copy a complete sample project (`contact`, `clock`, `calendar`, `youtube`, `gmail_web`, `playwright`).
-
-With `--template`, the project is a ready-to-run copy of that sample. Without it, `optics init` scaffolds the subdirectory layout (`test_cases/`, `modules/`, `test_data/`) plus a commented starter `config.yaml` for you to fill in.
+Everything below comes from the bundled `youtube` sample, which drives the real YouTube Android app three ways at once: by on-screen text, by XPath, and by image matching. Create it with `optics quickstart` (pick the `youtube` starting point) or `optics init my_project --template youtube`.
 
 ## CSV Use Cases
 
@@ -210,7 +200,7 @@ A Selenium-based sample that automates Gmail sign-in and account creation. It in
 To check for syntactical errors in your CSV files and configuration, run a dry run:
 
 ```bash
-optics dry_run ./contact
+optics dry_run ./youtube
 ```
 
 `dry_run` takes a project folder (not a single test case). It simulates execution without interacting with the device — validating that every keyword exists and every `${element}` resolves — helping you catch issues early.
@@ -220,9 +210,9 @@ optics dry_run ./contact
 Once validated, execute your tests with:
 
 ```bash
-optics execute ./contact
+optics execute ./youtube
 ```
 
-- **./contact**: Path to your project directory. The runner discovers test cases, modules, and config from this folder.
+- **./youtube**: Path to your project directory. The runner discovers test cases, modules, and config from this folder.
 
 Output, including logs, will be saved in the `execution_output/` folder.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,8 +49,8 @@ theme:
 nav:
   - Home: index.md
   - Introduction: introduction.md
-  - Installation & Prerequisites: prerequisites.md
-  - Quick Start: quickstart.md
+  - Installation: prerequisites.md
+  - Getting Started: getting-started.md
   - Configuration: configuration.md
   - User Workflow: user_workflow.md
   - Usage:

--- a/optics_framework/common/Junit_eventhandler.py
+++ b/optics_framework/common/Junit_eventhandler.py
@@ -1,4 +1,5 @@
 from optics_framework.common.events import EventSubscriber, Event, EventStatus, get_event_manager
+import json
 import xml.etree.ElementTree as ET #nosec B405
 from pathlib import Path
 from typing import List, Dict, Optional
@@ -26,13 +27,10 @@ class JUnitHandlerRegistry:
                 self._handlers[session_id].close()
                 del self._handlers[session_id]
 
-            # Only setup if JUnit logging is enabled
-            if not getattr(config, 'json_log', False):
-                return
-
             # Create session-specific output path
             junit_path = self._get_session_junit_path(session_id, config)
-            handler = JUnitEventHandler(junit_path)
+            json_log_path = self._get_json_log_path(config)
+            handler = JUnitEventHandler(junit_path, json_output_path=json_log_path)
 
             # Subscribe to session-specific EventManager
             event_manager = get_event_manager(session_id)
@@ -43,17 +41,28 @@ class JUnitHandlerRegistry:
             internal_logger.debug(f"Session {session_id} EventManager has {len(event_manager.subscribers)} subscribers: {list(event_manager.subscribers.keys())}")
 
     def _get_session_junit_path(self, session_id: str, config: Config) -> Path:
-        """Generate session-specific JUnit output path."""
-        log_dir = config.execution_output_path or (Path.cwd() / "logs")
+        """Generate the canonical JUnit XML output path.
 
-        # Use custom path if specified, otherwise create session-specific path
-        junit_path = getattr(config, 'json_log_path', None)
-        if junit_path:
-            junit_path = Path(junit_path).expanduser()
-            # Add session suffix to custom path
-            return junit_path.parent / f"{junit_path.stem}_{session_id}{junit_path.suffix}"
-        else:
-            return Path(log_dir) / f"junit_output_{session_id}.xml"
+        Falls back to a session-suffixed name when another active handler
+        already owns the canonical file in the same output directory, so
+        concurrent sessions never clobber each other's report.
+        """
+        log_dir = Path(config.execution_output_path or (Path.cwd() / "logs"))
+        junit_path = log_dir / "junit_output.xml"
+        for other_id, handler in self._handlers.items():
+            if other_id != session_id and handler.output_path == junit_path:
+                return log_dir / f"junit_output_{session_id}.xml"
+        return junit_path
+
+    def _get_json_log_path(self, config: Config) -> Optional[Path]:
+        """Generate the JSON event log output path, or None when json_log is disabled."""
+        if not getattr(config, 'json_log', False):
+            return None
+        custom_path = getattr(config, 'json_path', None)
+        if custom_path:
+            return Path(custom_path).expanduser()
+        log_dir = config.execution_output_path or (Path.cwd() / "logs")
+        return Path(log_dir) / "logs.json"
 
     def cleanup_session(self, session_id: str) -> None:
         """Cleanup JUnit handler for a specific session."""
@@ -108,8 +117,9 @@ class LogCaptureBuffer(logging.Handler):
         return self.records
 
 class JUnitEventHandler(EventSubscriber):
-    def __init__(self, output_path: Path):
+    def __init__(self, output_path: Path, json_output_path: Optional[Path] = None):
         self.output_path = output_path
+        self.json_output_path = json_output_path
         self.testsuites = ET.Element("testsuites")
         self.session_suites: Dict[str, ET.Element] = {}
         self.testcase_cases: Dict[str, ET.Element] = {}
@@ -118,6 +128,7 @@ class JUnitEventHandler(EventSubscriber):
         self.module_elements: Dict[str, ET.Element] = {}
         self.active_keyword_elements: Dict[str, ET.Element] = {}  # Per keyword_id for update during execution
         self.keyword_log_buffers: Dict[str, LogCaptureBuffer] = {}
+        self.json_events: List[Dict] = []
 
         internal_logger.debug(f"Initialized JUnitEventHandler with output: {self.output_path}")
 
@@ -125,6 +136,7 @@ class JUnitEventHandler(EventSubscriber):
     async def on_event(self, event: Event) -> None:
         internal_logger.debug(
             f"JUnitEventHandler received event: {event.model_dump()}")
+        self.json_events.append(event.model_dump())
         session_id = event.extra.get("session_id") if event.extra else None
         if not session_id and event.entity_type == "test_case":
             internal_logger.warning(
@@ -202,6 +214,9 @@ class JUnitEventHandler(EventSubscriber):
 
         kw_element = ET.SubElement(module_kw, "kw", name=event.name, status=event.status.value)
 
+        if event.status == EventStatus.FAIL and event.message:
+            kw_element.set("message", event.message)
+
         if event.start_time:
             kw_element.set("starttime", time.strftime('%Y%m%d %H:%M:%S', time.localtime(event.start_time)))
         if event.end_time:
@@ -269,6 +284,16 @@ class JUnitEventHandler(EventSubscriber):
         session_suite.set("tests", str(int(session_suite.get("tests", "0")) + 1))
         session_suite.set("failures", str(int(session_suite.get("failures", "0")) + len(detected)))
 
+    def _flush_json(self):
+        if self.json_output_path is None:
+            return
+        try:
+            self.json_output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.json_output_path, "w", encoding="utf-8") as f:
+                json.dump(self.json_events, f, indent=2)
+        except Exception as e:
+            internal_logger.error(f"Failed to flush JSON events: {str(e)}")
+
     def flush(self):
         try:
             internal_logger.debug(f"Flushing Robot-style XML to {self.output_path}")
@@ -283,6 +308,7 @@ class JUnitEventHandler(EventSubscriber):
                 f.write(pretty_xml)
         except Exception as e:
             internal_logger.error(f"Failed to flush Robot-style XML: {str(e)}")
+        self._flush_json()
 
     def close(self):
         self.flush()

--- a/optics_framework/common/config_handler.py
+++ b/optics_framework/common/config_handler.py
@@ -1,11 +1,11 @@
 import os
 from collections.abc import Mapping
-import logging
-from typing import List, Dict, Any, Optional
-import yaml
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel, Field
-from optics_framework.common.logging_config import initialize_handlers
+
 from optics_framework.common.error import OpticsError, Code
+from optics_framework.common.logging_config import initialize_handlers
 
 
 class DependencyConfig(BaseModel):
@@ -86,9 +86,15 @@ class Config(BaseModel):
         """
         return getattr(self, key, default)
 
+
 def deep_merge(c1: Config, c2: Config) -> Config:
     """
     Recursively merge two Config objects, giving priority to c2.
+
+    Note on list-valued keys: a list in ``c2`` REPLACES the one in ``c1``
+    wholesale — it is not merged item-by-item. This matters for a project's
+    ``driver_sources``/``elements_sources`` etc.: a project that lists its
+    sources overrides the defaults' source list rather than appending to it.
     """
     d1 = c1.model_dump()
     d2 = c2.model_dump()
@@ -111,7 +117,14 @@ def deep_merge(c1: Config, c2: Config) -> Config:
 
 
 class ConfigHandler:
-    DEFAULT_GLOBAL_CONFIG_PATH = os.path.expanduser("~/.optics/global_config.yaml")
+    """Holds a project's resolved configuration.
+
+    Configuration is always project-specific: the runner loads a project's own
+    ``config.yaml`` directly (see ``optics execute``/``optics.py``). There is no
+    global config layer anymore — the old ``~/.optics/global_config.yaml`` was
+    edited by ``optics config`` but never read on the execution path, so it has
+    been removed."""
+
     DEPENDENCY_KEYS: List[str] = [
         "driver_sources",
         "elements_sources",
@@ -122,7 +135,6 @@ class ConfigHandler:
 
     def __init__(self, config: Config):
         self.project_name: Optional[str] = None
-        self.global_config_path: str = self.DEFAULT_GLOBAL_CONFIG_PATH
         if config.execution_output_path is None:
             if config.project_path is not None:
                 config.execution_output_path = os.path.join(
@@ -142,27 +154,6 @@ class ConfigHandler:
     def set_project(self, project_name: str) -> None:
         self.project_name = project_name
 
-
-    def _ensure_global_config(self) -> None:
-        if not os.path.exists(self.global_config_path):
-            os.makedirs(os.path.dirname(self.global_config_path), exist_ok=True)
-            with open(self.global_config_path, "w", encoding="utf-8") as f:
-                yaml.dump(self.config.model_dump(), f, default_flow_style=False)
-
-    def load(self) -> Config:
-        default_config = Config()
-        global_config = self._load_yaml(self.global_config_path)
-        if global_config is None:
-            global_config = Config()
-        project_config = self.config
-        merged = deep_merge(default_config, global_config)
-        self.config = deep_merge(merged, project_config)
-        self._precompute_enabled_configs()
-
-        if hasattr(merged, "execution_output_path"):
-            self.config.execution_output_path = merged.execution_output_path
-        return self.config
-
     def update_config(self, new_config: dict) -> None:
         """
         Update the current configuration with a new configuration dictionary or Config object.
@@ -178,18 +169,6 @@ class ConfigHandler:
         merged_config = deep_merge(current_config, new_config_obj)
         self.config = merged_config
         self._precompute_enabled_configs()
-
-
-    def _load_yaml(self, path: str) -> Optional[Config]:
-        if os.path.exists(path):
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    data = yaml.safe_load(f) or {}
-                    return Config(**data)
-            except (yaml.YAMLError, IOError) as e:
-                logging.error(f"Error parsing YAML file {path}: {e}")
-                return None
-        return None
 
     def _is_enabled(self, details: Any) -> bool:
         """Check if a configuration is enabled."""
@@ -218,8 +197,3 @@ class ConfigHandler:
         if key in self.DEPENDENCY_KEYS:
             return self._enabled_configs.get(key, default if default is not None else [])
         return getattr(self.config, key, default)
-
-    def save_config(self) -> None:
-        os.makedirs(os.path.dirname(self.global_config_path), exist_ok=True)
-        with open(self.global_config_path, "w", encoding="utf-8") as f:
-            yaml.dump(self.config.model_dump(), f, default_flow_style=False)

--- a/optics_framework/common/execution.py
+++ b/optics_framework/common/execution.py
@@ -77,6 +77,7 @@ class BatchExecutor(Executor):
                 message=message,
                 extra={"session_id": session.session_id}
             ))
+            return runner.result_printer.test_state
         except Exception as e:
             await event_manager.publish_event(Event(
                 entity_type="execution",
@@ -127,6 +128,7 @@ class DryRunExecutor(Executor):
             message=message,
             extra={"session_id": session.session_id}
         ))
+        return runner.result_printer.test_state
 
 
 def _deserialize_single_param(param_value: str, param_type: Any) -> Any:

--- a/optics_framework/common/logging_config.py
+++ b/optics_framework/common/logging_config.py
@@ -281,5 +281,25 @@ def reconfigure_logging(config):
     initialize_handlers(config)
 
 
+def quiet_console_logs():
+    """
+    Raise the console handlers to WARNING so teardown records can no longer
+    reach the terminal once the result printer has rendered its final summary.
+    File handlers keep their configured levels and still record everything.
+    """
+    logging_manager.internal_console_handler.setLevel(logging.WARNING)
+    logging_manager.execution_console_handler.setLevel(logging.WARNING)
+
+
+def restore_console_logs():
+    """
+    Restore console handler levels (used when a new live render starts so
+    mid-run records are visible on the console again).
+    """
+    logging_manager.internal_console_handler.setLevel(internal_logger.level)
+    logging_manager.execution_console_handler.setLevel(execution_logger.level)
+
+
 __all__ = ["internal_logger","execution_logger",
-           "reconfigure_logging", "LoggerContext", "SessionLoggerAdapter"]
+           "reconfigure_logging", "quiet_console_logs", "restore_console_logs",
+           "LoggerContext", "SessionLoggerAdapter"]

--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -1,8 +1,9 @@
 import csv
 import yaml
 import re
+import inspect
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Union, List, Tuple, cast
+from typing import Callable, Optional, Dict, Union, List, Tuple, cast
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.models import (
     ApiData,
@@ -28,29 +29,6 @@ class DataReader(ABC):
         pass
 
     @staticmethod
-    def get_keyword_params(param_strings: List[str]) -> Dict[str, str]:
-        """
-        Parses a list of params (string) and filters only keyword params (i.e in format key=value) and returns them as a Dictionary
-        """
-        args = {}
-        for param in param_strings:
-            if DataReader.is_keyword_param(param):
-                arg_name, value = param.split("=", 1)
-                args[arg_name.strip()] = value.strip()
-        return args
-
-    @staticmethod
-    def get_positional_params(param_strings: List[str]) -> List[str]:
-        """
-        Parses a list of params (string) and returns a list of positional params (i.e not in key=value format)
-        """
-        args = []
-        for param in param_strings:
-            if not DataReader.is_keyword_param(param):
-                args.append(param.strip())
-        return args
-
-    @staticmethod
     def is_keyword_param(param: str) -> bool:
         """
         Checks if a parameter string is in key=value format.
@@ -64,6 +42,37 @@ class DataReader(ABC):
             return False
         # Must have a single = that is not part of ==, !=, <=, >=
         return bool(re.search(r'(?<![=!<>])=(?!=)', param))
+
+    @staticmethod
+    def split_params_by_signature(
+        method: Callable, param_strings: List[str]
+    ) -> Tuple[List[str], Dict[str, str]]:
+        """Split params into (positional, keyword) using the target method's signature.
+
+        A ``key=value`` token is treated as a keyword argument only when ``key``
+        names an actual parameter of ``method``; otherwise the whole token stays
+        positional. This keeps locator strategies such as ``text=...``,
+        ``css=...`` or ``id=...`` as the keyword's positional ``element`` argument
+        (they merely happen to contain ``=``) while still honouring genuine
+        keyword arguments like ``event_name=...`` or ``timeout=...``. When the
+        signature cannot be read the historical behaviour is kept (every
+        ``key=value`` is a keyword argument).
+        """
+        try:
+            valid: Optional[set] = set(inspect.signature(method).parameters)
+        except (TypeError, ValueError):
+            valid = None
+        positional: List[str] = []
+        keywords: Dict[str, str] = {}
+        for param in param_strings:
+            if DataReader.is_keyword_param(param):
+                key, value = param.split("=", 1)
+                key = key.strip()
+                if valid is None or key in valid:
+                    keywords[key] = value.strip()
+                    continue
+            positional.append(param.strip())
+        return positional, keywords
 
     @abstractmethod
     def read_test_cases(self, file_path: str) -> dict:

--- a/optics_framework/common/runner/printers.py
+++ b/optics_framework/common/runner/printers.py
@@ -10,6 +10,7 @@ from rich.panel import Panel
 from rich.progress import Progress, TaskID
 from rich.console import Group
 from rich import get_console
+from optics_framework.common.logging_config import quiet_console_logs, restore_console_logs
 
 
 class TestCaseResult(BaseModel):
@@ -34,6 +35,7 @@ class ModuleResult(BaseModel):
     name: str
     elapsed: str
     status: str
+    reason: str = ""
     keywords: List[KeywordResult] = Field(default_factory=list)
 
 
@@ -192,6 +194,36 @@ class TreeResultPrinter(IResultPrinter):
             Text(status_part, style=self.STATUS_COLORS.get(status, "white"))
         )
 
+    def _failure_detail_lines(self) -> List[str]:
+        """One line per failed step (and any step carrying a recorded reason)."""
+        lines: List[str] = []
+        for tc_result in self.test_state.values():
+            for module in tc_result.modules:
+                lines.extend(
+                    self._module_failure_lines(tc_result.name, module))
+        return lines
+
+    @staticmethod
+    def _module_failure_lines(test_name: str,
+                              module: ModuleResult) -> List[str]:
+        lines: List[str] = []
+        if module.status == "FAIL" and module.reason:
+            lines.append(
+                f"{test_name} → step '{module.name}' — {module.reason}")
+        for keyword in module.keywords:
+            line = TreeResultPrinter._keyword_failure_line(test_name, keyword)
+            if line is not None:
+                lines.append(line)
+        return lines
+
+    @staticmethod
+    def _keyword_failure_line(test_name: str,
+                              keyword: KeywordResult) -> Optional[str]:
+        if keyword.status != "FAIL" and not keyword.reason:
+            return None
+        detail = f" — {keyword.reason}" if keyword.reason else ""
+        return f"{test_name} → step '{keyword.resolved_name}'{detail}"
+
     def _render_tree(self) -> Group:
         tree = Tree("Test Suite", style="bold white")
         for tc_result in self.test_state.values():
@@ -217,7 +249,15 @@ class TreeResultPrinter(IResultPrinter):
         summary_text = f"Total Test Cases: {total} | Passed: {passed} | Failed: {failed}"
         summary_panel = Panel(
             summary_text, style="green" if failed == 0 else "red")
-        return Group(self.progress, tree, summary_panel)
+        renderables = [self.progress, tree, summary_panel]
+        failure_lines = self._failure_detail_lines()
+        if failure_lines:
+            renderables.append(Panel(
+                Text("\n".join(failure_lines), style="red"),
+                title="Failure details",
+                border_style="red",
+            ))
+        return Group(*renderables)
 
     def print_tree_log(self, test_case_result: TestCaseResult) -> None:
         self.test_state[test_case_result.name] = test_case_result
@@ -234,6 +274,7 @@ class TreeResultPrinter(IResultPrinter):
 
     def start_live(self) -> None:
         if not self._live:
+            restore_console_logs()
             console = get_console()
             console.force_terminal = True
             self._live = Live(self._render_tree(
@@ -244,3 +285,4 @@ class TreeResultPrinter(IResultPrinter):
         if self._live:
             self._live.stop()
             self._live = None
+            quiet_console_logs()

--- a/optics_framework/common/runner/test_runnner.py
+++ b/optics_framework/common/runner/test_runnner.py
@@ -3,6 +3,7 @@ import os
 import time
 import uuid
 import asyncio
+import difflib
 import tempfile
 import shutil
 import sys
@@ -113,6 +114,7 @@ class TestRunner(Runner):
         self.result_printer = result_printer
         self.config = session.config
         self.event_manager = event_manager
+        self._last_failure_reason: Optional[str] = None
         if hasattr(self.modules, "modules"):
             execution_logger.debug(
                 "Initialized test_state: %s with %d modules",
@@ -121,13 +123,40 @@ class TestRunner(Runner):
             )
         self._initialize_test_state()
 
+    def _safe_resolve_param(self, param: str) -> str:
+        try:
+            return self.resolve_param(param)
+        except (ValueError, OpticsError):
+            return param
+
+    def _note_failure(self, reason: str) -> None:
+        """Record the latest failure reason and log it so failures aren't silent."""
+        self._last_failure_reason = reason
+        execution_logger.error(reason)
+
+    def _suggest_keyword(self, name: str) -> str:
+        """Return a 'Did you mean ...?' hint for an unknown keyword, else empty."""
+        func_name = "_".join(name.split()).lower()
+        matches = difflib.get_close_matches(
+            func_name, list(self.keyword_map), n=1, cutoff=0.6)
+        if not matches:
+            return ""
+        pretty = matches[0].replace("_", " ").title()
+        return f" Did you mean '{pretty}'? (run `optics list` to see all keywords)"
+
+    def _unknown_step_reason(self, name: str) -> str:
+        """Reason for a step that resolves to neither a module nor a keyword."""
+        reason = f"Unknown keyword or module: '{name}'"
+        hint = self._suggest_keyword(name)
+        return f"{reason}.{hint}" if hint else reason
+
     def _initialize_test_state(self) -> None:
         def _init_keywords(module_node):
             keywords = []
             current_keyword = module_node.keywords_head
             while current_keyword:
                 resolved_params = [
-                    self.resolve_param(param) for param in current_keyword.params
+                    self._safe_resolve_param(param) for param in current_keyword.params
                 ]
                 resolved_name = (
                     f"{current_keyword.name} ({', '.join(str(p) for p in resolved_params)})"
@@ -237,6 +266,17 @@ class TestRunner(Runner):
                     f"Keyword id {keyword_id} not found in module {module_name}"
                 )
         raise ValueError(f"Module {module_name} not found in test_state")
+
+    def _step_resolves(self, module_name: str) -> bool:
+        definition = (
+            self.modules.get_module_definition(module_name)
+            if self.modules is not None
+            else None
+        )
+        if definition:
+            return True
+        func_name = "_".join(module_name.split()).lower()
+        return func_name in self.keyword_map
 
     def _update_status(
         self,
@@ -377,11 +417,14 @@ class TestRunner(Runner):
 
     async def _handle_keyword_not_found(self, keyword_node, module_node, keyword_result, start_time, test_case_result):
         keyword_node.state = State.COMPLETED_FAILED
+        reason = f"Keyword not found: {keyword_node.name}.{self._suggest_keyword(keyword_node.name)}"
+        self._note_failure(reason)
+        keyword_result.reason = reason
         await self._send_event(
             "keyword",
             keyword_node,
             EventStatus.FAIL,
-            reason=f"Keyword not found: {keyword_node.name}",
+            reason=reason,
             parent_id=module_node.id,
             start_time=start_time,
             end_time=time.time(),
@@ -408,11 +451,14 @@ class TestRunner(Runner):
 
     async def _handle_element_not_found(self, keyword_node, module_node, keyword_result, start_time, test_case_result, var_name, capture_handler):
         keyword_node.state = State.COMPLETED_FAILED
+        reason = f"Element not found: {var_name}"
+        self._note_failure(reason)
+        keyword_result.reason = reason
         await self._send_event(
             "keyword",
             keyword_node,
             EventStatus.FAIL,
-            f"Element not found: {var_name}",
+            reason,
             parent_id=module_node.id,
             start_time=start_time,
             end_time=time.time(),
@@ -432,7 +478,7 @@ class TestRunner(Runner):
             if attempts > MAX_ATTEMPTS:
                 break
             try:
-                resolved_positional_params, resolved_kw_params = self._resolve_candidate_params(candidate_args)
+                resolved_positional_params, resolved_kw_params = self._resolve_candidate_params(method, candidate_args)
                 method(*resolved_positional_params, **resolved_kw_params)
                 keyword_node.state = State.COMPLETED_PASSED
                 await self._send_event(
@@ -461,11 +507,14 @@ class TestRunner(Runner):
 
     async def _handle_keyword_exception(self, keyword_node, module_node, keyword_result, start_time, test_case_result, exc, capture_handler):
         keyword_node.state = State.COMPLETED_FAILED
+        reason = f"Keyword '{keyword_node.name}' failed: {exc}"
+        self._note_failure(reason)
+        keyword_result.reason = reason
         await self._send_event(
             "keyword",
             keyword_node,
             EventStatus.FAIL,
-            f"Keyword '{keyword_node.name}' failed: {exc}",
+            reason,
             parent_id=module_node.id,
             start_time=start_time,
             end_time=time.time(),
@@ -476,11 +525,14 @@ class TestRunner(Runner):
 
     async def _handle_fallback_exhausted(self, keyword_node, module_node, keyword_result, start_time, test_case_result, capture_handler):
         keyword_node.state = State.COMPLETED_FAILED
+        reason = f"Keyword '{keyword_node.name}' failed after fallback attempts"
+        self._note_failure(reason)
+        keyword_result.reason = reason
         await self._send_event(
             "keyword",
             keyword_node,
             EventStatus.FAIL,
-            f"Keyword '{keyword_node.name}' failed after fallback attempts",
+            reason,
             parent_id=module_node.id,
             start_time=start_time,
             end_time=time.time(),
@@ -489,7 +541,33 @@ class TestRunner(Runner):
         )
         self._update_status(keyword_result, "FAIL", time.time() - start_time, test_case_result.name)
 
+    def _end_of_run_driver_open(self) -> bool:
+        """Best-effort check that the driver session is still alive.
+
+        Drivers expose their live handle as ``page`` (Playwright) or ``driver``
+        (Appium/Selenium); a present-but-None handle means the run's own teardown
+        already terminated it, so capture attempts would only raise. Handles must
+        be read off the wrapper's ``active_instance`` -- ``InstanceFallback``
+        routes attribute access through ``__getattr__``, which hides the real
+        value behind a generated callable.
+        """
+        driver_fallback = getattr(self.session, "driver", None)
+        if driver_fallback is None:
+            return False
+        active_driver = getattr(driver_fallback, "active_instance", None)
+        driver = active_driver if active_driver is not None else driver_fallback
+        return all(
+            getattr(driver, attr) is not None
+            for attr in ("page", "driver")
+            if hasattr(driver, attr)
+        )
+
     def _capture_end_of_run_artifacts(self) -> None:
+        if not self._end_of_run_driver_open():
+            internal_logger.debug(
+                "End-of-run artifact capture skipped: driver session unavailable."
+            )
+            return
         try:
             output_dir = self.session.config.execution_output_path
             strategy_manager = StrategyManager(
@@ -509,7 +587,7 @@ class TestRunner(Runner):
             utils.save_screenshot(screenshot, "end_of_run", output_dir)
             internal_logger.debug("End-of-run screenshot saved.")
         except Exception as e:
-            internal_logger.warning("Failed to capture end-of-run screenshot: %s", e)
+            internal_logger.warning("End-of-run screenshot skipped: %s", e)
 
     def _save_end_of_run_pagesource(
         self, strategy_manager: StrategyManager, output_dir: str
@@ -523,7 +601,7 @@ class TestRunner(Runner):
             internal_logger.debug("End-of-run page source saved.")
             return page_source, timestamp
         except Exception as e:
-            internal_logger.warning("Failed to capture end-of-run page source: %s", e)
+            internal_logger.warning("End-of-run page source skipped: %s", e)
             return None, None
 
     def _run_end_of_run_detection(
@@ -574,6 +652,26 @@ class TestRunner(Runner):
             module_result, "RUNNING", time.time() - start_time, test_case_result.name
         )
 
+        if not self._step_resolves(module_node.name):
+            module_node.state = State.COMPLETED_FAILED
+            reason = self._unknown_step_reason(module_node.name)
+            self._note_failure(reason)
+            module_result.reason = reason
+            await self._send_event(
+                "module",
+                module_node,
+                EventStatus.FAIL,
+                reason=reason,
+                parent_id=test_case_result.id,
+                start_time=start_time,
+                end_time=time.time(),
+                elapsed=time.time() - start_time,
+            )
+            self._update_status(
+                module_result, "FAIL", time.time() - start_time, test_case_result.name
+            )
+            return False
+
         current = module_node.keywords_head
         while current:
             extra["keyword"] = current.name
@@ -585,6 +683,7 @@ class TestRunner(Runner):
                     "module",
                     module_node,
                     EventStatus.FAIL,
+                    reason=self._last_failure_reason,
                     parent_id=test_case_result.id,
                     start_time=start_time,
                     end_time=time.time(),
@@ -618,6 +717,7 @@ class TestRunner(Runner):
         self, test_case: str, dry_run: bool = False
     ) -> TestCaseResult:
         start_time = time.time()
+        self._last_failure_reason = None
         testcase_id = str(uuid.uuid4())
         extra = self._extra(test_case)
         test_case_result = self._init_test_case(test_case)
@@ -669,6 +769,7 @@ class TestRunner(Runner):
                         "test_case",
                         current,
                         EventStatus.FAIL,
+                        reason=self._last_failure_reason,
                         start_time=start_time,
                         end_time=time.time(),
                         elapsed=time.time() - start_time,
@@ -689,6 +790,7 @@ class TestRunner(Runner):
                         "test_case",
                         current,
                         EventStatus.FAIL,
+                        reason=self._last_failure_reason,
                         start_time=start_time,
                         end_time=time.time(),
                         elapsed=time.time() - start_time,
@@ -734,6 +836,24 @@ class TestRunner(Runner):
         )
         self._update_status(module_result, "RUNNING", 0.0, test_case_result.name)
 
+        if not self._step_resolves(module_node.name):
+            module_node.state = State.COMPLETED_FAILED
+            reason = self._unknown_step_reason(module_node.name)
+            self._note_failure(reason)
+            module_result.reason = reason
+            await self._send_event(
+                "module",
+                module_node,
+                EventStatus.FAIL,
+                reason=reason,
+                parent_id=testcase_id,
+                start_time=start_time,
+                end_time=time.time(),
+                elapsed=time.time() - start_time,
+            )
+            self._update_status(module_result, "FAIL", 0.0, test_case_result.name)
+            return False
+
         keyword_current = module_node.keywords_head
         while keyword_current:
             keyword_result = self._find_result(
@@ -761,14 +881,19 @@ class TestRunner(Runner):
                     )
                 func_name = "_".join(keyword_current.name.split()).lower()
                 if func_name not in self.keyword_map:
-                    raise ValueError("Keyword not found")
-            except ValueError as e:
+                    raise ValueError(
+                        f"Keyword not found: {keyword_current.name}."
+                        f"{self._suggest_keyword(keyword_current.name)}")
+            except (ValueError, OpticsError) as e:
+                reason = getattr(e, "message", None) or str(e)
+                self._note_failure(reason)
+                keyword_result.reason = reason
                 keyword_current.state = State.COMPLETED_FAILED
                 await self._send_event(
                     "keyword",
                     keyword_current,
                     EventStatus.FAIL,
-                    str(e),
+                    reason,
                     parent_id=module_node.id,
                     start_time=start_time,
                     end_time=time.time(),
@@ -823,9 +948,9 @@ class TestRunner(Runner):
             current = current.next
         self.result_printer.stop_live()
 
-    def _resolve_candidate_params(self, candidate_args):
-        kw_params = DataReader.get_keyword_params(list(candidate_args))
-        positional_params = DataReader.get_positional_params(list(candidate_args))
+    def _resolve_candidate_params(self, method, candidate_args):
+        positional_params, kw_params = DataReader.split_params_by_signature(
+            method, list(candidate_args))
         resolved_positional_params = [self.resolve_param(param) for param in positional_params]
         resolved_kw_params = {}
         for key, value in kw_params.items():
@@ -988,7 +1113,7 @@ class PytestRunner(Runner):
             if attempts > MAX_ATTEMPTS:
                 break
             try:
-                resolved_positional_params, resolved_kw_params = self._resolve_candidate_params(candidate_args)
+                resolved_positional_params, resolved_kw_params = self._resolve_candidate_params(method, candidate_args)
                 method(*resolved_positional_params, **resolved_kw_params)
                 self._queue_keyword_pass_event(keyword, keyword_id, module_id)
                 return True
@@ -1028,9 +1153,9 @@ class PytestRunner(Runner):
         self._queue_event_fail(keyword, keyword_id, module_id, msg)
         pytest.fail(msg)
 
-    def _resolve_candidate_params(self, candidate_args):
-        kw_params = DataReader.get_keyword_params(list(candidate_args))
-        positional_params = DataReader.get_positional_params(list(candidate_args))
+    def _resolve_candidate_params(self, method, candidate_args):
+        positional_params, kw_params = DataReader.split_params_by_signature(
+            method, list(candidate_args))
         resolved_positional_params = [self.resolve_param(param) for param in positional_params]
         resolved_kw_params = {}
         for key, value in kw_params.items():

--- a/optics_framework/common/session_manager.py
+++ b/optics_framework/common/session_manager.py
@@ -40,14 +40,15 @@ def _get_enabled_config_list(config: object, attr_name: str) -> list:
 def _maybe_setup_junit(
     config: Config, session_id: str, execution_output_path: Optional[str]
 ) -> None:
-    """Configure json_path and call setup_junit when json_log and output path are set."""
-    if not (config.json_log is True and execution_output_path is not None):
+    """Configure json_path when json_log is enabled and enable JUnit event logging for the session."""
+    if execution_output_path is None:
         return
-    config.json_path = (
-        str(Path(config.json_path).expanduser())
-        if config.json_path
-        else str((Path(execution_output_path) / "logs.json").expanduser())
-    )
+    if config.json_log is True:
+        config.json_path = (
+            str(Path(config.json_path).expanduser())
+            if config.json_path
+            else str((Path(execution_output_path) / "logs.json").expanduser())
+        )
     setup_junit(session_id, config)
 
 

--- a/optics_framework/engines/elementsources/playwright_page_source.py
+++ b/optics_framework/engines/elementsources/playwright_page_source.py
@@ -90,9 +90,7 @@ class PlaywrightPageSource(ElementSourceInterface):
         Returns:
             Tuple[str, str]: (page_source, timestamp)
         """
-        internal_logger.error("trying get_page_source ..............")
         page = self._require_page()
-        internal_logger.error("trying get_page_source _require_page ..............")
         timestamp = utils.get_timestamp()
 
         html: str = run_async(page.content())

--- a/optics_framework/helper/autocompletion.py
+++ b/optics_framework/helper/autocompletion.py
@@ -1,6 +1,9 @@
 import os
+import sys
 from pathlib import Path
 from typing import Optional
+
+from rich.prompt import Confirm
 
 from optics_framework.helper.initialize import available_templates
 
@@ -10,7 +13,10 @@ from optics_framework.helper.initialize import available_templates
 ZSH_COMPLETION_CONTENT = r"""# Description: Zsh completion script for the Optics CLI tool
 local -a _optics_subcommands=(
   'list: List available API methods'
-  'config: Manage configuration'
+  'configure: Edit a project config.yaml (guided prompts or --edit TUI)'
+  'config: Deprecated alias for configure'
+  'doctor: Diagnose a project setup (engines, config, tooling)'
+  'quickstart: Guided walkthrough to create and configure a first project'
   'dry_run: Run tests in dry-run mode'
   'init: Initialize a new project'
   'execute: Execute tests'
@@ -47,8 +53,22 @@ _optics_completions() {
       ;;
     args)
       case $words[2] in
-        list|config|completion)
+        list|config|completion|quickstart)
           _arguments '--help[-h]'
+          ;;
+
+        configure)
+          _arguments \
+            '*:project_folder:_files -/' \
+            '--edit[Launch the full-field Textual editor]' \
+            '--help[-h]'
+          ;;
+
+        doctor)
+          _arguments \
+            '*:project_folder:_files -/' \
+            '--check[Exit non-zero if any check fails]' \
+            '--help[-h]'
           ;;
 
         live)
@@ -75,7 +95,8 @@ _optics_completions() {
 
         init)
           _arguments \
-            '--name=[Project name]' \
+            '1:project_name:' \
+            '--name=[Project name (deprecated; use the positional)]' \
             '--path=[Project path]' \
             '--force[Override existing]' \
             "--template=[Template name]:template:(${templates[@]})" \
@@ -127,7 +148,7 @@ _optics_completions() {
   local cur prev words cword
   _init_completion || return
 
-  local subcommands="list config dry_run init execute live generate setup serve mcp completion"
+  local subcommands="list configure config doctor quickstart dry_run init execute live generate setup serve mcp completion"
 
   local template_options="__OPTICS_TEMPLATES_BASH__"
   local runner_options="test_runner pytest"
@@ -146,8 +167,24 @@ _optics_completions() {
   esac
 
   case ${COMP_WORDS[1]} in
-    list|config|completion)
+    list|config|completion|quickstart)
       COMPREPLY=( $(compgen -W "--help -h" -- "$cur") )
+      ;;
+
+    configure)
+      if [[ $cur == -* ]]; then
+        COMPREPLY=( $(compgen -W "--edit -h --help" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -d -- "$cur") )
+      fi
+      ;;
+
+    doctor)
+      if [[ $cur == -* ]]; then
+        COMPREPLY=( $(compgen -W "--check -h --help" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -d -- "$cur") )
+      fi
       ;;
 
     live)
@@ -240,7 +277,20 @@ def write_completion_scripts():
     bash_path.write_text(_render(BASH_COMPLETION_CONTENT))
     return zsh_path, bash_path
 
+def _manual_instruction(rc_file: Path, source_line: str) -> str:
+    """The copy-pasteable fallback shown when the rc file is left untouched."""
+    return (f"To enable manually, add this line to {rc_file}:\n"
+            f"  {source_line.strip()}")
+
+
 def update_shell_rc(shell: Optional[str] = None):
+    """Enable shell autocompletion — with consent.
+
+    The ``~/.optics/optics_completion.*`` scripts are always generated. The
+    rc-file mutation itself is gated: with a TTY stdin the user is asked
+    before anything is appended, and a decline (or a non-TTY stdin, which
+    cannot answer prompts) leaves the rc file untouched and prints the manual
+    ``source`` line instead."""
     zsh_path, bash_path = write_completion_scripts()
     home = Path.home()
     if shell is None:
@@ -264,6 +314,12 @@ def update_shell_rc(shell: Optional[str] = None):
         if any(source_line.strip() in line.strip() for line in lines):
             print(f"Autocompletion already enabled in {rc_file}")
             return
+
+    if not sys.stdin.isatty() or not Confirm.ask(
+        f"Add autocompletion to {rc_file}?", default=True
+    ):
+        print(_manual_instruction(rc_file, source_line))
+        return
 
     with open(rc_file, "a", encoding="utf-8") as f:
         f.write(f"\n# Optics CLI autocompletion\n{source_line}")

--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -1,17 +1,21 @@
 import argparse
+import os
 import sys
 from typing import Literal, Optional
 from pydantic import BaseModel
 from optics_framework.helper.list_keyword import main as list_main
-from optics_framework.helper.config_manager import main as config_main
 from optics_framework.helper.initialize import create_project, available_templates
 from optics_framework.helper.version import VERSION
 from optics_framework.helper.execute import execute_main, dryrun_main
 from optics_framework.helper.live import live_main
 from optics_framework.helper.generate import generate_test_file as generate_framework_code
-from optics_framework.helper.setup import EngineInstallerApp, SetupError, list_engines, install_extras, resolve_engines
+from optics_framework.helper.setup import EngineInstallerApp, SetupError, list_engines, install_extras, resolve_engines, print_install_next_steps
 from optics_framework.helper.serve import run_uvicorn_server
 from optics_framework.helper.autocompletion import update_shell_rc
+from optics_framework.helper.config_manager import configure as configure_project
+from optics_framework.helper.onboarding import welcome, is_first_run, mark_onboarded
+from optics_framework.helper.doctor import run_doctor
+from optics_framework.helper.quickstart import run_quickstart
 
 
 class Command:
@@ -181,13 +185,74 @@ class MCPCommand(Command):
             port=mcp_args.port
         )
 
-class ConfigCommand(Command):
+class ConfigureCommand(Command):
     def register(self, subparsers: argparse._SubParsersAction):
-        parser = subparsers.add_parser("config", help="Manage configuration")
+        parser = subparsers.add_parser(
+            "configure", help="Edit a project's config.yaml (beginner prompts or --edit TUI)"
+        )
+        parser.add_argument(
+            "folder", nargs="?", default=None,
+            help="Project folder whose config.yaml to edit (default: current directory)",
+        )
+        parser.add_argument(
+            "--edit", action="store_true",
+            help="Launch the full-field Textual editor instead of the guided prompts",
+        )
         parser.set_defaults(func=self.execute)
 
     def execute(self, args):
-        config_main()
+        configure_project(folder=args.folder, edit=args.edit)
+
+
+class ConfigCommand(Command):
+    """Deprecated alias for ``optics configure``.
+
+    ``optics config`` used to edit a global file the runner never read. It now
+    forwards to the project-scoped guided configuration in the current directory
+    with a deprecation notice, so existing muscle memory keeps working."""
+
+    def register(self, subparsers: argparse._SubParsersAction):
+        parser = subparsers.add_parser(
+            "config", help="Manage configuration (deprecated; use `configure`)"
+        )
+        parser.set_defaults(func=self.execute)
+
+    def execute(self, args):
+        print(
+            "`optics config` is deprecated; use `optics configure [folder]` — "
+            "answering a few questions to configure the project in the current directory."
+        )
+        configure_project(folder=os.getcwd(), edit=False)
+
+
+class DoctorCommand(Command):
+    def register(self, subparsers: argparse._SubParsersAction):
+        parser = subparsers.add_parser(
+            "doctor", help="Diagnose a project's setup (engines, config, tooling)"
+        )
+        parser.add_argument(
+            "folder", nargs="?", default=None,
+            help="Project folder to diagnose (default: current directory)",
+        )
+        parser.add_argument(
+            "--check", action="store_true",
+            help="Non-interactive: exit non-zero if any check fails",
+        )
+        parser.set_defaults(func=self.execute)
+
+    def execute(self, args):
+        raise SystemExit(run_doctor(folder=args.folder, check=args.check))
+
+
+class QuickstartCommand(Command):
+    def register(self, subparsers: argparse._SubParsersAction):
+        parser = subparsers.add_parser(
+            "quickstart", help="Guided walkthrough to create and configure a first project"
+        )
+        parser.set_defaults(func=self.execute)
+
+    def execute(self, args):
+        run_quickstart()
 
 
 class InitArgs(BaseModel):
@@ -202,8 +267,12 @@ class InitArgs(BaseModel):
 class InitCommand(Command):
     def register(self, subparsers: argparse._SubParsersAction):
         parser = subparsers.add_parser("init", help="Initialize a new project")
-        parser.add_argument("--name", required=True,
-                            help="Project name (required)")
+        parser.add_argument(
+            "name_positional", nargs="?", default=None,
+            help="Project name (positional, preferred)",
+        )
+        parser.add_argument("--name", dest="name_flag", default=None,
+                            help="Project name (deprecated; pass it as a positional instead)")
         parser.add_argument(
             "--path", help="Directory where the project will be created"
         )
@@ -222,8 +291,33 @@ class InitCommand(Command):
         parser.set_defaults(func=self.execute)
 
     def execute(self, args):
+        positional = args.name_positional
+        flag = args.name_flag
+        if positional is not None and flag is not None and positional != flag:
+            raise ValueError(
+                f"Conflicting project names: '{positional}' (positional) vs "
+                f"'{flag}' (--name). Pass the name once."
+            )
+        if positional is not None:
+            name = positional
+        elif flag is not None:
+            # Soft deprecation: keep --name working, nudge toward the positional.
+            print(
+                "Note: `--name` is deprecated; use a positional, e.g. "
+                "`optics init myproject`."
+            )
+            name = flag
+        elif sys.stdin.isatty():
+            name = input("Project name: ").strip()
+            if not name:
+                raise ValueError("A project name is required.")
+        else:
+            name = sys.stdin.readline().strip()
+            if not name:
+                raise ValueError("A project name is required (pass it as a positional).")
+
         init_args = InitArgs(
-            name=args.name,
+            name=name,
             path=args.path,
             force=args.force,
             template=args.template,
@@ -242,7 +336,7 @@ class DryRunArgs(BaseModel):
 class DryRunCommand(Command):
     def register(self, subparsers: argparse._SubParsersAction):
         parser = subparsers.add_parser(
-            "dry_run", help="Execute test cases from CSV files"
+            "dry_run", help="Validate a project's test cases without running them"
         )
         parser.add_argument(
             "folder_path", type=str, help="Path to the folder containing CSV files"
@@ -379,15 +473,16 @@ class EngineInstaller(Command):
                 engines, invalid = resolve_engines(args.install)
             except SetupError as exc:
                 print(f"Error: {exc}")
-                return
+                sys.exit(1)
             if invalid:
                 print(f"Error: Invalid engine(s): {', '.join(invalid)}")
                 print("Use `optics setup --list` to see available engines")
-                return
+                sys.exit(1)
             success, message = install_extras(engines)
             print(message)
             if not success:
                 sys.exit(1)
+            print_install_next_steps()
         else:
             EngineInstallerApp().run()
 
@@ -414,7 +509,10 @@ def main():
     # Register all commands.
     commands = [
         ListCommand(),
+        ConfigureCommand(),
         ConfigCommand(),
+        DoctorCommand(),
+        QuickstartCommand(),
         DryRunCommand(),
         InitCommand(),
         ExecuteCommand(),
@@ -439,13 +537,26 @@ def main():
             print(f"Argument error: {e}", file=sys.stderr)
             sys.exit(2)
         except ValueError as e:
-            print(f"Value error: {e}", file=sys.stderr)
+            print(f"Error: {e}", file=sys.stderr)
             sys.exit(3)
         except Exception as e:
-            print(f"Unexpected error: {e}", file=sys.stderr)
+            print(f"Unexpected error ({type(e).__name__}): {e}", file=sys.stderr)
+            print(
+                "Run `optics doctor` to check your setup, "
+                "or `optics <command> --help` for usage.",
+                file=sys.stderr,
+            )
             sys.exit(1)
     elif len(sys.argv) == 1:
-        parser.print_help()
+        # Bare `optics`: greet first-timers with the full banner, then mark
+        # them onboarded. Returning users get a one-line hint instead — they
+        # already know the golden path. `optics --help` is handled by argparse
+        # above and is left untouched.
+        if is_first_run():
+            welcome(first_run=True)
+            mark_onboarded()
+        else:
+            print("Run `optics quickstart` to start a project, or `optics --help` for everything else.")
 
 
 if __name__ == "__main__":

--- a/optics_framework/helper/config_manager.py
+++ b/optics_framework/helper/config_manager.py
@@ -1,13 +1,47 @@
+import os
+
+import yaml
+from rich.prompt import Confirm
 from textual.app import App, ComposeResult
-from textual.widgets import Header, Footer, ListView, ListItem, Label, Input, Button, Static
-from textual.containers import Vertical, Horizontal, Container
+from textual.containers import Container, Horizontal, Vertical
 from textual.screen import ModalScreen
-from optics_framework.common.config_handler import ConfigHandler, Config, DependencyConfig
-import ast
+from textual.widgets import Button, Footer, Header, Input, Label, ListView, ListItem, Static
+
+from optics_framework.common.config_handler import Config, ConfigHandler, DependencyConfig
+
+_CONFIG_LIST_ID = "#config-list"
+
+
+def _project_config_path(folder: str) -> str:
+    """Absolute path to a project's ``config.yaml``."""
+    return os.path.join(folder, "config.yaml")
+
+
+def _load_project_config(folder: str) -> Config:
+    """Read ``<folder>/config.yaml`` into a :class:`Config`.
+
+    A missing file yields the built-in defaults (every source present but
+    disabled); a malformed file logs and also falls back to defaults so the
+    editor stays usable instead of crashing on a broken project."""
+    path = _project_config_path(folder)
+    if not os.path.exists(path):
+        return Config()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (yaml.YAMLError, OSError):
+        return Config()
+    return Config(**data)
 
 
 class QuitConfirmScreen(ModalScreen[bool]):
     """Modal screen to confirm quitting without saving."""
+
+    BINDINGS = [
+        ("y", "confirm_yes", "Yes"),
+        ("n", "confirm_no", "No"),
+        ("escape", "confirm_no", "No"),
+    ]
 
     def compose(self) -> ComposeResult:
         yield Vertical(
@@ -22,6 +56,12 @@ class QuitConfirmScreen(ModalScreen[bool]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.dismiss(event.button.id == "yes")
+
+    def action_confirm_yes(self) -> None:
+        self.dismiss(True)
+
+    def action_confirm_no(self) -> None:
+        self.dismiss(False)
 
 
 class ErrorScreen(ModalScreen[None]):
@@ -43,8 +83,15 @@ class ErrorScreen(ModalScreen[None]):
             self.dismiss(None)
 
 
-class LoggerTUI(App):
-    """A Textual-based UI for editing logger configuration."""
+class ProjectConfigTUI(App):
+    """A Textual-based UI for editing a PROJECT's ``config.yaml``.
+
+    Unlike the old global-file editor, this reads and writes the project's own
+    ``config.yaml`` — the file the runner actually loads — so edits here take
+    effect on the next ``optics execute``/``dry_run``."""
+
+    TITLE = "optics configure"
+
     CSS = """
     Screen {
         align: center middle;
@@ -97,26 +144,28 @@ class LoggerTUI(App):
     """
 
     BINDINGS = [
-        ("up", "move_up", "Move up"),
-        ("down", "move_down", "Move down"),
         ("space", "edit", "Edit value"),
         ("s", "save", "Save config"),
         ("q", "quit", "Quit"),
     ]
 
-    def __init__(self):
+    def __init__(self, folder: str):
         super().__init__()
-        self.config_handler = ConfigHandler(config=Config())
-        self.config_handler.load()
-        self.options = list(self.config_handler.config.model_fields.keys())
-        self.selected_index = 0  # Changed to plain int
+        self.folder = folder
+        self.config_path = _project_config_path(folder)
+        self.config = _load_project_config(folder)
+        self.options = list(self.config.model_fields.keys())
+        self._editing_key: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static(
-            f"Editing GLOBAL config: {self.config_handler.global_config_path}\n"
-            "Note: `optics execute <folder>` reads that folder's own config.yaml, "
-            "not this global file.",
+            f"Editing PROJECT config: {self.config_path}\n"
+            "This is the file `optics execute`/`dry_run` read.",
+            classes="option-label",
+        )
+        yield Static(
+            "↑/↓ move · Space edits the highlighted field · S saves · Q quits",
             classes="option-label",
         )
         yield ListView(*[ListItem(Label(f"{key}: {self.get_value(key)}", classes="option-label"))
@@ -124,45 +173,51 @@ class LoggerTUI(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        self.query_one("#config-list").focus()
+        self.query_one(_CONFIG_LIST_ID).focus()
 
     def get_value(self, key: str) -> str:
-        """Fetch and format the current config value."""
-        value = getattr(self.config_handler.config, key)
-        if key in self.config_handler.DEPENDENCY_KEYS:
-            return str(self.config_handler.get(key))
+        """Fetch and format the current config value.
+
+        Dependency-list keys show their enabled source names (e.g.
+        ``['appium']``) instead of the full nested structure — the part a
+        user is actually tuning."""
+        value = getattr(self.config, key)
+        if key in ConfigHandler.DEPENDENCY_KEYS and isinstance(value, list):
+            enabled = [
+                name for item in value
+                for name, details in item.items()
+                if getattr(details, "enabled", False)
+            ]
+            return str(enabled)
         return str(value)
 
-    def action_move_up(self) -> None:
-        self.selected_index = max(0, self.selected_index - 1)
-        self.refresh_list()
-
-    def action_move_down(self) -> None:
-        self.selected_index = min(
-            len(self.options) - 1, self.selected_index + 1)
-        self.refresh_list()
+    def _current_index(self) -> int:
+        """The row the user has highlighted — ListView owns navigation."""
+        index = self.query_one(_CONFIG_LIST_ID, ListView).index
+        return index if index is not None else 0
 
     def refresh_list(self) -> None:
-        list_view = self.query_one("#config-list", ListView)
+        list_view = self.query_one(_CONFIG_LIST_ID, ListView)
         for idx, key in enumerate(self.options):
             list_view.children[idx].query_one(Label).update(
                 f"{key}: {self.get_value(key)}")
-        list_view.index = self.selected_index
 
     async def action_edit(self) -> None:
-        key = self.options[self.selected_index]
-        current_value = getattr(self.config_handler.config, key)
+        key = self.options[self._current_index()]
+        current_value = getattr(self.config, key)
 
         if isinstance(current_value, bool):
-            setattr(self.config_handler.config, key, not current_value)
+            setattr(self.config, key, not current_value)
             self.refresh_list()
         else:
+            self._editing_key = key
             input_widget = Input(placeholder=str(
                 current_value), id="edit-input")
             confirm_button = Button(
                 "Confirm", variant="success", id="confirm-edit")
             self.mount(
                 Container(input_widget, confirm_button, classes="editing"))
+            input_widget.focus()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         self.handle_edit_confirm(event.value)
@@ -173,36 +228,46 @@ class LoggerTUI(App):
             self.handle_edit_confirm(input_value)
 
     def handle_edit_confirm(self, new_value: str) -> None:
-        key = self.options[self.selected_index]
-        current_value = getattr(self.config_handler.config, key)
+        key = self._editing_key or self.options[self._current_index()]
+        current_value = getattr(self.config, key)
 
         try:
-            if isinstance(current_value, list) and key in self.config_handler.DEPENDENCY_KEYS:
+            if isinstance(current_value, list) and key in ConfigHandler.DEPENDENCY_KEYS:
+                import ast
                 parsed = ast.literal_eval(new_value)
                 if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
                     raise ValueError("Must be a list of strings")
                 # Each entry must be keyed by the actual source name (e.g. "appium"),
                 # not the literal "name" — otherwise every source collapses to one
                 # unresolvable key.
-                setattr(self.config_handler.config, key,
+                setattr(self.config, key,
                         [{source: DependencyConfig(enabled=True)} for source in parsed])
             else:
                 parsed = type(current_value)(new_value)
-                setattr(self.config_handler.config, key, parsed)
+                setattr(self.config, key, parsed)
             self.refresh_list()
         except Exception as e:
             self.push_screen(ErrorScreen(
                 f"Invalid input: {e}"), lambda _: None)
         finally:
             self.query_one(".editing").remove()
+            self._editing_key = None
 
     def action_save(self) -> None:
         try:
-            self.config_handler.save_config()
+            self._save_to_disk()
             self.exit(0)
         except Exception as e:
             self.push_screen(ErrorScreen(
                 f"Error saving config: {e}"), lambda _: None)
+
+    def _save_to_disk(self) -> None:
+        # NOTE: rewriting config.yaml via yaml.safe_dump loses any YAML comments
+        # the user wrote. This is acceptable for the --edit power-user path; the
+        # beginner path (`optics configure`) writes a freshly rendered config.
+        os.makedirs(self.folder, exist_ok=True)
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(self.config.model_dump(), f, default_flow_style=False)
 
     async def action_quit(self) -> None:
         self.push_screen(QuitConfirmScreen(), self.handle_quit)
@@ -212,5 +277,41 @@ class LoggerTUI(App):
             self.exit(0)
 
 
-def main():
-    LoggerTUI().run()
+def configure(folder: str | None = None, edit: bool = False) -> None:
+    """Edit a project's ``config.yaml``.
+
+    ``edit=False`` (the default, beginner path) confirms before overwriting an
+    existing ``config.yaml`` — BEFORE any question is asked, so declining
+    wastes no answers — then walks the user through
+    :func:`prompt_project_config`, writes the rendered result and prints next
+    steps.
+
+    ``edit=True`` launches the full-field Textual editor on the project's
+    ``config.yaml`` for power users.
+    """
+    target = folder if folder is not None else os.getcwd()
+
+    if edit:
+        ProjectConfigTUI(target).run()
+        return
+
+    from optics_framework.helper.onboarding import print_next_steps
+    from optics_framework.helper.project_config import (
+        prompt_project_config,
+        render_project_config,
+        write_project_config,
+    )
+
+    config_path = _project_config_path(target)
+    if os.path.exists(config_path) and not Confirm.ask(
+        f"{config_path} already exists. Overwrite it?", default=False
+    ):
+        print("Aborted; existing config left unchanged.")
+        return
+
+    answers = prompt_project_config()
+    text = render_project_config(answers)
+
+    write_project_config(target, text)
+    print(f"Wrote {config_path}")
+    print_next_steps(target, configured=True)

--- a/optics_framework/helper/doctor.py
+++ b/optics_framework/helper/doctor.py
@@ -1,0 +1,467 @@
+"""``optics doctor`` — a friendly environment and project health check.
+
+Doctor answers two beginner questions: "is my machine ready?" and "is my
+project set up correctly?". Machine checks (Python, engines, adb/Appium,
+browser binaries) are best-effort and report warnings — a fresh machine should
+get a readable to-do list, not a wall of failures. Project checks
+(``validate_project``) are the strict ones: a structurally broken config.yaml
+is reported as a failure and makes ``run_doctor(check=True)`` exit non-zero so
+CI can gate on it.
+
+Project configs are parsed with plain ``yaml.safe_load`` — doctor deliberately
+never constructs ``ConfigHandler``, because its constructor creates an
+``execution_output/`` directory as a side effect and a diagnostic command must
+not mutate the project it is inspecting.
+"""
+import os
+import shutil
+import socket
+import subprocess  # nosec B404
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import NamedTuple
+from urllib.parse import urlparse
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from optics_framework.helper.setup import ALL_ENGINES, DISTRIBUTION_NAME
+
+_console = Console()
+
+_SOCKET_TIMEOUT_S = 3.0
+_ADB_TIMEOUT_S = 10.0
+
+_STATUS_GLYPH = {
+    "ok": "[green]✅[/green]",
+    "warn": "[yellow]⚠️[/yellow] ",
+    "fail": "[red]❌[/red]",
+}
+
+_ADB_DEVICES = "adb devices"
+_APPIUM_SERVER = "appium server"
+_PLAYWRIGHT_BROWSER = "playwright browser"
+_SELENIUM_WEBDRIVER = "selenium webdriver"
+_CONFIG_DRIVER = "config: driver"
+
+
+class Check(NamedTuple):
+    """One row of the doctor report."""
+    name: str
+    status: str  # "ok" | "warn" | "fail"
+    detail: str
+    hint: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Environment checks                                                           #
+# --------------------------------------------------------------------------- #
+
+def check_core() -> list[Check]:
+    """Python and optics-framework itself.
+
+    The Python row is informational only — it never fails, because the package
+    cannot even be imported below the supported pin, so a failing row would
+    never be seen anyway."""
+    py = sys.version_info
+    rows = [
+        Check("python", "ok", f"{py.major}.{py.minor}.{py.micro}",
+              "informational — optics needs Python 3.12+"),
+    ]
+    try:
+        rows.append(Check("optics-framework", "ok",
+                          f"installed, version {version(DISTRIBUTION_NAME)}"))
+    except PackageNotFoundError:
+        rows.append(Check("optics-framework", "warn",
+                          "not installed as a package (source checkout?)",
+                          "pip install optics-framework"))
+    return rows
+
+
+def check_engines() -> list[Check]:
+    """One row per known engine backend, keyed on its primary pip package."""
+    rows: list[Check] = []
+    for backend in ALL_ENGINES.values():
+        package = backend.packages[0]
+        try:
+            rows.append(Check(backend.name, "ok", f"{package} {version(package)}"))
+        except PackageNotFoundError:
+            rows.append(Check(backend.name, "warn", f"{package} not installed",
+                              f"optics setup --install {backend.extra}"))
+    return rows
+
+
+def check_mobile(host: str = "127.0.0.1", port: int = 4723) -> list[Check]:
+    """Android tooling (adb + attached devices) and Appium reachability.
+
+    Everything here is advisory: adb only matters for Android users and an
+    unstarted Appium server is a normal state before the first mobile run."""
+    rows: list[Check] = []
+    adb = shutil.which("adb")
+    if adb is None:
+        rows.append(Check(
+            "adb", "warn", "not found on PATH",
+            "Install Android platform-tools (needed to drive Android devices)."))
+    else:
+        rows.append(Check("adb", "ok", f"found at {adb}"))
+        rows.append(_adb_devices_row(adb))
+    rows.append(_appium_row(host, port))
+    return rows
+
+
+def check_web() -> list[Check]:
+    """Browser-binary presence for the web drivers, best-effort.
+
+    A pip package being installed says nothing about whether its browser was
+    downloaded, so anything short of a confirmed binary is a warning."""
+    return [_playwright_row(), _selenium_row()]
+
+
+def _adb_devices_row(adb: str) -> Check:
+    try:
+        result = subprocess.run(  # nosec B603
+            [adb, "devices"], capture_output=True, text=True,
+            timeout=_ADB_TIMEOUT_S, check=False, shell=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return Check(_ADB_DEVICES, "warn", f"could not run adb: {exc}",
+                     "Check your platform-tools installation.")
+    serials = _parse_adb_devices(result.stdout)
+    if serials is None:
+        first_line = next((line.strip() for line in result.stdout.splitlines()
+                           if line.strip()), "(no output)")
+        return Check(_ADB_DEVICES, "warn",
+                     f"unexpected adb output: {first_line}",
+                     "Check your platform-tools installation.")
+    if serials:
+        return Check(_ADB_DEVICES, "ok",
+                     f"{len(serials)} connected: {', '.join(serials)}")
+    return Check(_ADB_DEVICES, "warn", "no devices attached",
+                 "Connect a device or start an emulator (USB debugging on).")
+
+
+def _parse_adb_devices(stdout: str) -> list[str] | None:
+    """Serials in the ``device`` state from `adb devices` output.
+
+    Returns None when the device-list header is absent. Real adb prints
+    "List of devices attached"; anything else is a daemon banner or an error
+    message, which must not be mistaken for "zero devices attached"."""
+    serials: list[str] = []
+    in_list = False
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("List of devices attached"):
+            in_list = True
+            continue
+        if in_list and stripped:
+            parts = stripped.split()
+            if len(parts) >= 2 and parts[1] == "device":
+                serials.append(parts[0])
+    return serials if in_list else None
+
+
+def _appium_row(host: str, port: int) -> Check:
+    try:
+        socket.create_connection((host, port), timeout=_SOCKET_TIMEOUT_S).close()
+    except OSError:
+        return Check(_APPIUM_SERVER, "warn", f"not reachable at {host}:{port}",
+                     "Start it in another terminal with the `appium` command.")
+    return Check(_APPIUM_SERVER, "ok", f"reachable at {host}:{port}")
+
+
+def _playwright_row() -> Check:
+    try:
+        version("playwright")
+    except PackageNotFoundError:
+        return Check(_PLAYWRIGHT_BROWSER, "warn",
+                     "Playwright package not installed",
+                     "optics setup --install playwright")
+    if _playwright_chromium_downloaded():
+        return Check(_PLAYWRIGHT_BROWSER, "ok", "Chromium download found")
+    return Check(_PLAYWRIGHT_BROWSER, "warn",
+                 "package installed, but no Chromium download detected",
+                 "playwright install chromium  (or: optics setup --install playwright)")
+
+
+def _playwright_chromium_downloaded() -> bool:
+    home = os.path.expanduser("~")
+    cache_dirs = (
+        os.path.join(home, "Library", "Caches", "ms-playwright"),  # macOS
+        os.path.join(home, ".cache", "ms-playwright"),  # Linux
+    )
+    for base in cache_dirs:
+        try:
+            entries = os.listdir(base)
+        except OSError:
+            continue
+        if any(name.startswith("chromium") for name in entries):
+            return True
+    return False
+
+
+def _selenium_row() -> Check:
+    try:
+        version("selenium")
+    except PackageNotFoundError:
+        return Check(_SELENIUM_WEBDRIVER, "warn",
+                     "Selenium package not installed",
+                     "optics setup --install selenium")
+    driver = shutil.which("chromedriver") or shutil.which("geckodriver")
+    if driver:
+        return Check(_SELENIUM_WEBDRIVER, "ok", f"driver found at {driver}")
+    return Check(_SELENIUM_WEBDRIVER, "warn",
+                 "package installed, but no WebDriver binary on PATH",
+                 "Install a browser with a matching driver (e.g. chromedriver).")
+
+
+# --------------------------------------------------------------------------- #
+# Project checks                                                               #
+# --------------------------------------------------------------------------- #
+
+def _load_project_yaml(folder: str) -> tuple[dict | None, str | None]:
+    """Read ``<folder>/config.yaml`` with plain yaml.safe_load. Returns
+    ``(data, None)`` or ``(None, reason)`` — never constructs ConfigHandler,
+    whose constructor would create execution_output/ as a side effect."""
+    path = os.path.join(folder, "config.yaml")
+    if not os.path.isfile(path):
+        return None, f"no config.yaml in {folder}"
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (yaml.YAMLError, OSError) as exc:
+        return None, f"could not parse config.yaml: {exc}"
+    if not isinstance(data, dict):
+        return None, "config.yaml is not a mapping"
+    return data, None
+
+
+def _enabled_entries(section: object) -> dict[str, dict]:
+    """Map of name → entry for every ``enabled: true`` item in a dependency
+    section (a list of single-key mappings)."""
+    enabled: dict[str, dict] = {}
+    for entry in section or []:
+        if isinstance(entry, dict):
+            for name, cfg in entry.items():
+                if isinstance(cfg, dict) and cfg.get("enabled") is True:
+                    enabled[str(name)] = cfg
+    return enabled
+
+
+def validate_project(folder: str) -> list[Check]:
+    """Lint ``<folder>/config.yaml`` structurally.
+
+    Checks that exactly one driver is enabled, that it has at least one
+    matching ``<driver>_*`` element source, and that the settings needed to
+    open a session are present. Failing rows are what ``run_doctor(check=True)``
+    turns into a non-zero exit."""
+    data, error = _load_project_yaml(folder)
+    if error:
+        return [Check("config: file", "fail", error,
+                      "Re-create the project with `optics quickstart`.")]
+
+    rows: list[Check] = []
+    drivers = _enabled_entries(data.get("driver_sources"))
+    sources = set(_enabled_entries(data.get("elements_sources")))
+    if not drivers:
+        rows.append(Check(
+            _CONFIG_DRIVER, "fail", "no driver enabled",
+            "Set enabled: true under exactly one driver_sources entry."))
+    elif len(drivers) > 1:
+        rows.append(Check(
+            _CONFIG_DRIVER, "warn", f"{len(drivers)} drivers enabled "
+            f"({', '.join(sorted(drivers))})",
+            "Enable exactly one unless you deliberately want driver fallback."))
+    else:
+        rows.append(Check(_CONFIG_DRIVER, "ok",
+                          f"{next(iter(drivers))} enabled"))
+
+    for driver, cfg in sorted(drivers.items()):
+        rows.append(_source_row(driver, sources))
+        rows.append(_settings_row(driver, cfg))
+
+    if all(row.status == "ok" for row in rows):
+        rows.append(Check("config: project", "ok",
+                          "driver, element sources and settings look runnable"))
+    return rows
+
+
+def _source_row(driver: str, enabled_sources: set[str]) -> Check:
+    matching = sorted(s for s in enabled_sources if s.startswith(f"{driver}_"))
+    if matching:
+        return Check(f"config: {driver} element source", "ok",
+                     f"enabled: {', '.join(matching)}")
+    return Check(f"config: {driver} element source", "fail",
+                 f"no {driver}_* element source enabled",
+                 "Enable at least one matching entry under elements_sources.")
+
+
+def _settings_row(driver: str, cfg: dict) -> Check:
+    name = f"config: {driver} settings"
+    problems: list[str] = []
+    fatal = False
+    if driver in ("appium", "selenium") and not cfg.get("url"):
+        problems.append("url is missing")
+        fatal = True
+    caps = cfg.get("capabilities") or {}
+    if driver == "appium":
+        problems.extend(
+            f"{key} missing in capabilities"
+            for key in ("deviceName", "platformName")
+            if not caps.get(key))
+        # iOS launches apps by bundleId — without one XCUITest has nothing to
+        # launch, so it is a hard failure; Android keeps the historical
+        # appPackage/appActivity requirements at their existing severity.
+        if str(caps.get("platformName", "")).lower() == "ios":
+            if not caps.get("bundleId"):
+                problems.append("bundleId missing in capabilities")
+                fatal = True
+        else:
+            problems.extend(
+                f"{key} missing in capabilities"
+                for key in ("appPackage", "appActivity")
+                if not caps.get(key))
+    if driver == "playwright" and not caps.get("browser"):
+        problems.append("capabilities.browser missing (chromium is the default)")
+    if not problems:
+        return Check(name, "ok", "required settings present")
+    return Check(name, "fail" if fatal else "warn", "; ".join(problems),
+                 "Edit config.yaml in this project folder.")
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                       #
+# --------------------------------------------------------------------------- #
+
+_NO_CONFIG_HINT = ("Run `optics quickstart` to create a project, "
+                   "or pass a project folder")
+
+_DRIVER_ROW_NAMES = {
+    "selenium": (_SELENIUM_WEBDRIVER,),
+    "playwright": (_PLAYWRIGHT_BROWSER,),
+}
+
+
+def _enabled_driver_names(folder: str) -> set[str]:
+    """Names of the drivers the project's config enables (empty when there is
+    no readable config — e.g. a bare `optics doctor` with no folder)."""
+    data, _ = _load_project_yaml(folder)
+    if data is None:
+        return set()
+    return set(_enabled_entries(data.get("driver_sources")))
+
+
+def _mandatory_hints(rows: list[Check], drivers: set[str]) -> list[str]:
+    """Hints of warnings on an ENABLED driver's must-have pieces.
+
+    A warning for something the user never enabled (say, Playwright's browser
+    while they drive Appium) is an optional extra; a warning for their own
+    driver's server/device/browser blocks the first real run and gets called
+    out in the closing message. Order follows the rows, deduplicated."""
+    hints: list[str] = []
+    for row in rows:
+        if row.status != "warn" or not row.hint:
+            continue
+        mandatory = (
+            ("appium" in drivers
+             and (row.name == _APPIUM_SERVER
+                  or (row.name == _ADB_DEVICES
+                      and "no devices attached" in row.detail)))
+            or any(row.name in names
+                   for driver, names in _DRIVER_ROW_NAMES.items()
+                   if driver in drivers)
+        )
+        if mandatory and row.hint not in hints:
+            hints.append(row.hint)
+    return hints
+
+
+def _appium_target(folder: str) -> tuple[str, int] | None:
+    """(host, port) of the project's enabled appium url, or None when the
+    project doesn't drive appium (or its url is unusable)."""
+    data, _ = _load_project_yaml(folder)
+    if data is None:
+        return None
+    for driver, cfg in _enabled_entries(data.get("driver_sources")).items():
+        if driver == "appium":
+            return _split_host_port(cfg.get("url"))
+    return None
+
+
+def _split_host_port(url: object) -> tuple[str, int] | None:
+    if not isinstance(url, str) or not url.strip():
+        return None
+    try:
+        # "//" (not http://) lets urlparse read a bare host:port as a netloc.
+        parsed = urlparse(url if "://" in url else f"//{url}")
+        return parsed.hostname or "127.0.0.1", parsed.port or 4723
+    except ValueError:
+        return None
+
+
+def _print_report(rows: list[Check], mandatory_hints: list[str]) -> None:
+    """Print the report table, the counts line and the closing message.
+
+    ``mandatory_hints`` carries the warnings on the ENABLED driver's own
+    requirements; when non-empty the reassurance line is replaced by a
+    targeted call-to-action listing them."""
+    table = Table(title="🩺 optics doctor", header_style="bold")
+    table.add_column("")
+    table.add_column("Check")
+    table.add_column("Details")
+    table.add_column("Hint", style="dim")
+    for row in rows:
+        table.add_row(_STATUS_GLYPH.get(row.status, "•"),
+                      row.name, row.detail, row.hint)
+    _console.print(table)
+
+    counts = {status: sum(1 for r in rows if r.status == status)
+              for status in ("ok", "warn", "fail")}
+    _console.print(
+        f"{counts['ok']} ok, {counts['warn']} warning(s), {counts['fail']} failure(s)")
+    if counts["fail"]:
+        _console.print("[red]Fix the ❌ rows above, then re-run optics doctor.[/red]")
+    elif counts["warn"]:
+        if mandatory_hints:
+            _console.print("[yellow]⚠️ Before your first real run:[/yellow]")
+            for hint in mandatory_hints:
+                _console.print(f"  • {hint}")
+        else:
+            _console.print(
+                "Good enough to start — ⚠️ rows are optional extras you can add later.")
+    else:
+        _console.print("[green]Everything looks good — happy testing![/green]")
+
+
+def run_doctor(folder: str | None = None, check: bool = False) -> int:
+    """Run every check and print the report. Returns 0, or 1 under
+    ``check=True`` when a project-config row failed (environment gaps stay
+    warnings — they are installable later and must not fail a fresh machine).
+
+    With ``folder``, the Appium probe targets that project's enabled appium
+    url (falling back to 127.0.0.1:4723) and ``validate_project`` rows are
+    appended.
+
+    Without ``folder``, the diagnosed folder is the current directory: when it
+    holds no config.yaml a ⚠️ row says so (a warning, never a --check
+    failure)."""
+    host, port = "127.0.0.1", 4723
+    if folder:
+        target = _appium_target(folder)
+        if target:
+            host, port = target
+    rows = [
+        *check_core(),
+        *check_engines(),
+        *check_mobile(host, port),
+        *check_web(),
+    ]
+    if folder:
+        rows.extend(validate_project(folder))
+    elif not os.path.isfile(os.path.join(os.getcwd(), "config.yaml")):
+        rows.append(Check("project", "warn", "No config.yaml found here",
+                          _NO_CONFIG_HINT))
+    drivers = _enabled_driver_names(folder) if folder else set()
+    _print_report(rows, _mandatory_hints(rows, drivers))
+    if check and any(row.status == "fail" for row in rows):
+        return 1
+    return 0

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -1,11 +1,17 @@
 import os
+import shutil
+import socket
+import subprocess  # nosec B404
 import sys
 import asyncio
-from typing import Optional, Tuple, List, Dict, Set, Any
+from typing import NoReturn, Optional, Tuple, List, Dict, Set, Any
+from urllib.parse import urlparse
 import yaml
 from pydantic import BaseModel, field_validator
 from pathlib import Path
-from optics_framework.common.config_handler import Config
+from rich.console import Console
+from rich.panel import Panel
+from optics_framework.common.config_handler import Config, DependencyConfig
 from optics_framework.common.logging_config import internal_logger, initialize_handlers
 from optics_framework.common.runner.data_reader import (
     CSVDataReader,
@@ -259,7 +265,10 @@ def validate_required_files(
             for f, p in [("test_cases", test_case_files), ("modules", module_files)]
             if not p
         ]
-        error_msg = f"Missing required files in {folder_path}: {', '.join(missing)}"
+        error_msg = (
+            f"Missing required files in {folder_path}: {', '.join(missing)}. "
+            "Run `optics init <name>` to scaffold a complete project."
+        )
         internal_logger.error(error_msg)
         print(f"Error: {error_msg}", file=sys.stderr)
         sys.exit(1)
@@ -466,6 +475,175 @@ def build_linked_list(
         internal_logger.error(f"Error building linked list: {e}")
         raise OpticsError(Code.E0701, message=f"Failed to build linked list: {e}", details={"exception": str(e)})
 
+_PREFLIGHT_SKIP_ENV = "OPTICS_SKIP_PREFLIGHT"
+_PREFLIGHT_SOCKET_TIMEOUT_S = 2.0
+_PREFLIGHT_ADB_TIMEOUT_S = 5.0
+_APPIUM_DEFAULT_URL = "http://127.0.0.1:4723"
+_SELENIUM_DEFAULT_URL = "http://127.0.0.1:4444/wd/hub"
+
+
+def _probe_tcp(url: str | None, default_port: int,
+               timeout: float = _PREFLIGHT_SOCKET_TIMEOUT_S) -> bool:
+    """
+    Check whether something is listening at ``url`` with a short TCP probe.
+
+    Deliberately a plain socket attempt (no HTTP round-trip, no retries): it
+    only answers "is a server reachable there?" within ``timeout`` seconds.
+    Missing or unparseable URLs count as unreachable so callers can report the
+    real fix instead of an opaque driver error minutes into the run.
+
+    :param url: Server URL from config.yaml (e.g. ``http://127.0.0.1:4723``).
+    :param default_port: Port used when the URL carries none.
+    :param timeout: Seconds to wait for the connection.
+    :return: True when the TCP connection succeeds.
+    """
+    if not url or not url.strip():
+        return False
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port or default_port
+    except ValueError:
+        return False
+    if not host:
+        return False
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _adb_device_count() -> int | None:
+    """
+    Count attached Android devices/emulators via ``adb devices``.
+
+    Counts only entries in the ``device`` state (offline/unauthorized entries
+    cannot be driven) and only after the "List of devices attached" header, so
+    daemon banners or error text are never mistaken for devices.
+
+    :return: Device count, or None when adb is missing or cannot be executed —
+             letting callers tell "no tooling installed" apart from "no device".
+    """
+    adb = shutil.which("adb")
+    if adb is None:
+        return None
+    try:
+        result = subprocess.run(  # nosec B603
+            [adb, "devices"], capture_output=True, text=True,
+            timeout=_PREFLIGHT_ADB_TIMEOUT_S, check=False, shell=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    in_list = False
+    count = 0
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("List of devices attached"):
+            in_list = True
+            continue
+        parts = stripped.split() if in_list and stripped else []
+        if len(parts) >= 2 and parts[1] == "device":
+            count += 1
+    return count if in_list else 0
+
+
+def _abort_preflight(lines: List[str]) -> NoReturn:
+    """Print a friendly rich block explaining the failure and exit non-zero."""
+    console = Console(file=sys.stderr)
+    console.print(Panel("\n".join(lines), title="Cannot start",
+                        border_style="red"))
+    sys.exit(1)
+
+
+def _preflight_or_exit(config: Config | None, folder_path: str = "<folder>") -> None:
+    """
+    Beginner-facing environment gate for ``optics execute``, run before any
+    test executes so failures surface as guidance instead of a fake
+    "Launch App | PASS".
+
+    Checks the first enabled driver from the project's config:
+
+    - playwright: self-contained, skipped silently.
+    - selenium: probes the configured WebDriver URL (~2s).
+    - appium: probes the configured Appium server URL (~2s); when capabilities
+      say Android, additionally requires adb on PATH and one attached device.
+      iOS projects get the server probe only.
+
+    On failure prints exactly what is wrong and how to fix it, then exits 1
+    without executing tests (dry_run never invokes this gate). Callers pass
+    ``None`` when no Config is available (e.g. test doubles) and the gate
+    quietly steps aside; a no-driver-enabled config is likewise left to the
+    existing gate in ``BaseRunner._setup_session``.
+
+    Set the environment variable ``OPTICS_SKIP_PREFLIGHT`` to ``1`` or
+    ``true`` to skip the entire preflight (e.g. for CI images where servers
+    are known-good or intentionally absent).
+
+    :param config: The project's resolved configuration.
+    :param folder_path: Project folder, used in the re-run hint.
+    """
+    if os.environ.get(_PREFLIGHT_SKIP_ENV, "").strip().lower() in {"1", "true"}:
+        return
+    enabled = next(
+        ((name, details)
+         for source in (config.driver_sources if config else [])
+         for name, details in source.items()
+         if details.enabled),
+        None,
+    )
+    if enabled is None or enabled[0] == "playwright":
+        return
+    name, details = enabled
+    if name == "appium":
+        _preflight_appium(details, folder_path)
+    elif name == "selenium":
+        _preflight_selenium(details, folder_path)
+
+
+def _preflight_appium(details: DependencyConfig, folder_path: str) -> None:
+    """Probe the Appium server and, for Android, adb + an attached device."""
+    url = details.url or _APPIUM_DEFAULT_URL
+    if not _probe_tcp(url, default_port=4723):
+        _abort_preflight([
+            f"No Appium server reachable at {url}.",
+            "",
+            "Start one in another terminal:  appium",
+            f"Then re-run:  optics execute {folder_path}",
+        ])
+    platform = str(details.capabilities.get("platformName", "")).lower()
+    if platform != "android":
+        return
+    device_count = _adb_device_count()
+    if device_count is None:
+        _abort_preflight([
+            "Android run requested, but the adb tool was not found.",
+            "",
+            "Install Android platform-tools (any option that puts adb on PATH),",
+            "then check:  adb devices",
+            f"Then re-run:  optics execute {folder_path}",
+        ])
+    if device_count == 0:
+        _abort_preflight([
+            "No Android device/emulator attached (adb reports none).",
+            "",
+            "Connect a device (USB debugging on) or start an emulator,",
+            "then check:  adb devices",
+            f"Then re-run:  optics execute {folder_path}",
+        ])
+
+
+def _preflight_selenium(details: DependencyConfig, folder_path: str) -> None:
+    """Probe the configured Selenium/WebDriver URL."""
+    url = details.url or _SELENIUM_DEFAULT_URL
+    if not _probe_tcp(url, default_port=4444):
+        _abort_preflight([
+            f"No Selenium/WebDriver server reachable at {url}.",
+            "",
+            "Start one, e.g.:  docker run -d -p 4444:4444 selenium/standalone",
+            f"Then re-run:  optics execute {folder_path}",
+        ])
+
+
 class RunnerArgs(BaseModel):
     """Arguments for BaseRunner initialization."""
 
@@ -609,6 +787,8 @@ class BaseRunner:
 
 
     def _filter_and_build_execution_queue(self):
+        if not self.test_cases_data:
+            self._exit_no_test_cases()
         included = self.config.get("include")
         excluded = self.config.get("exclude")
         self.filtered_test_cases: Dict[str, Any] = filter_test_cases(
@@ -618,7 +798,30 @@ class BaseRunner:
             self.filtered_test_cases, self.modules_data
         )
 
+    def _exit_no_test_cases(self) -> None:
+        """Exit with actionable guidance when the project has no test cases."""
+        message = (
+            f"No test cases to run in {self.folder_path}.\n"
+            "Your test_cases file has no rows yet — a freshly created project "
+            "starts empty.\n"
+            "Add a test case (a row in test_cases/test_cases.csv naming a module) "
+            "and define that module in modules/modules.csv, or start from a "
+            "ready-made example:\n"
+            "    optics init <name> --template <sample>   (see `optics init --help`)\n"
+            f"Then re-run:  optics dry_run {self.folder_path}"
+        )
+        internal_logger.error("No test cases found in %s", self.folder_path)
+        print(message, file=sys.stderr)
+        sys.exit(1)
+
     def _setup_session(self):
+        if not self._has_enabled_driver():
+            config_path = os.path.join(self.folder_path, "config.yaml")
+            print(
+                f"No driver enabled in {config_path}. "
+                f"Run `optics configure {self.folder_path}`, then re-run."
+            )
+            sys.exit(1)
         self.manager: SessionManager = SessionManager()
         self.session_id: str = self.manager.create_session(
             self.config,
@@ -630,6 +833,14 @@ class BaseRunner:
             self.error_definitions_data,
         )
         self.engine: ExecutionEngine = ExecutionEngine(self.manager)
+
+    def _has_enabled_driver(self) -> bool:
+        return any(
+            details.enabled
+            for source in self.config.driver_sources
+            for details in source.values()
+        )
+
     async def run(self, mode: str):
         """Run the specified mode using ExecutionEngine."""
         try:
@@ -642,7 +853,7 @@ class BaseRunner:
             internal_logger.debug(
                 f"Executing with runner_type: {self.runner}, use_printer: {self.use_printer}"
             )
-            await self.engine.execute(params)
+            return await self.engine.execute(params)
         except Exception as e:
             internal_logger.error(f"{mode.capitalize()} failed: {e}")
             raise
@@ -660,13 +871,19 @@ class BaseRunner:
 class ExecuteRunner(BaseRunner):
     async def execute(self):
         """Execute test cases."""
-        await self.run("batch")
+        return await self.run("batch")
 
 
 class DryRunRunner(BaseRunner):
     async def execute(self):
         """Perform dry run of test cases."""
-        await self.run("dry_run")
+        return await self.run("dry_run")
+
+
+def _has_failed_results(results: Any) -> bool:
+    return isinstance(results, dict) and any(
+        getattr(tc, "status", None) != "PASS" for tc in results.values()
+    )
 
 
 def execute_main(
@@ -675,7 +892,10 @@ def execute_main(
     """Entry point for execute command."""
     args = RunnerArgs(folder_path=folder_path, runner=runner, use_printer=use_printer)
     runner_instance = ExecuteRunner(args)
-    asyncio.run(runner_instance.execute())
+    _preflight_or_exit(getattr(runner_instance, "config", None), folder_path)
+    results = asyncio.run(runner_instance.execute())
+    if _has_failed_results(results):
+        sys.exit(1)
 
 
 def dryrun_main(
@@ -684,4 +904,6 @@ def dryrun_main(
     """Entry point for dry run command."""
     args = RunnerArgs(folder_path=folder_path, runner=runner, use_printer=use_printer)
     runner_instance = DryRunRunner(args)
-    asyncio.run(runner_instance.execute())
+    results = asyncio.run(runner_instance.execute())
+    if _has_failed_results(results):
+        sys.exit(1)

--- a/optics_framework/helper/generate.py
+++ b/optics_framework/helper/generate.py
@@ -11,6 +11,8 @@ from optics_framework.common.utils import unescape_csv_value
 
 TestCaseKey = "Test Cases"
 
+logger = logging.getLogger(__name__)
+
 # Type aliases for clarity
 TestCases = Dict[str, List[str]]
 Modules = Dict[str, List[Tuple[str, List[str]]]]
@@ -530,9 +532,10 @@ class FileWriter:
         tests_folder = os.path.join(folder_path, "Tests")
         os.makedirs(tests_folder, exist_ok=True)
         output_file = os.path.join(tests_folder, filename)
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(content)
-        logging.info(f"Generated test file: {output_file}")
+        logger.info(f"Generated test file: {output_file}")
 
         # Create requirements.txt in generated/ directory
         requirements = [
@@ -546,7 +549,7 @@ class FileWriter:
         requirements_file = os.path.join(folder_path, "requirements.txt")
         with open(requirements_file, "w", encoding="utf-8") as f:
             f.write("\n".join(requirements) + "\n")
-        logging.info(f"Generated requirements file: {requirements_file}")
+        logger.info(f"Generated requirements file: {requirements_file}")
 
     def copy_input_templates(self, source_folder: str, generated_folder: str) -> None:
         """
@@ -569,12 +572,12 @@ class FileWriter:
 
                 # Copy the entire input_templates folder
                 shutil.copytree(input_templates_path, destination_path)
-                logging.info(f"Copied input_templates folder to: {destination_path}")
+                logger.info(f"Copied input_templates folder to: {destination_path}")
 
             except Exception as e:
-                logging.error(f"Failed to copy input_templates folder: {e}")
+                logger.exception(f"Failed to copy input_templates folder: {e}")
         else:
-            logging.info("No input_templates folder found - skipping copy")
+            logger.debug("No input_templates folder found - skipping copy")
 
 
 def detect_file_type(file_path: str) -> Optional[Tuple[str, str]]:
@@ -601,7 +604,7 @@ def _detect_csv_type(file_path: str) -> Optional[Tuple[str, str]]:
         if "element_name" in headers and "element_id" in headers:
             return "csv", "elements"
     except Exception as e:
-        logging.error(f"Error reading CSV {file_path}: {e}")
+        logger.exception(f"Error reading CSV {file_path}: {e}")
     return None
 
 
@@ -618,7 +621,7 @@ def _detect_yaml_type(file_path: str) -> Optional[Tuple[str, str]]:
         if "Elements" in data:
             return "yaml", "elements"
     except Exception as e:
-        logging.error(f"Error reading YAML {file_path}: {e}")
+        logger.exception(f"Error reading YAML {file_path}: {e}")
     return None
 
 
@@ -778,24 +781,23 @@ def generate_test_file(
         framework (str): Target framework ('pytest' or 'robot').
         output_filename (str): Name of the output file (optional).
     """
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     # Find all files for mixed CSV/YAML support
     all_files = find_all_files(folder_path)
 
-    # Check for required files
-    if not all_files["config"]:
-        logging.error("Error: Missing config.yaml")
-        return
-    if not all_files["test_cases"]:
-        logging.error("Error: Missing test cases file")
-        return
-    if not all_files["modules"]:
-        logging.error("Error: Missing modules file")
-        return
-    if not all_files["elements"]:
-        logging.error("Error: Missing elements file")
-        return
+    required = {
+        "config.yaml": all_files["config"],
+        "test cases file": all_files["test_cases"],
+        "modules file": all_files["modules"],
+        "elements file": all_files["elements"],
+    }
+    missing = [label for label, found in required.items() if not found]
+    if missing:
+        raise ValueError(
+            f"Cannot generate: missing {', '.join(missing)} in {folder_path}. "
+            "Run `optics init <name>` to scaffold a complete project, or check the path."
+        )
 
     if framework == "pytest":
         generator = PytestGenerator()
@@ -804,8 +806,8 @@ def generate_test_file(
         generator = RobotGenerator()
         default_filename = f"test_{os.path.basename(folder_path)}.robot"
     else:
-        logging.error(f"Unsupported framework: {framework}")
-        return
+        raise ValueError(
+            f"Unsupported framework: {framework}. Use 'pytest' or 'robot'.")
 
     # Read and merge data from all files
     test_cases = read_mixed_data(all_files["test_cases"], "test_cases")

--- a/optics_framework/helper/initialize.py
+++ b/optics_framework/helper/initialize.py
@@ -1,7 +1,11 @@
 import os
+import json
 import shutil
 import subprocess # nosec
 import pathlib
+import sys
+
+from optics_framework.helper.onboarding import print_next_steps
 
 
 # Files/directories that must never be copied out of a sample template.
@@ -28,6 +32,54 @@ def available_templates() -> list[str]:
         p.name for p in samples.iterdir()
         if p.is_dir() and not _is_junk(p.name)
     )
+
+
+def _template_choices() -> list[tuple[str, str]]:
+    """Ordered ``(display_name, folder_name)`` choices for the interactive picker.
+
+    Built from ``samples/metadata.json`` (the ``displayName`` field) so the
+    picker shows friendly names ("Contacts") while still mapping back to the
+    underlying sample folder ("contact"). A "Blank project" sentinel is prepended
+    so a user can opt out of a template interactively. Falls back to folder names
+    if the metadata file is missing or malformed."""
+    choices: list[tuple[str, str]] = [("(Blank project)", "")]
+    metadata_path = _samples_dir() / "metadata.json"
+    try:
+        with open(metadata_path, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+        for sample in metadata.get("samples", []):
+            display = sample.get("displayName")
+            folder = sample.get("folderName")
+            if display and folder:
+                choices.append((display, folder))
+    except (OSError, json.JSONDecodeError):
+        # Metadata missing/corrupt: fall back to bare folder names.
+        for folder in available_templates():
+            choices.append((folder, folder))
+    return choices
+
+
+def _pick_template() -> str | None:
+    """Prompt the user to choose a template interactively.
+
+    Returns the chosen ``folderName`` (or ``""`` for Blank) on a clean pick,
+    or ``None`` if the user backs out. Only called when stdin is a TTY."""
+    choices = _template_choices()
+    print("\nChoose a starting template:")
+    for idx, (display, _) in enumerate(choices, start=1):
+        print(f"  {idx}. {display}")
+    while True:
+        raw = input(f"Select [1-{len(choices)}] (blank to cancel): ").strip()
+        if not raw:
+            return None
+        try:
+            idx = int(raw)
+        except ValueError:
+            print("Please enter a number.")
+            continue
+        if 1 <= idx <= len(choices):
+            return choices[idx - 1][1]
+        print(f"Enter a number between 1 and {len(choices)}.")
 
 
 # A commented starter config for `optics init` without a template. It mirrors the
@@ -105,20 +157,22 @@ file_log: true
 """
 
 
-def _check_and_prepare_directory(project_path: str, force: bool) -> bool:
-    """Check if project directory exists and prepare it based on force flag."""
+def _check_and_prepare_directory(project_path: str, force: bool) -> None:
+    """Check if project directory exists and prepare it based on force flag.
+
+    Raises ``ValueError`` when the path exists and ``force`` is False, so the
+    CLI maps it to a non-zero exit instead of silently skipping creation."""
     if os.path.exists(project_path):
         if force:
             shutil.rmtree(project_path)
             print(
                 f"Existing project folder removed due to --force: {project_path}")
         else:
-            print(
-                f"Project '{project_path}' already exists. Use --force to override.")
-            return False
+            raise ValueError(
+                f"Project '{project_path}' already exists."
+                " Use --force to delete it and recreate the project.")
     os.makedirs(project_path)
     print(f"Created project directory: {project_path}")
-    return True
 
 
 def _scaffold_project(project_path: str) -> None:
@@ -164,9 +218,53 @@ def _copy_template(project_path: str, template: str) -> bool:
     return True
 
 
-def create_project(args):
+def _resolve_template(args, pick_template: bool) -> tuple[str | None, bool]:
+    """Resolve the template name (or ``None`` for a blank project) before any
+    directory is created.
+
+    Returns ``(template, cancelled)``: ``cancelled`` is True when the user backed
+    out of the interactive picker, so the caller creates nothing. Raises
+    ``ValueError`` for an unknown ``--template`` — again before anything is
+    written to disk.
+    """
+    template = args.template
+    if not template and pick_template and sys.stdin.isatty():
+        picked = _pick_template()
+        if picked is None:
+            return None, True
+        template = picked or None
+    if template and template not in available_templates():
+        raise ValueError(
+            f"Template '{template}' not found. "
+            f"Available templates: {', '.join(available_templates())}")
+    return template, False
+
+
+def _init_git_repo(project_path: str, enabled: bool) -> None:
+    """Best-effort ``git init`` inside the new project when requested."""
+    if not enabled:
+        return
+    try:
+        git_path = shutil.which("git")
+        if git_path:
+            subprocess.run([git_path, "init"], cwd=project_path,  # nosec B603
+                           check=True, shell=False)
+    except FileNotFoundError:
+        print("Error: Git not found!")
+    except subprocess.CalledProcessError as e:
+        print(f"Error initializing git repository: {e}")
+
+
+def create_project(args, *, show_next_steps: bool = True,
+                   pick_template: bool = True):
     """
     Creates a new project structure for the Optics Framework.
+
+    When no ``template`` was passed, stdin is a TTY and ``pick_template`` is
+    True, an interactive picker built from ``samples/metadata.json`` offers the
+    available samples plus a blank start. The template is resolved before any
+    directory is touched, so backing out of the picker leaves no empty project
+    folder behind.
 
     Parameters
     ----------
@@ -177,41 +275,52 @@ def create_project(args):
         - force (bool, optional): If True, overrides an existing project directory.
         - template (str, optional): Name of a template to copy from `optics_framework/samples/`.
         - git_init (bool, optional): If True, initializes a Git repository in the project.
+    show_next_steps : bool, keyword-only
+        Print the "Next steps" guidance block at the end. Callers that print
+        their own next steps afterwards (e.g. ``quickstart``) pass False to
+        avoid duplicate — and for blank projects contradictory — advice.
+    pick_template : bool, keyword-only
+        Allow the interactive template picker to run when no template was
+        given. Embedded callers (e.g. ``quickstart``, which asks its own
+        template question first) pass False so ``template=None`` deterministically
+        means "blank project" instead of re-prompting whenever stdin happens
+        to be a TTY.
 
     Returns
     -------
     None
+
+    Raises
+    ------
+    ValueError
+        If the project directory already exists without ``force``, or the
+        requested template is unknown. Neither case creates anything.
     """
     project_name = args.name
     base_path = args.path if args.path else os.getcwd()
     project_path = os.path.join(base_path, project_name)
 
-    if not _check_and_prepare_directory(project_path, args.force):
+    template, cancelled = _resolve_template(args, pick_template)
+    if cancelled:
+        print("Cancelled; no project created.")
         return
 
-    # A template is a complete, runnable sample — copy it verbatim. Otherwise
-    # scaffold an empty starter project. (Previously we always scaffolded AND
-    # then copied on top, producing a confusing hybrid layout.)
-    if args.template:
-        if not _copy_template(project_path, args.template):
+    _check_and_prepare_directory(project_path, args.force)
+
+    if template:
+        if not _copy_template(project_path, template):
             return
     else:
         _scaffold_project(project_path)
 
-    if args.git_init:
-        try:
-            git_path = shutil.which("git")  # Get the absolute path of Git
-            if git_path:
-                subprocess.run([git_path, "init"], cwd=project_path,               #nosec B603
-                            check=True, shell=False)
-        except FileNotFoundError:
-            print("Error: Git not found!")
-        except subprocess.CalledProcessError as e:
-            print(f"Error initializing git repository: {e}")
+    _init_git_repo(project_path, args.git_init)
 
     print(f"\nProject ready at: {project_path}")
-    if args.template:
-        print(f"Next: review {project_name}/config.yaml, then run:  optics dry_run {project_path}")
-    else:
-        print(f"Next: enable a driver in {project_name}/config.yaml and add your "
-              f"test cases, then run:  optics dry_run {project_path}")
+    # `configured=True` when a template was copied (a ready-to-tune config.yaml
+    # exists); the scaffolded blank project still has the commented starter so
+    # the user has work to do before running.
+    if show_next_steps:
+        print_next_steps(project_path, configured=bool(template))
+        if not template:
+            print("Test steps go in test_cases/test_cases.csv — run `optics list` "
+                  "to see every available step.")

--- a/optics_framework/helper/list_keyword.py
+++ b/optics_framework/helper/list_keyword.py
@@ -19,7 +19,9 @@ def list_api_methods(package):
         module = importlib.import_module(f"{package.__name__}.{module_name}")
 
         for name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ == module.__name__:  # Ensure class belongs to this module
+            if cls.__module__ == module.__name__ and not name.startswith(
+                "_"
+            ):  # Ensure class belongs to this module and is public
                 methods = [
                     func
                     for func in dir(cls)

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -14,6 +14,7 @@ import re
 import csv
 import sys
 import time
+import difflib
 import shlex
 import shutil
 import logging
@@ -540,24 +541,24 @@ class LiveController:
         start = time.time()
         try:
             tokens = shlex.split(raw, posix=True)
-        except ValueError as exc:
-            return ActionResult(raw=raw, status=ActionStatus.FAIL, message=f"Parse error: {exc}")
+        except ValueError:
+            tokens = raw.split()
         if not tokens:
-            return ActionResult(raw=raw, status=ActionStatus.FAIL, message="Empty command")
+            return ActionResult(raw=raw, status=ActionStatus.FAIL, message="Empty input")
 
-        keyword_token, params = tokens[0], tokens[1:]
-        func_name = "_".join(keyword_token.split()).lower()
-        method = self.keyword_map.get(func_name)
-        if method is None:
+        func_name, params = self._match_keyword(tokens)
+        if func_name is None:
+            guessed = " ".join(tokens[:2])
             return ActionResult(
                 raw=raw,
-                keyword=keyword_token,
+                keyword=guessed,
                 status=ActionStatus.FAIL,
-                message=f"Unknown keyword: {keyword_token}",
+                message=self._unknown_keyword_message(guessed),
             )
 
         if any(p.startswith("${") for p in params):
             self.ensure_elements_loaded()
+        method = self.keyword_map[func_name]
 
         try:
             param_candidates = self._build_candidates(params)
@@ -600,6 +601,49 @@ class LiveController:
             execution_logger.setLevel(prev_level)
             internal_logger_obj.removeHandler(internal_capture)
 
+    def _match_keyword(self, tokens: List[str]) -> Tuple[Optional[str], List[str]]:
+        """Resolve the leading tokens to a keyword in ``self.keyword_map``.
+
+        Longest match first, so both the CSV display form (``Launch App url``)
+        and snake_case (``launch_app url``) resolve: each leading token span is
+        underscore-joined and lowercased before lookup, and the remaining
+        tokens become the parameter list.
+        """
+        for count in range(len(tokens), 0, -1):
+            candidate = "_".join(tokens[:count]).lower()
+            if candidate in self.keyword_map:
+                return candidate, tokens[count:]
+        return None, []
+
+    def _unknown_keyword_message(self, guessed: str) -> str:
+        """Actionable unknown-keyword text, plus the closest real keyword when one exists.
+
+        The input is normalised exactly like :meth:`_match_keyword` normalises tokens
+        before lookup, so ``Launch App`` and ``launch app`` suggest ``launch_app``.
+        """
+        normalized = "_".join(guessed.split()).lower()
+        matches = difflib.get_close_matches(normalized, self.keyword_map.keys(), n=1, cutoff=0.6)
+        suggestion = f" Did you mean '{matches[0]}'?" if matches else ""
+        return (
+            f"Unknown keyword: '{guessed}'. Keywords use snake_case — "
+            f"run `optics list` (e.g. launch_app, validate_element).{suggestion}"
+        )
+
+    def _signature_hint_message(self, func_name: str) -> str:
+        """Friendly usage message for a call whose args wouldn't bind (ValueError/TypeError).
+
+        Shows the same ``<required> [optional]`` shape the completion popup uses
+        (:meth:`keyword_signature`), so a mistyped call reads as a usage problem
+        instead of an interpreter crash.
+        """
+        signature = self.keyword_signature(func_name)
+        expected = signature.split(" ", 1)[1] if signature else None
+        expected_part = f"expected {expected} — " if expected else ""
+        return (
+            f"Couldn't run '{func_name}': {expected_part}"
+            "check `optics list` or Tab-complete for the signature."
+        )
+
     @staticmethod
     def _is_fallback_error(exc: OpticsError) -> bool:
         """True for element-location codes (E02xx / X0201) — retry the next locator.
@@ -622,7 +666,7 @@ class LiveController:
         """
         internal_capture.clear()
         try:
-            positional, keywords = self._resolve_candidate(combo)
+            positional, keywords = self._resolve_candidate(method, combo)
             method(*positional, **keywords)
         except OpticsError as exc:
             return exc
@@ -664,13 +708,20 @@ class LiveController:
                 strategy=self._winning_strategy(strategy_capture),
                 recorded=record,
             )
+        if isinstance(last_exc, (TypeError, ValueError)):
+            internal_logger.debug(
+                "'%s' failed with %s: %s", func_name, type(last_exc).__name__, last_exc
+            )
+            message = self._signature_hint_message(func_name)
+        else:
+            message = self._format_error(last_exc)
         return ActionResult(
             raw=raw,
             keyword=func_name,
             params=params,
             status=ActionStatus.FAIL,
             elapsed=time.time() - start,
-            message=self._format_error(last_exc),
+            message=message,
         )
 
     def _build_candidates(self, params: List[str]) -> List[List[str]]:
@@ -690,11 +741,15 @@ class LiveController:
                 candidates.append([param])
         return candidates
 
-    def _resolve_candidate(self, combo: Tuple[str, ...]) -> Tuple[List[str], Dict[str, str]]:
-        """Split one candidate combination into positional args and keyword args."""
+    def _resolve_candidate(self, method: Callable[..., Any], combo: Tuple[str, ...]) -> Tuple[List[str], Dict[str, str]]:
+        """Split one candidate combination into positional args and keyword args.
+
+        Whether a ``key=value`` token is a keyword argument is decided against
+        ``method``'s signature, so ``text=``/``css=``/``id=`` locators stay
+        positional (the keyword's ``element`` argument).
+        """
         combo_list = list(combo)
-        kw_params = DataReader.get_keyword_params(combo_list)
-        positional = DataReader.get_positional_params(combo_list)
+        positional, kw_params = DataReader.split_params_by_signature(method, combo_list)
         resolved_positional = [self._resolve_value(p) for p in positional]
         resolved_kw: Dict[str, str] = {}
         for key, value in kw_params.items():
@@ -772,8 +827,11 @@ class LiveController:
         Appends to three fixed-name files so a session can build up a test suite one
         module at a time: ``modules/modules.csv`` (the recorded keywords as one module
         named ``module_name``), ``test_cases/test_cases.csv`` (a ``(test_case,
-        module_name)`` row), and ``elements/elements.csv`` (a header-only stub for
-        manual editing).
+        module_name)`` row), and the project's elements CSV. Elements go into an
+        existing elements file when one is tracked anywhere in the project (the
+        scaffolds keep it at ``test_data/elements.csv``) — only names not already
+        present are merged in; with no elements CSV anywhere, a header-only
+        ``elements/elements.csv`` stub is created as before.
 
         Session artifacts are copied to ``execution_output/<module_name>/``.
 
@@ -792,12 +850,10 @@ class LiveController:
 
         modules_dir = os.path.join(self.folder_path, "modules")
         test_cases_dir = os.path.join(self.folder_path, "test_cases")
-        elements_dir = os.path.join(self.folder_path, "elements")
-        for directory in (modules_dir, test_cases_dir, elements_dir):
+        for directory in (modules_dir, test_cases_dir):
             os.makedirs(directory, exist_ok=True)
         modules_path = os.path.join(modules_dir, "modules.csv")
         test_cases_path = os.path.join(test_cases_dir, "test_cases.csv")
-        elements_path = os.path.join(elements_dir, "elements.csv")
 
         module_exists = mod in self._existing_names(modules_path, "module_name")
         test_case_exists = tc in self._existing_names(test_cases_path, "test_case")
@@ -813,7 +869,7 @@ class LiveController:
         step_count = len(self.recorded)
         self._append_module_csv(modules_path, mod)
         self._append_test_case_csv(test_cases_path, tc, mod)
-        self._ensure_elements_stub(elements_path)
+        elements_path = self._write_elements()
 
         artifacts_path: Optional[str] = None
         if os.path.isdir(self._artifacts_dir) and os.listdir(self._artifacts_dir):
@@ -912,6 +968,92 @@ class LiveController:
             return
         with open(path, "w", encoding="utf-8", newline="") as fh:
             csv.writer(fh).writerow(["Element_Name", "Element_ID"])
+
+    def _write_elements(self) -> str:
+        """Merge the session's elements into the project's tracked elements CSV.
+
+        An existing elements CSV anywhere under the project is preferred over
+        creating a second file (the scaffolds track elements in
+        ``test_data/elements.csv``, and a fresh ``elements/elements.csv`` stub
+        would scatter element data across two folders). Only names not already
+        present are appended; with no elements CSV anywhere, today's header-only
+        ``elements/elements.csv`` stub is created. Returns the file written.
+        """
+        self.ensure_elements_loaded()
+        existing = self._find_elements_csv()
+        if existing is not None:
+            self._append_new_elements(existing)
+            return existing
+        elements_path = os.path.join(self.folder_path, "elements", "elements.csv")
+        os.makedirs(os.path.dirname(elements_path), exist_ok=True)
+        self._ensure_elements_stub(elements_path)
+        return elements_path
+
+    def _find_elements_csv(self) -> Optional[str]:
+        """Path of an existing elements CSV under the project, or None.
+
+        Content-header based discovery (an ``element_name``/``element_id``
+        header), mirroring :func:`optics_framework.helper.execute.find_files`.
+        ``test_data/elements.csv`` — the scaffold convention — wins when present,
+        otherwise the lexicographically first match keeps the choice deterministic.
+        """
+        matches: List[str] = []
+        for root, _dirs, files in os.walk(self.folder_path):
+            for fname in files:
+                if not fname.lower().endswith(".csv"):
+                    continue
+                path = os.path.join(root, fname)
+                if "elements" in identify_file_content(path):
+                    matches.append(path)
+        if not matches:
+            return None
+        preferred = os.path.join(self.folder_path, "test_data", "elements.csv")
+        if preferred in matches:
+            return preferred
+        return min(matches)
+
+    def _existing_element_names(self, path: str) -> set[str]:
+        """Element names already tracked in ``path``, lowercased.
+
+        Column matching is case-insensitive too, so files headed
+        ``Element_Name`` (the samples) and ``element_name`` both work.
+        """
+        names: set[str] = set()
+        for row in self._read_rows(path):
+            for key, value in row.items():
+                if key is not None and key.strip().lower() == "element_name":
+                    name = (value or "").strip()
+                    if name:
+                        names.add(name.lower())
+        return names
+
+    def _append_new_elements(self, path: str) -> None:
+        """Append session element rows missing from ``path`` (never duplicates).
+
+        Dedupe is case-insensitive on element name; rows are appended verbatim
+        so the file's existing content, column layout, and line endings stay
+        intact. A missing trailing newline on the last row is repaired before
+        appending so the first new row doesn't glue onto it.
+        """
+        elements = self.session.elements
+        if elements is None or not elements.elements:
+            return
+        present = self._existing_element_names(path)
+        rows = [
+            (escape_csv_value(name), escape_csv_value(value))
+            for name, values in elements.elements.items()
+            if name.strip().lower() not in present
+            for value in values
+        ]
+        if not rows:
+            return
+        with open(path, "r", encoding="utf-8", newline="") as fh:
+            raw = fh.read()
+        terminator = "\r\n" if raw.endswith("\r\n") else "\n"
+        with open(path, "a", encoding="utf-8", newline="") as fh:
+            if raw and not raw.endswith(("\r", "\n")):
+                fh.write(terminator)
+            csv.writer(fh, lineterminator=terminator).writerows(rows)
 
     # -- Devices ------------------------------------------------------------------
 

--- a/optics_framework/helper/live_tui.py
+++ b/optics_framework/helper/live_tui.py
@@ -42,7 +42,7 @@ from optics_framework.helper.live import (
 )
 
 
-_STATUS_HINT = "Tab complete · Ctrl-K keywords · Ctrl-N AI mode · /help · /quit"
+_STATUS_HINT = "/help · /quit · Tab complete · Ctrl-K keywords · Ctrl-N AI mode"
 
 # Style class for secondary / muted text, reused across history and overlays.
 _META = "class:meta"
@@ -548,6 +548,8 @@ class LiveTUI:
             return
         if text.startswith("/"):
             self._handle_command(text)
+        elif text.lower() in ("quit", "exit"):
+            self._handle_command("/quit")
         elif self._nl_mode:
             self._run_nl_async(text)
         else:
@@ -686,7 +688,7 @@ class LiveTUI:
         }
         handler = handlers.get(command)
         if handler is None:
-            self._info(f"Unknown command: {command}  (try /help)")
+            self._info(f"Unknown command: {command} — available: {' '.join(handlers)}")
             return
         handler(arg)
 

--- a/optics_framework/helper/mcp_server.py
+++ b/optics_framework/helper/mcp_server.py
@@ -34,6 +34,7 @@ from optics_framework.api.verifier import Verifier
 from optics_framework.common import expose_api
 from optics_framework.common.error import OpticsError
 from optics_framework.common.logging_config import internal_logger
+from optics_framework.helper.version import VERSION
 
 # fastmcp is optional (extra: mcp). Import lazily with a clear, actionable error.
 try:
@@ -235,7 +236,7 @@ def _decode_screenshot(result: Any) -> bytes:
 def build_server() -> "FastMCP":
     """Construct the FastMCP server with all keyword tools and state resources."""
     _require_fastmcp()
-    mcp = FastMCP(SERVER_NAME, instructions=SERVER_INSTRUCTIONS)
+    mcp = FastMCP(SERVER_NAME, instructions=SERVER_INSTRUCTIONS, version=VERSION)
 
     # --- Lifecycle tools -------------------------------------------------------
     async def start_session(

--- a/optics_framework/helper/onboarding.py
+++ b/optics_framework/helper/onboarding.py
@@ -1,0 +1,114 @@
+"""Beginner-facing onboarding output for the optics CLI.
+
+Everything a newcomer sees on their first runs lives here: the welcome banner,
+the first-run marker under ``~/.optics``, and the "now run:" block printed at
+the end of project creation. Engineer B's CLI commands call these directly —
+see ``quickstart.py`` for the guided flow that stitches them together.
+
+The marker path is computed inside each function (not at import time) so that
+tests can point ``HOME`` at a temporary directory.
+"""
+import json
+import os
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from optics_framework.helper.version import VERSION
+
+_console = Console()
+_CMD_STYLE = "cyan bold"
+
+
+def _marker_dir() -> str:
+    """Directory holding the first-run marker.
+
+    Honours ``OPTICS_HOME`` so constrained environments (read-only HOME,
+    containers, CI) can point the marker at a writable location without
+    touching ``~/.optics``. Falls back to ``~/.optics`` when unset."""
+    override = os.environ.get("OPTICS_HOME")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(os.path.expanduser("~"), ".optics")
+
+
+def _marker_path() -> str:
+    """Path of the first-run marker; resolved lazily so HOME is read at call
+    time (tests monkeypatch it)."""
+    return os.path.join(_marker_dir(), ".onboarded")
+
+
+def is_first_run() -> bool:
+    """True until a readable, version-stamped marker object exists.
+
+    A missing marker means the user never onboarded; an unreadable, corrupt
+    or shape-mismatched one (permissions changed mid-flight, truncated write,
+    any parseable JSON that is not the object mark_onboarded writes) is
+    treated as a first run rather than locking the user out of guidance
+    forever."""
+    try:
+        with open(_marker_path(), encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return True
+    return not isinstance(data, dict)
+
+
+def mark_onboarded() -> None:
+    """Write the first-run marker as ``{"version": <optics version>}``.
+
+    Creates ``~/.optics/`` if needed. Best-effort by design: a read-only HOME
+    must never break an optics command, so every filesystem error is swallowed.
+    """
+    try:
+        os.makedirs(os.path.dirname(_marker_path()), exist_ok=True)
+        with open(_marker_path(), "w", encoding="utf-8") as fh:
+            json.dump({"version": VERSION}, fh)
+    except OSError:
+        pass
+
+
+def welcome(first_run: bool = False) -> None:
+    """Print the welcome banner shown by ``optics quickstart``.
+
+    One line on what Optics is, then the golden path: ``optics quickstart``
+    first, with ``optics doctor`` and ``optics --help`` as companions. When
+    ``first_run`` is True a friendly greeting is prepended."""
+    body = Text()
+    if first_run:
+        body.append("👋 First time here? We'll walk you through it.\n\n")
+    body.append("Optics drives real phones and browsers with plain-English "
+                "test steps — no code required.\n\n")
+    body.append("Golden path:\n", style="bold")
+    body.append("  optics quickstart", style=_CMD_STYLE)
+    body.append("   Create a project, pick your platform, get a ready config.\n")
+    body.append("  optics doctor", style=_CMD_STYLE)
+    body.append("      Check your environment and project setup.\n")
+    body.append("  optics --help", style=_CMD_STYLE)
+    body.append("       See everything else optics can do.")
+    _console.print(Panel(body, title="Optics Framework",
+                         subtitle=f"v{VERSION}", border_style="cyan"))
+
+
+def print_next_steps(project_path: str, *, configured: bool = False) -> None:
+    """Print the "now run:" block pointing at the next CLI commands.
+
+    With ``configured=False`` (a scaffolded project whose config.yaml still
+    needs answers) the configure step comes first; once configured the user
+    goes straight to validating and running their tests."""
+    body = Text()
+    if not configured:
+        body.append("  optics configure", style=_CMD_STYLE)
+        body.append(f" {project_path}\n", style="yellow")
+        body.append("      Answer a few questions to generate config.yaml.\n")
+    body.append("  optics dry_run", style=_CMD_STYLE)
+    body.append(f" {project_path}\n", style="yellow")
+    body.append("      Validate your test steps without touching a device.\n")
+    if configured:
+        body.append("  optics execute", style=_CMD_STYLE)
+        body.append(f" {project_path}\n", style="yellow")
+        body.append("      Run your tests for real.")
+    else:
+        body.rstrip()
+    _console.print(Panel(body, title="Next steps", border_style="green"))

--- a/optics_framework/helper/project_config.py
+++ b/optics_framework/helper/project_config.py
@@ -1,0 +1,254 @@
+"""Interactive builder for a project-specific ``config.yaml``.
+
+Asks the beginner only about the platform they picked (a Selenium user never
+sees an Appium question), then renders a fully commented config file that keeps
+the explanatory comments of the ``_STARTER_CONFIG`` template in
+``initialize.py`` — which is why the output is built as text rather than
+serialised from a model with ``yaml.dump``.
+
+Answers schema (normalised):
+  platform:       "android" | "ios" | "web-playwright" | "web-selenium"
+  android:        device_name, platform_name, app_package, app_activity,
+                  appium_url
+  ios:            device_name, platform_name, bundle_id, appium_url
+  web-selenium:   selenium_url
+  web-playwright: browser, headless (bool)
+  common:         ocr (bool), log_level (str, default "INFO")
+"""
+import os
+
+from rich.prompt import Confirm, Prompt
+
+# Every platform maps to exactly ONE action driver; that driver owns the
+# matching ``<driver>_*`` elements sources.
+_DRIVER_BY_PLATFORM = {
+    "android": "appium",
+    "ios": "appium",
+    "web-selenium": "selenium",
+    "web-playwright": "playwright",
+}
+
+_ELEMENTS_SOURCES_BY_DRIVER = {
+    "appium": ["appium_find_element", "appium_page_source", "appium_screenshot"],
+    "selenium": ["selenium_find_element", "selenium_page_source", "selenium_screenshot"],
+    "playwright": ["playwright_find_element", "playwright_page_source", "playwright_screenshot"],
+}
+
+_SOURCE_GROUP_TITLES = {
+    "appium": "Appium locators / page source / screenshots:",
+    "selenium": "Selenium locators / page source / screenshots:",
+    "playwright": "Playwright locators / page source / screenshots:",
+}
+
+_AUTOMATION_NAME = {"android": "UiAutomator2", "ios": "XCUITest"}
+
+
+def _quote(value: object) -> str:
+    """Render a value as a double-quoted YAML scalar (embedded quotes folded
+    to singles so the generated file always stays parseable)."""
+    return '"' + str(value).replace("\\", "\\\\").replace('"', "'") + '"'
+
+
+def _enabled(enabled: bool) -> str:
+    return "true" if enabled else "false"
+
+
+def prompt_project_config(domain: str | None = None) -> dict:
+    """Ask the beginner about their target, one platform at a time.
+
+    When ``domain`` is given (quickstart already knows whether the user picked
+    mobile or web), the platform question only offers that domain's platforms —
+    so a mobile user can never pick an engine they didn't install.
+    ``domain=None`` (standalone ``optics configure``) offers all four.
+
+    Question order (stable — callers' tests rely on it): platform, then only
+    that platform's fields, then the shared OCR / log-level questions."""
+    if domain == "mobile":
+        choices, default = ["android", "ios"], "android"
+    elif domain == "web":
+        choices, default = ["web-playwright", "web-selenium"], "web-playwright"
+    else:
+        choices, default = list(_DRIVER_BY_PLATFORM), "android"
+    platform = Prompt.ask(
+        "What are you automating?",
+        choices=choices,
+        default=default,
+    )
+    answers: dict = {"platform": platform}
+    if platform == "android":
+        answers["device_name"] = Prompt.ask(
+            "Device or emulator name (see `adb devices`)",
+            default="emulator-5554")
+        answers["platform_name"] = Prompt.ask(
+            "Platform name", default="Android")
+        answers["app_package"] = Prompt.ask(
+            "App package id (e.g. com.example.app)", default="com.example.app")
+        answers["app_activity"] = Prompt.ask(
+            "App main activity (e.g. com.example.app.MainActivity)",
+            default="com.example.app.MainActivity")
+        answers["appium_url"] = Prompt.ask(
+            "Appium server URL", default="http://127.0.0.1:4723")
+    elif platform == "ios":
+        # iOS launches apps by bundle identifier — appPackage/appActivity are
+        # Android-only capabilities and would be ignored (or rejected) by
+        # XCUITest.
+        answers["device_name"] = Prompt.ask(
+            "Device or simulator name", default="iPhone 15")
+        answers["platform_name"] = Prompt.ask(
+            "Platform name", default="iOS")
+        answers["bundle_id"] = Prompt.ask(
+            "Bundle identifier (e.g. com.example.app)", default="com.example.app")
+        answers["appium_url"] = Prompt.ask(
+            "Appium server URL", default="http://127.0.0.1:4723")
+    elif platform == "web-selenium":
+        answers["selenium_url"] = Prompt.ask(
+            "Selenium/WebDriver server URL", default="http://127.0.0.1:4444/wd/hub")
+    else:  # web-playwright
+        answers["browser"] = Prompt.ask(
+            "Which browser?", choices=["chromium", "firefox", "webkit"],
+            default="chromium")
+        answers["headless"] = Confirm.ask(
+            "Run headless (no browser window)?", default=False)
+    answers["ocr"] = Confirm.ask(
+        "Also find elements by on-screen text (EasyOCR)? Useful when there "
+        "are no stable locators.", default=False)
+    answers["log_level"] = Prompt.ask(
+        "Log level", choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO")
+    return answers
+
+
+def _header(platform: str) -> list[str]:
+    return [
+        "# Optics Framework project configuration.",
+        f"# Generated for the {platform} platform by optics.",
+        "#",
+        "# Getting started:",
+        "#   1. Your driver is already enabled below; replace anything that",
+        "#      still shows an example value.",
+        "#   2. Install its packages if you haven't, e.g.",
+        "#      optics setup --install appium",
+        "#   3. Validate everything with  optics doctor <this-folder>",
+        "#",
+        "# Full reference: https://mozarkai.github.io/optics-framework/configuration/",
+        "",
+    ]
+
+
+def _appium_block(answers: dict, enabled: bool) -> list[str]:
+    platform = answers.get("platform", "android")
+    if platform not in _DRIVER_BY_PLATFORM:
+        platform = "android"
+    lines = [
+        "  # Native Android/iOS via Appium. Needs a running Appium server and a",
+        "  # connected device/emulator.  Install:  optics setup --install appium",
+        "  - appium:",
+        f"      enabled: {_enabled(enabled)}",
+        f"      url: {_quote(answers.get('appium_url') or 'http://127.0.0.1:4723')}",
+        "      capabilities:",
+    ]
+    if platform == "ios":
+        # XCUITest launches apps by bundleId; appPackage/appActivity are
+        # Android-only and must not appear in an iOS config.
+        lines += [
+            f"        bundleId: {_quote(answers.get('bundle_id') or 'com.example.app')}",
+            "        automationName: "
+            + _AUTOMATION_NAME.get(platform, "UiAutomator2"),
+            f"        deviceName: {_quote(answers.get('device_name') or 'iPhone 15')}",
+            f"        platformName: {_quote(answers.get('platform_name') or 'iOS')}",
+        ]
+    else:
+        lines += [
+            f"        appPackage: {_quote(answers.get('app_package') or 'com.example.app')}",
+            "        appActivity: "
+            + _quote(answers.get("app_activity") or "com.example.app.MainActivity"),
+            "        automationName: "
+            + _AUTOMATION_NAME.get(platform, "UiAutomator2"),
+            f"        deviceName: {_quote(answers.get('device_name') or 'emulator-5554')}",
+            f"        platformName: {_quote(answers.get('platform_name') or 'Android')}",
+        ]
+    return lines
+
+
+def _driver_sources_section(answers: dict, driver: str) -> list[str]:
+    lines = [
+        "driver_sources:",
+        *_appium_block(answers, enabled=driver == "appium"),
+        "  # Web via a Selenium/WebDriver server.  Install:  optics setup --install selenium",
+        "  - selenium:",
+        f"      enabled: {_enabled(driver == 'selenium')}",
+        "      url: "
+        + _quote(answers.get("selenium_url") or "http://localhost:4444/wd/hub"),
+        "      capabilities: {}",
+        "  # Web via Playwright (no external server).  Install:  optics setup --install playwright",
+        "  - playwright:",
+        f"      enabled: {_enabled(driver == 'playwright')}",
+        "      capabilities:",
+        f"        browser: {answers.get('browser') or 'chromium'}",
+        f"        headless: {_enabled(bool(answers.get('headless', False)))}",
+        "",
+    ]
+    return lines
+
+
+def _elements_sources_section(driver: str) -> list[str]:
+    wanted = _ELEMENTS_SOURCES_BY_DRIVER[driver]
+    lines = ["elements_sources:"]
+    for group, sources in _ELEMENTS_SOURCES_BY_DRIVER.items():
+        lines.append(f"  # {_SOURCE_GROUP_TITLES[group]}")
+        for source in sources:
+            lines.append(f"  - {source}:")
+            lines.append(f"      enabled: {_enabled(source in wanted)}")
+        lines.append("")
+    return lines
+
+
+def _vision_sections(answers: dict) -> list[str]:
+    return [
+        "# Optional vision fallbacks: locate elements by on-screen text (OCR) or image.",
+        "text_detection:",
+        "  - easyocr:            # install: optics setup --install easyocr",
+        f"      enabled: {_enabled(bool(answers.get('ocr', False)))}",
+        "image_detection:",
+        "  - templatematch:",
+        "      enabled: false",
+        "",
+    ]
+
+
+def render_project_config(answers: dict) -> str:
+    """Render the commented ``config.yaml`` TEXT for the given answers.
+
+    Pure function — no prompts, no filesystem. Missing keys fall back to the
+    same example values the interactive flow suggests. Exactly one driver plus
+    its matching elements sources end up ``enabled: true`` (plus EasyOCR under
+    ``text_detection`` when ``answers["ocr"]``); every other entry stays listed
+    but disabled so the file doubles as a reference."""
+    platform = answers.get("platform")
+    if platform not in _DRIVER_BY_PLATFORM:
+        platform = "android"
+    driver = _DRIVER_BY_PLATFORM[platform]
+
+    sections: list[str] = [
+        *_header(platform),
+        *_driver_sources_section(answers, driver),
+        *_elements_sources_section(driver),
+        *_vision_sections(answers),
+        f"log_level: {answers.get('log_level') or 'INFO'}",
+        "json_log: true",
+        "file_log: true",
+    ]
+    return "\n".join(sections) + "\n"
+
+
+def write_project_config(folder: str, text: str) -> str:
+    """Write ``text`` to ``<folder>/config.yaml`` (creating ``folder`` if
+    needed) and return the written path.
+
+    Overwrites unconditionally — the caller owns any confirm-before-overwrite
+    UX (see ``quickstart.py``, which asks before clobbering a template)."""
+    os.makedirs(folder, exist_ok=True)
+    path = os.path.join(folder, "config.yaml")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    return path

--- a/optics_framework/helper/quickstart.py
+++ b/optics_framework/helper/quickstart.py
@@ -1,0 +1,147 @@
+"""``optics quickstart`` — the guided golden path for beginners.
+
+One command walks a newcomer from "nothing installed" to a runnable project:
+welcome → pick a domain → install the right engine → scaffold the project →
+answer a short config Q&A → doctor verifies everything → next steps.
+
+The wizard scaffolds and explains; it deliberately NEVER runs ``dry_run`` or
+``execute`` itself — those are printed as the user's next moves so the first
+execution is always an intentional, visible act.
+"""
+import os
+import types
+
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+
+from optics_framework.helper import doctor, initialize, onboarding, project_config
+from optics_framework.helper.setup import install_extras, resolve_engines
+
+_console = Console()
+
+_TEMPLATE_DOMAINS = {
+    "calendar": "mobile",
+    "clock": "mobile",
+    "contact": "mobile",
+    "youtube": "mobile",
+    "gmail_web": "web",
+    "playwright": "web",
+}
+
+
+def run_quickstart() -> None:
+    """Run the full guided journey end to end."""
+    onboarding.welcome(first_run=onboarding.is_first_run())
+    domain = _ask_domain()
+    _offer_engine_install(domain)
+    template = _choose_template()
+    while template is not None and _TEMPLATE_DOMAINS.get(template, domain) != domain:
+        target_domain = _TEMPLATE_DOMAINS[template]
+        if Confirm.ask(
+            f"The '{template}' sample targets {target_domain}, but you chose "
+            f"{domain}. Use it anyway?", default=False):
+            break
+        template = _choose_template()
+    name = Prompt.ask("Project name", default="my-optics-project")
+    base_path = Prompt.ask("Where should the project live?", default=os.getcwd())
+    project_path = os.path.join(base_path, name)
+    while os.path.exists(project_path):
+        _console.print(
+            f"Project '{project_path}' already exists. Choose a different name.")
+        try:
+            name = Prompt.ask("Project name").strip()
+        except EOFError:
+            _console.print("Aborted; the existing project was left untouched.")
+            raise SystemExit(1)
+        if not name:
+            _console.print("A project name can't be empty.")
+            continue
+        project_path = os.path.join(base_path, name)
+
+    # The wizard resolved its template question above and prints its own next
+    # steps below (configured=True — it just wrote the user's answers into
+    # config.yaml), so suppress create_project's picker and guidance block:
+    # pick_template=False makes template=None deterministically mean "blank"
+    # instead of re-prompting on a TTY, and show_next_steps=False avoids a
+    # duplicate — for blank projects contradictory — advice block.
+    initialize.create_project(types.SimpleNamespace(
+        name=name, path=base_path, force=False, template=template, git_init=False),
+        show_next_steps=False, pick_template=False)
+
+    _build_config(project_path, template, domain)
+    doctor.run_doctor(folder=project_path)
+    onboarding.print_next_steps(project_path, configured=True)
+
+
+def _ask_domain() -> str:
+    return Prompt.ask(
+        "What do you want to automate?", choices=["mobile", "web"],
+        default="mobile")
+
+
+def _offer_engine_install(domain: str) -> None:
+    """Offer to pip-install the engines the chosen domain needs.
+
+    The domain doubles as a ``setup`` bundle token ("mobile"/"web"), so engine
+    resolution keeps a single source of truth in setup.py's bundles — this
+    module never re-lists engines.
+
+    A failed install never aborts the wizard — the most common cause (PEP 668
+    externally-managed Python) just needs a virtualenv, so say that plainly."""
+    requests, invalid = resolve_engines([domain])
+    if invalid or not requests:  # defensive: the domain is a fixed bundle token
+        return
+    names = ", ".join(sorted({req.engine.name for req in requests}))
+    if not Confirm.ask(f"Install {names} now?", default=True):
+        _console.print(f"No problem — install later with:  "
+                       f"optics setup --install {domain}")
+        return
+    success, message = install_extras(requests)
+    _console.print(message)
+    if not success:
+        _console.print(
+            "\nIf pip complained about an [bold]externally managed environment"
+            "[/bold], put optics in a virtualenv first:\n"
+            "  python3 -m venv .venv\n"
+            "  source .venv/bin/activate\n"
+            "  pip install optics-framework\n"
+            "Then re-run this step — your answers so far are kept.")
+
+
+def _choose_template() -> str | None:
+    """Offer every packaged sample plus a blank start. Returns None for blank."""
+    templates = initialize.available_templates()
+    options = ["blank", *templates]
+    _console.print("Pick a starting point:")
+    for number, option in enumerate(options, start=1):
+        label = ("An empty project (recommended)" if option == "blank"
+                 else f"The '{option}' sample project")
+        _console.print(f"  {number}. {label}")
+    choice = Prompt.ask(
+        "Template number",
+        choices=[str(i) for i in range(1, len(options) + 1)], default="1")
+    index = int(choice) - 1
+    return None if index == 0 else options[index]
+
+
+def _build_config(project_path: str, template: str | None, domain: str) -> None:
+    """Q&A-render-write the project's config.yaml.
+
+    The wizard's already-chosen ``domain`` constrains the platform question —
+    a mobile user must not be able to pick web-selenium and end up with an
+    engine they never installed.
+
+    write_project_config overwrites unconditionally, so the wizard owns the
+    confirm-before-overwrite: a sample template ships a curated, runnable
+    config and must not lose it to a silent regeneration."""
+    config_path = os.path.join(project_path, "config.yaml")
+    if template is not None and os.path.isfile(config_path):
+        if not Confirm.ask(
+            f"'{template}' ships its own working config.yaml. Overwrite it "
+            "with your own answers?", default=False):
+            _console.print(f"Keeping the template's config at {config_path}.")
+            return
+    answers = project_config.prompt_project_config(domain=domain)
+    text = project_config.render_project_config(answers)
+    written = project_config.write_project_config(project_path, text)
+    _console.print(f"Wrote [bold]{written}[/bold]")

--- a/optics_framework/helper/setup.py
+++ b/optics_framework/helper/setup.py
@@ -1,7 +1,9 @@
 import re
 import subprocess  # nosec B404
+import threading
+from collections import deque
 from importlib.metadata import PackageNotFoundError, version
-from typing import Dict, List, Optional
+from typing import Deque, Dict, List, Optional
 import sys
 from textual import work
 from textual.app import App, ComposeResult
@@ -12,6 +14,7 @@ from pydantic import BaseModel
 
 
 DISTRIBUTION_NAME = "optics-framework"
+_STATUS_ID = "#status"
 
 
 class SetupError(Exception):
@@ -221,6 +224,11 @@ def resolve_engines(tokens: List[str]) -> tuple[List[InstallRequest], List[str]]
 class EngineInstallerApp(App):
     TITLE = "optics setup"
 
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("ctrl+c", "quit", "Quit"),
+    ]
+
     CSS = """
     #engine-list {
         height: 1fr;
@@ -243,6 +251,7 @@ class EngineInstallerApp(App):
     def __init__(self):
         super().__init__()
         self.selected_engines: Dict[str, EngineBackend] = {}
+        self._install_finished = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -301,20 +310,54 @@ class EngineInstallerApp(App):
             self.notify("No engines selected!", severity="warning")
             return
         requests = [InstallRequest(engine=e) for e in self.selected_engines.values()]
+        self._install_finished = False
         self.query_one("#install", Button).disabled = True
-        self.query_one("#status", Static).update(
+        self.query_one(_STATUS_ID, Static).update(
             "Installing… this can take a while (browser/model downloads); the UI stays responsive."
         )
         self._install_worker(requests)
 
     @work(thread=True)
     def _install_worker(self, requests: List[InstallRequest]) -> None:
-        """Run the blocking install off the UI thread, then report back on it."""
-        success, message = install_extras(requests)
+        """Run the blocking install off the UI thread, then report back on it.
+
+        A 1 Hz ticker thread keeps the status line showing elapsed time — the
+        TUI's alternate screen would otherwise sit silent (pip output can't be
+        printed here) for minutes during big downloads, which reads as a hang."""
+        names = ", ".join(request.engine.name for request in requests)
+        done = threading.Event()
+        ticker = threading.Thread(
+            target=self._tick_install_progress, args=(names, done), daemon=True)
+        ticker.start()
+        try:
+            success, message = install_extras(requests, stream=False)
+        finally:
+            done.set()
+            ticker.join()
         self.call_from_thread(self._on_install_finished, success, message)
 
+    def _tick_install_progress(self, names: str, done: threading.Event) -> None:
+        elapsed = 0
+        while not done.wait(1.0):
+            elapsed += 1
+            self.call_from_thread(
+                self._show_install_progress, f"Installing {names}… {elapsed}s")
+
+    def _show_install_progress(self, text: str) -> None:
+        # Checked on the UI thread so a tick already in flight when the install
+        # finishes can never overwrite the final status.
+        if self._install_finished:
+            return
+        self.query_one(_STATUS_ID, Static).update(text)
+
     def _on_install_finished(self, success: bool, message: str) -> None:
-        self.query_one("#status", Static).update(message)
+        self._install_finished = True
+        status = message
+        if success:
+            # The TUI's alternate screen swallows print(), so fold the next
+            # steps into the status line the user is already watching.
+            status = f"{message}{install_next_steps_text()}"
+        self.query_one(_STATUS_ID, Static).update(status)
         self.notify(
             message.splitlines()[0],
             severity="information" if success else "error",
@@ -331,7 +374,62 @@ def _installed_version() -> Optional[str]:
         return None
 
 
-def install_extras(requests: List[InstallRequest]) -> tuple[bool, str]:
+def install_next_steps_text() -> str:
+    """Concrete next steps shown after a successful engine install.
+
+    Shared by the ``optics setup --install`` CLI path (printed) and the TUI's
+    finish handler (folded into its status line) so both say the same thing."""
+    return (
+        "\nNext steps:\n"
+        "  1. optics init myproject            # scaffold a new project\n"
+        "  2. optics configure myproject       # write its config.yaml\n"
+        "  3. optics doctor myproject          # verify the setup is ready\n"
+        "  4. optics dry_run myproject         # validate without a device\n"
+        "  5. optics execute myproject         # run on a real device"
+    )
+
+
+def print_install_next_steps() -> None:
+    """Print the next-steps text for the ``optics setup --install`` CLI path."""
+    print(install_next_steps_text())
+
+
+# Last N output lines a streamed command keeps buffered, quoted on failure so a
+# pip error excerpt survives without holding the whole (potentially huge) log.
+_TAIL_LINES = 15
+
+
+def _run_capture(cmd: List[str]) -> None:
+    """Run cmd capturing all output (TUI path, where printing is swallowed).
+
+    Raises CalledProcessError carrying e.stderr/e.stdout on failure."""
+    subprocess.run(  # nosec B603
+        cmd, capture_output=True, text=True, check=True, shell=False)
+
+
+def _run_streaming(cmd: List[str]) -> None:
+    """Run cmd echoing its merged output to the console live (CLI path), so long
+    installs show pip's progress instead of minutes of silence.
+
+    A short tail stays buffered and rides out on CalledProcessError.output if
+    the command fails. Raises CalledProcessError on non-zero exit."""
+    tail: Deque[str] = deque(maxlen=_TAIL_LINES)
+    process = subprocess.Popen(  # nosec B603
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1, shell=False)
+    for line in process.stdout:
+        if line.lstrip().startswith("Requirement already satisfied"):
+            continue
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        tail.append(line.rstrip("\n"))
+    process.stdout.close()
+    if process.wait() != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode, cmd, output="".join(f"{line}\n" for line in tail))
+
+
+def install_extras(requests: List[InstallRequest], *, stream: bool = True) -> tuple[bool, str]:
     """Install the selected engine backends by pulling the matching
     `optics-framework` extras, pinned to the installed version so the CLI is
     never upgraded out from under the user.
@@ -344,9 +442,14 @@ def install_extras(requests: List[InstallRequest]) -> tuple[bool, str]:
     override targets. Extra packages, like pytesseract's pillow, stay on the
     extra's bound.
 
-    Returns ``(success, message)`` rather than printing, so both the CLI
+    ``stream=True`` (the CLI default) echoes the command's output live so the
+    user sees pip working; ``stream=False`` (the TUI, whose alternate screen
+    swallows prints) captures quietly instead.
+
+    Returns ``(success, message)`` rather than raising, so both the CLI
     (`optics setup --install`) and the TUI can surface the outcome — the TUI's
-    alternate screen swallows ``print``. Callers decide how to display it."""
+    alternate screen swallows ``print``. On failure the message carries an
+    excerpt of the captured output. Callers decide how to display it."""
     if not requests:
         return False, "No engines selected."
 
@@ -358,24 +461,21 @@ def install_extras(requests: List[InstallRequest]) -> tuple[bool, str]:
 
     pinned = [f"{req.engine.packages[0]}{req.version}" for req in requests if req.version]
 
+    run = _run_streaming if stream else _run_capture
     try:
-        subprocess.run(  # nosec B603
-            [sys.executable, "-m", "pip", "install", spec, *pinned],
-            capture_output=True, text=True, check=True, shell=False)
+        run([sys.executable, "-m", "pip", "install", spec, *pinned])
 
         if any(req.engine.extra == "playwright" for req in requests):
             # Per https://playwright.dev/python/docs/browsers this must run after
             # the pip install. Chromium is the most common target; --with-deps
             # pulls the required OS libraries.
-            subprocess.run(  # nosec B603
-                [sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"],
-                capture_output=True, text=True, check=True, shell=False)
+            run([sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"])
 
         return True, "Engines installed successfully!"
     except subprocess.CalledProcessError as e:
-        # capture_output routes the command's diagnostics to e.stderr/e.stdout
-        # rather than the console, so fold them into the message for a debuggable
-        # failure.
+        # capture_output / _run_streaming route the command's diagnostics to
+        # e.stderr/e.stdout rather than losing them, so fold them into the
+        # message for a debuggable failure.
         detail = (e.stderr or "").strip() or (e.stdout or "").strip()
         message = f"Installation failed: {e}"
         if detail:

--- a/optics_framework/samples/calendar/config.yaml
+++ b/optics_framework/samples/calendar/config.yaml
@@ -83,5 +83,5 @@ api:
             extract:
               today: time_zone.date
 
-log_level: DEBUG
+log_level: INFO
 file_log: true

--- a/optics_framework/samples/gmail_web/config.yaml
+++ b/optics_framework/samples/gmail_web/config.yaml
@@ -61,4 +61,4 @@ image_detection:
       capabilities: {}
 
 
-log_level: "DEBUG"
+log_level: "INFO"

--- a/optics_framework/samples/playwright/config.yaml
+++ b/optics_framework/samples/playwright/config.yaml
@@ -4,7 +4,7 @@
 console: true
 file_log: true
 json_log: false
-log_level: DEBUG
+log_level: INFO
 
 # --------------------------------------------------
 # Runtime behavior

--- a/tests/units/common/test_config_handler.py
+++ b/tests/units/common/test_config_handler.py
@@ -1,0 +1,144 @@
+"""Unit tests for ``optics_framework.common.config_handler``.
+
+Pins two things after the global-config layer was removed:
+
+1. Constructing a ``ConfigHandler`` creates **no** ``~/.optics/global_config.yaml``
+   (the dead global layer is gone — HOME is monkeypatched to a tmp dir and we
+   assert the file is absent afterwards).
+2. ``deep_merge`` / ``update_config`` preserve their real semantics: a list-valued
+   key in the incoming config REPLACES the default list wholesale (not an
+   item-wise merge) — so a project that names its own ``driver_sources`` overrides
+   the defaults entirely.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from optics_framework.common.config_handler import Config, ConfigHandler, deep_merge
+
+pytestmark = pytest.mark.white_box
+
+
+def _make_handler(tmp_home: Path) -> ConfigHandler:
+    """A ConfigHandler whose execution_output lands in a tmp dir."""
+    config = Config()
+    config.execution_output_path = str(tmp_home / "execution_output")
+    return ConfigHandler(config)
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Point HOME at a throwaway dir so any stray global write is detectable."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+class TestNoGlobalConfigLayer:
+    def test_constructing_handler_writes_no_global_file(self, isolated_home, tmp_path):
+        handler = _make_handler(tmp_path)
+        # The old global file must not be created by construction.
+        assert not (isolated_home / ".optics" / "global_config.yaml").exists()
+        # And the handler exposes no global-config attributes/methods anymore.
+        assert not hasattr(handler, "global_config_path")
+        assert not hasattr(ConfigHandler, "DEFAULT_GLOBAL_CONFIG_PATH")
+        assert not hasattr(handler, "load")
+        assert not hasattr(handler, "save_config")
+        assert not hasattr(handler, "_ensure_global_config")
+        assert not hasattr(handler, "_load_yaml")
+
+    def test_no_global_dir_created_at_all(self, isolated_home, tmp_path):
+        _make_handler(tmp_path)
+        # Not even the ~/.optics directory should be touched now.
+        assert not (isolated_home / ".optics").exists()
+
+
+class TestUpdateConfigMerges:
+    def test_update_config_merges_scalar_overrides(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        handler.update_config({"log_level": "DEBUG"})
+        assert handler.config.log_level == "DEBUG"
+
+    def test_update_config_accepts_config_object(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        override = Config(log_level="WARNING")
+        handler.update_config(override)
+        assert handler.config.log_level == "WARNING"
+
+
+class TestDeepMergeListSemantics:
+    """A list in c2 REPLACES the list in c1 — not an item-wise merge. This is the
+    load-bearing rule for project configs: a project listing its own
+    ``driver_sources`` overrides the defaults' driver list entirely."""
+
+    def test_project_driver_sources_replaces_default_list(self):
+        default = Config()
+        # Sanity: defaults ship three disabled drivers.
+        default_names = [next(iter(d)) for d in default.driver_sources]
+        assert "appium" in default_names
+
+        project = Config(
+            driver_sources=[
+                {"playwright": {"enabled": True, "url": None, "capabilities": {}}}
+            ]
+        )
+        merged = deep_merge(default, project)
+        names = [next(iter(d)) for d in merged.driver_sources]
+        # The default appium/selenium/ble are GONE — replaced, not appended.
+        assert names == ["playwright"]
+        assert "appium" not in names
+
+    def test_empty_project_list_falls_back_to_defaults(self):
+        # An empty list means "I specified nothing" — Config.__init__ refills
+        # the defaults, consistent with how a project omitting the key behaves.
+        default = Config()
+        project = Config(driver_sources=[])
+        merged = deep_merge(default, project)
+        assert len(merged.driver_sources) > 0
+        # But the OTHER defaults (untouched by project) survive.
+        assert len(merged.elements_sources) > 0
+
+    def test_scalar_override_wins(self):
+        default = Config()
+        project = Config(log_level="ERROR")
+        merged = deep_merge(default, project)
+        assert merged.log_level == "ERROR"
+
+    def test_list_replacement_is_wholesale_not_itemwise(self):
+        # The load-bearing rule: a project that lists its own driver_sources
+        # OVERRIDES the defaults' list entirely. The default appium/selenium/ble
+        # are gone — there is no positional merge of list items.
+        default = Config()
+        default_names = [next(iter(d)) for d in default.driver_sources]
+        assert "appium" in default_names
+
+        project = Config(
+            driver_sources=[
+                {"playwright": {"enabled": True, "url": "http://proj", "capabilities": {"browser": "chromium"}}}
+            ]
+        )
+        merged = deep_merge(default, project)
+        names = [next(iter(d)) for d in merged.driver_sources]
+        assert names == ["playwright"]
+        assert "appium" not in names
+        entry = merged.driver_sources[0]["playwright"]
+        assert entry.enabled is True
+        assert entry.url == "http://proj"
+        assert entry.capabilities == {"browser": "chromium"}
+
+
+def test_config_handler_precomputes_enabled(tmp_path):
+    config = Config(
+        driver_sources=[
+            {"appium": {"enabled": True, "url": "http://x", "capabilities": {}}},
+            {"selenium": {"enabled": False, "url": None, "capabilities": {}}},
+        ]
+    )
+    config.execution_output_path = str(tmp_path / "out")
+    handler = ConfigHandler(config)
+    assert handler.get("driver_sources") == ["appium"]
+    assert handler.get("elements_sources") == []

--- a/tests/units/common/test_console_log_gate.py
+++ b/tests/units/common/test_console_log_gate.py
@@ -1,0 +1,119 @@
+"""Unit tests for the post-summary console-log gate.
+
+Source under test: ``logging_config.quiet_console_logs`` / ``restore_console_logs``
+and their wiring into ``TreeResultPrinter.stop_live`` / ``start_live``. Once the
+result printer has rendered its final summary panel, teardown INFO records
+(``[Playwright] Terminating session``, ``[AsyncUtils] Creating persistent event
+loop``) must stop reaching the *console* handler — while file handlers keep their
+configured levels and still record everything.
+"""
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from optics_framework.common.logging_config import (
+    internal_logger,
+    logging_manager,
+    quiet_console_logs,
+    restore_console_logs,
+)
+from optics_framework.common.runner import printers as printers_module
+from optics_framework.common.runner.printers import (
+    TerminalWidthProvider,
+    TreeResultPrinter,
+)
+
+pytestmark = pytest.mark.white_box
+
+
+@pytest.fixture(autouse=True)
+def _leave_console_loud():
+    yield
+    restore_console_logs()
+    TreeResultPrinter.get_instance(TerminalWidthProvider())._live = None
+
+
+class TestQuietConsoleLogs:
+    def test_console_handler_drops_to_warning(self):
+        console = logging_manager.internal_console_handler
+        restore_console_logs()
+        assert console.level != logging.WARNING or internal_logger.level == logging.WARNING
+        quiet_console_logs()
+        assert console.level == logging.WARNING
+
+    def test_file_handlers_keep_their_levels(self, tmp_path):
+        file_handler = logging.FileHandler(tmp_path / "internal_logs.log")
+        file_handler.setLevel(logging.DEBUG)
+        internal_logger.addHandler(file_handler)
+        try:
+            quiet_console_logs()
+            assert file_handler.level == logging.DEBUG
+            assert logging_manager.internal_console_handler.level == logging.WARNING
+        finally:
+            internal_logger.removeHandler(file_handler)
+            file_handler.close()
+
+    def test_info_records_still_reach_file_after_quiet(self, tmp_path):
+        log_file = tmp_path / "internal_logs.log"
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        previous_level = internal_logger.level
+        internal_logger.setLevel(logging.INFO)  # mirrors initialize_handlers
+        internal_logger.addHandler(file_handler)
+        try:
+            logging_manager.internal_console_handler.setLevel(logging.INFO)
+            quiet_console_logs()
+            internal_logger.info("[Playwright] Terminating session")
+        finally:
+            internal_logger.removeHandler(file_handler)
+            internal_logger.setLevel(previous_level)
+            file_handler.close()
+        assert "[Playwright] Terminating session" in log_file.read_text()
+
+    def test_restore_returns_console_to_logger_level(self):
+        quiet_console_logs()
+        assert logging_manager.internal_console_handler.level == logging.WARNING
+        restore_console_logs()
+        assert logging_manager.internal_console_handler.level == internal_logger.level
+
+
+class TestPrinterGateWiring:
+    def _printer(self) -> TreeResultPrinter:
+        return TreeResultPrinter.get_instance(TerminalWidthProvider())
+
+    def test_stop_live_quiets_console(self):
+        printer = self._printer()
+        printer._live = MagicMock()
+        restore_console_logs()
+
+        printer.stop_live()
+
+        assert printer._live is None
+        assert logging_manager.internal_console_handler.level == logging.WARNING
+
+    def test_start_live_restores_console(self, monkeypatch):
+        printer = self._printer()
+        printer._live = None
+        monkeypatch.setattr(printers_module, "Live", MagicMock())
+        monkeypatch.setattr(
+            printers_module, "get_console", lambda: type("C", (), {"force_terminal": False})()
+        )
+        quiet_console_logs()
+
+        printer.start_live()
+
+        assert logging_manager.internal_console_handler.level == internal_logger.level
+        assert logging_manager.internal_console_handler.level != logging.WARNING or (
+            internal_logger.level == logging.WARNING
+        )
+
+    def test_stop_live_without_display_is_a_no_op(self):
+        printer = self._printer()
+        printer._live = None
+        restore_console_logs()
+
+        printer.stop_live()
+
+        assert logging_manager.internal_console_handler.level == internal_logger.level

--- a/tests/units/common/test_data_reader.py
+++ b/tests/units/common/test_data_reader.py
@@ -9,6 +9,7 @@ import pytest
 from optics_framework.common.models import ApiData
 from optics_framework.common.runner.data_reader import (
     CSVDataReader,
+    DataReader,
     YAMLDataReader,
     merge_dicts,
 )
@@ -19,6 +20,41 @@ def _write(tmp_path, name, content):
     path = tmp_path / name
     path.write_text(content, encoding="utf-8")
     return str(path)
+
+
+# --------------------------------------------------------------------------- #
+# split_params_by_signature — '=' locator vs genuine keyword-arg disambiguation #
+# --------------------------------------------------------------------------- #
+
+class TestSplitParamsBySignature:
+    @staticmethod
+    def _method(element, timeout="10", rule="all", event_name=None):
+        """Stand-in with a validate_element-like signature (no ``text`` param)."""
+
+    def test_equals_locators_stay_positional(self):
+        pos, kw = DataReader.split_params_by_signature(
+            self._method, ["text=Example Domain", "css=.btn", "xpath=//a[@id='x']"])
+        assert pos == ["text=Example Domain", "css=.btn", "xpath=//a[@id='x']"]
+        assert kw == {}
+
+    def test_real_keyword_args_are_split_off(self):
+        pos, kw = DataReader.split_params_by_signature(
+            self._method, ["text=OK", "event_name=tap", "5"])
+        assert pos == ["text=OK", "5"]
+        assert kw == {"event_name": "tap"}
+
+    def test_params_without_equals_are_untouched(self):
+        pos, kw = DataReader.split_params_by_signature(
+            self._method, ["${Heading}", "https://example.com"])
+        assert pos == ["${Heading}", "https://example.com"]
+        assert kw == {}
+
+    def test_unreadable_signature_falls_back_to_keyword(self):
+        # A non-introspectable target keeps the historical behaviour: a
+        # ``key=value`` token is treated as a keyword argument.
+        pos, kw = DataReader.split_params_by_signature(object(), ["text=x"])
+        assert pos == []
+        assert kw == {"text": "x"}
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/units/common/test_junit_eventhandler.py
+++ b/tests/units/common/test_junit_eventhandler.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``optics_framework.common.Junit_eventhandler``.
+
+Pins the two output contracts of the session-scoped JUnit handler:
+
+1. ``logs.json`` is produced if and only if ``json_log`` is enabled, while
+   ``junit_output.xml`` is always produced in the session's output directory.
+2. Concurrent sessions sharing one resolved output directory never clobber
+   each other: the newcomer falls back to ``junit_output_<session_id>.xml``
+   while the canonical name stays with its owner, and once sessions are
+   cleaned up later ones get the canonical name again.
+"""
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET  # nosec B405
+from pathlib import Path
+
+import pytest
+
+from optics_framework.common.Junit_eventhandler import (
+    JUnitHandlerRegistry,
+    cleanup_junit,
+    get_junit_handler_registry,
+    setup_junit,
+)
+from optics_framework.common.config_handler import Config
+from optics_framework.common.events import Event, EventStatus
+from optics_framework.common.session_manager import _maybe_setup_junit
+
+pytestmark = pytest.mark.white_box
+
+
+def _config(output_dir, json_log=False, json_path=None):
+    """A minimal Config pointing JUnit output at a tmp dir."""
+    config = Config(execution_output_path=str(output_dir), json_log=json_log)
+    if json_path is not None:
+        config.json_path = str(json_path)
+    return config
+
+
+def _tc_event(session_id, tc_id, name, status):
+    return Event(
+        entity_type="test_case",
+        entity_id=tc_id,
+        name=name,
+        status=status,
+        extra={"session_id": session_id},
+    )
+
+
+async def _run_testcase(handler, session_id, tc_id, name):
+    """Drive a RUNNING -> PASS test-case pair through the handler."""
+    await handler.on_event(_tc_event(session_id, tc_id, name, EventStatus.RUNNING))
+    await handler.on_event(_tc_event(session_id, tc_id, name, EventStatus.PASS))
+
+
+def _testcase_names(junit_file):
+    root = ET.parse(junit_file).getroot()
+    return {tc.get("name") for tc in root.iter("testcase")}
+
+
+class TestJsonLogGate:
+    async def test_json_log_disabled_writes_junit_only(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        registry.setup_junit_for_session("gate-off", _config(tmp_path, json_log=False))
+        handler = registry.get_handler("gate-off")
+        assert handler is not None
+        assert handler.json_output_path is None
+
+        await _run_testcase(handler, "gate-off", "tc-1", "Login")
+        registry.cleanup_session("gate-off")
+
+        junit_file = tmp_path / "junit_output.xml"
+        assert junit_file.exists()
+        assert _testcase_names(junit_file) == {"Login"}
+        assert not (tmp_path / "logs.json").exists()
+
+    async def test_json_log_enabled_writes_both(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        registry.setup_junit_for_session("gate-on", _config(tmp_path, json_log=True))
+        handler = registry.get_handler("gate-on")
+        assert handler.json_output_path == tmp_path / "logs.json"
+
+        await _run_testcase(handler, "gate-on", "tc-1", "Login")
+        registry.cleanup_session("gate-on")
+
+        assert (tmp_path / "junit_output.xml").exists()
+        events = json.loads((tmp_path / "logs.json").read_text(encoding="utf-8"))
+        assert [e["entity_id"] for e in events] == ["tc-1", "tc-1"]
+        assert all(e["extra"]["session_id"] == "gate-on" for e in events)
+
+    async def test_json_log_custom_path_used_when_enabled(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        custom = tmp_path / "custom" / "events.json"
+        registry.setup_junit_for_session(
+            "gate-custom", _config(tmp_path, json_log=True, json_path=custom)
+        )
+        try:
+            assert registry.get_handler("gate-custom").json_output_path == custom
+        finally:
+            registry.cleanup_session("gate-custom")
+
+
+class TestConcurrentSessionIsolation:
+    async def test_overlapping_sessions_write_distinct_junit_files(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        registry.setup_junit_for_session("iso-a", _config(tmp_path))
+        registry.setup_junit_for_session("iso-b", _config(tmp_path))
+
+        first = registry.get_handler("iso-a")
+        second = registry.get_handler("iso-b")
+        assert first.output_path == tmp_path / "junit_output.xml"
+        assert second.output_path == tmp_path / "junit_output_iso-b.xml"
+
+        await _run_testcase(first, "iso-a", "tc-a", "Case A")
+        await _run_testcase(second, "iso-b", "tc-b", "Case B")
+        registry.cleanup_session("iso-a")
+        registry.cleanup_session("iso-b")
+
+        canonical = tmp_path / "junit_output.xml"
+        newcomer = tmp_path / "junit_output_iso-b.xml"
+        assert {p for p in tmp_path.glob("*.xml")} == {canonical, newcomer}
+        assert _testcase_names(canonical) == {"Case A"}
+        assert _testcase_names(newcomer) == {"Case B"}
+
+    async def test_canonical_name_returns_once_its_owner_leaves(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        registry.setup_junit_for_session("seq-a", _config(tmp_path))
+        registry.setup_junit_for_session("seq-b", _config(tmp_path))
+        registry.cleanup_session("seq-a")
+
+        registry.setup_junit_for_session("seq-c", _config(tmp_path))
+        assert registry.get_handler("seq-c").output_path == tmp_path / "junit_output.xml"
+        assert registry.get_handler("seq-b").output_path == tmp_path / "junit_output_seq-b.xml"
+
+        registry.cleanup_session("seq-b")
+        registry.cleanup_session("seq-c")
+
+    def test_sequential_sessions_reuse_canonical_name(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        registry.setup_junit_for_session("run-1", _config(tmp_path))
+        assert registry.get_handler("run-1").output_path == tmp_path / "junit_output.xml"
+        registry.cleanup_session("run-1")
+
+        registry.setup_junit_for_session("run-2", _config(tmp_path))
+        assert registry.get_handler("run-2").output_path == tmp_path / "junit_output.xml"
+        registry.cleanup_session("run-2")
+
+
+class TestSessionJunitWiring:
+    def test_global_setup_and_cleanup_route_through_registry(self, tmp_path):
+        registry = get_junit_handler_registry()
+        setup_junit("wire-1", _config(tmp_path, json_log=True))
+        try:
+            assert "wire-1" in registry.get_active_sessions()
+            assert registry.get_handler("wire-1") is not None
+        finally:
+            cleanup_junit("wire-1")
+        assert registry.get_handler("wire-1") is None
+
+    def test_maybe_setup_junit_sets_json_path_only_when_enabled(self, tmp_path):
+        config = Config(execution_output_path=str(tmp_path), json_log=True)
+        try:
+            _maybe_setup_junit(config, "wire-json-1", str(tmp_path))
+            assert config.json_path == str((tmp_path / "logs.json").expanduser())
+            handler = get_junit_handler_registry().get_handler("wire-json-1")
+            assert handler.json_output_path == Path(config.json_path)
+        finally:
+            cleanup_junit("wire-json-1")
+
+    def test_maybe_setup_junit_without_json_log_still_sets_up_junit(self, tmp_path):
+        config = Config(execution_output_path=str(tmp_path), json_log=False)
+        try:
+            _maybe_setup_junit(config, "wire-json-2", str(tmp_path))
+            assert config.json_path is None
+            handler = get_junit_handler_registry().get_handler("wire-json-2")
+            assert handler.output_path == tmp_path / "junit_output.xml"
+            assert handler.json_output_path is None
+        finally:
+            cleanup_junit("wire-json-2")
+
+    def test_maybe_setup_junit_requires_execution_output_path(self):
+        config = Config(json_log=True)
+        _maybe_setup_junit(config, "wire-none", None)
+        assert get_junit_handler_registry().get_handler("wire-none") is None
+
+
+class TestKeywordFailureMessage:
+    """A failed keyword records why on its <kw> element."""
+
+    async def test_failed_keyword_records_reason_on_kw_element(self, tmp_path):
+        registry = JUnitHandlerRegistry()
+        sid = "kwfail"
+        registry.setup_junit_for_session(sid, _config(tmp_path))
+        handler = registry.get_handler(sid)
+
+        await handler.on_event(Event(
+            entity_type="test_case", entity_id="tc-1", name="TC",
+            status=EventStatus.RUNNING, extra={"session_id": sid}))
+        await handler.on_event(Event(
+            entity_type="module", entity_id="mod-1", name="Mod",
+            status=EventStatus.RUNNING, parent_id="tc-1",
+            extra={"session_id": sid}))
+        reason = "Keyword not found: Bogus Keyword. Did you mean 'Launch App'?"
+        await handler.on_event(Event(
+            entity_type="keyword", entity_id="kw-1", name="Bogus Keyword",
+            status=EventStatus.FAIL, message=reason, parent_id="mod-1",
+            extra={"session_id": sid}))
+        registry.cleanup_session(sid)
+
+        root = ET.parse(tmp_path / "junit_output.xml").getroot()
+        failed = [e for e in root.iter("kw") if e.get("name") == "Bogus Keyword"]
+        assert failed
+        assert "Did you mean 'Launch App'" in (failed[0].get("message") or "")

--- a/tests/units/common/test_test_runner.py
+++ b/tests/units/common/test_test_runner.py
@@ -20,27 +20,38 @@ built via ``__new__`` and wired with the minimal collaborators (real ``ElementDa
 a real ``NullResultPrinter``, and a tiny fake event manager) so the assertions stay
 behaviour-focused rather than call-order-focused.
 """
+import logging
 import time
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+from optics_framework.common.base_factory import InstanceFallback
 from optics_framework.common.error import OpticsError, Code
+from optics_framework.common.events import EventStatus
 from optics_framework.common.logging_config import LogCaptureBuffer
 from optics_framework.common.models import (
     ElementData,
     KeywordNode,
+    ModuleData,
     ModuleNode,
     State,
 )
+# Aliased on import: pytest would otherwise try to collect the ``Test``-prefixed
+# class and emit PytestCollectionWarning.
+from optics_framework.common.models import TestCaseNode as _TestCaseNode
 from optics_framework.common.runner.printers import (
     NullResultPrinter,
     ModuleResult,
     KeywordResult,
+    TerminalWidthProvider,
+    TreeResultPrinter,
 )
 # Aliased on import: pytest would otherwise try to collect these ``Test``-prefixed
 # classes and emit PytestCollectionWarning.
 from optics_framework.common.runner.printers import TestCaseResult as _TestCaseResult
+from optics_framework.common.runner import test_runnner as _test_runnner
 from optics_framework.common.runner.test_runnner import TestRunner as _TestRunner
 
 
@@ -61,11 +72,12 @@ class _FakeEventManager:
         return None
 
 
-def _make_runner(elements=None, keyword_map=None):
+def _make_runner(elements=None, keyword_map=None, modules=None):
     """A ``TestRunner`` with just the collaborators the fallback path touches."""
     runner = _TestRunner.__new__(_TestRunner)
     runner.elements = elements if elements is not None else ElementData()
     runner.keyword_map = keyword_map or {}
+    runner.modules = modules if modules is not None else ModuleData()
     runner.session_id = "sess-1"
     runner.result_printer = NullResultPrinter()
     runner.event_manager = _FakeEventManager()
@@ -268,11 +280,16 @@ class TestFallbackSuccess:
         elements = ElementData()
         elements.add_element("n", "3")
         runner = _make_runner(elements=elements)
-        method = _Recorder()
-        # "L1" is positional; "repeat=${n}" becomes kwarg repeat=3 after resolution
+        calls = []
+
+        def method(element, repeat=None):  # a realistic keyword signature
+            calls.append(((element,), {"repeat": repeat}))
+
+        # "L1" is positional; "repeat=${n}" is a real kwarg (method HAS `repeat`)
+        # so it resolves to repeat="3"; a `text=`-style locator would stay positional.
         result = await _run_fallback(runner, method, [["L1"], ["repeat=${n}"]])
         assert result is True
-        assert method.calls == [(("L1",), {"repeat": "3"})]
+        assert calls == [(("L1",), {"repeat": "3"})]
 
 
 # --------------------------------------------------------------------------- #
@@ -413,3 +430,490 @@ class TestExecuteKeywordNameResolution:
         assert ok is False
         assert called == []                 # never dispatched — element unresolved
         assert kw_result.status == "FAIL"
+
+
+# --------------------------------------------------------------------------- #
+# Module-step resolution — a test-case step must name a known module or a      #
+# registered keyword, in dry-run AND batch mode                                #
+# --------------------------------------------------------------------------- #
+
+class TestModuleStepResolution:
+    @staticmethod
+    def _wire_module(runner, module_name, keywords=None):
+        module_result = ModuleResult(
+            name=module_name, elapsed="0.00s", status="NOT_RUN",
+            keywords=keywords or [],
+        )
+        tc_result = _TestCaseResult(
+            id="tc-1", name="tc", elapsed="0.00s", status="NOT_RUN",
+            modules=[module_result],
+        )
+        runner.result_printer.test_state = {"tc": tc_result}
+        return tc_result, module_result
+
+    def test_step_resolves_via_module_definition_or_keyword(self):
+        modules = ModuleData()
+        modules.add_module_definition("Use Var", [("Validate Element", [])])
+        runner = _make_runner(keyword_map={"launch_app": lambda: None}, modules=modules)
+        assert runner._step_resolves("Use Var") is True
+        assert runner._step_resolves("Launch App") is True
+        assert runner._step_resolves("Bogus Keyword Of Doom hello") is False
+
+    async def test_unknown_step_fails_dry_run(self):
+        runner = _make_runner()
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, module_result = self._wire_module(runner, step)
+        ok = await runner._dry_run_module(_mod_node(name=step), tc_result, "tc-node-1")
+        assert ok is False
+        assert module_result.status == "FAIL"
+
+    async def test_unknown_step_fails_batch(self):
+        runner = _make_runner(keyword_map={"known": lambda: None})
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, module_result = self._wire_module(runner, step)
+        ok = await runner._process_module(_mod_node(name=step), tc_result, {})
+        assert ok is False
+        assert module_result.status == "FAIL"
+
+    async def test_unknown_step_fail_event_carries_reason(self):
+        runner = _make_runner()
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, _ = self._wire_module(runner, step)
+        await runner._dry_run_module(_mod_node(name=step), tc_result, "tc-node-1")
+        fails = [e for e in runner.event_manager.events if e.status == EventStatus.FAIL]
+        assert any(
+            e.entity_type == "module"
+            and e.message == f"Unknown keyword or module: '{step}'"
+            for e in fails
+        )
+
+    async def test_known_module_still_passes_dry_run(self):
+        modules = ModuleData()
+        modules.add_module_definition("Launch App", [("Launch App", [])])
+        runner = _make_runner(keyword_map={"launch_app": lambda: None}, modules=modules)
+        keyword_node = _kw_node(name="Launch App")
+        kw_result = _kw_result(node_id=keyword_node.id, name=keyword_node.name)
+        tc_result, module_result = self._wire_module(
+            runner, "Launch App", keywords=[kw_result]
+        )
+        module_node = _mod_node(name="Launch App")
+        module_node.add_keyword(keyword_node)
+        ok = await runner._dry_run_module(module_node, tc_result, "tc-node-1")
+        assert ok is True
+        assert module_result.status == "PASS"
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run param resolution — an unresolved ``${var}`` is a per-keyword FAIL,   #
+# not an aborted run                                                           #
+# --------------------------------------------------------------------------- #
+
+class TestDryRunUnresolvedParam:
+    async def test_missing_variable_marks_fail_instead_of_raising(self):
+        modules = ModuleData()
+        modules.add_module_definition("Use Var", [("Validate Element", ["${NoSuchVar}"])])
+        runner = _make_runner(modules=modules)
+        kw_result = _kw_result(node_id="kw-1", name="Validate Element")
+        module_result = ModuleResult(
+            name="Use Var", elapsed="0.00s", status="NOT_RUN", keywords=[kw_result],
+        )
+        tc_result = _TestCaseResult(
+            id="tc-1", name="tc", elapsed="0.00s", status="NOT_RUN",
+            modules=[module_result],
+        )
+        runner.result_printer.test_state = {"tc": tc_result}
+        module_node = _mod_node(name="Use Var")
+        module_node.add_keyword(_kw_node(name="Validate Element", params=["${NoSuchVar}"]))
+
+        ok = await runner._dry_run_module(module_node, tc_result, "tc-node-1")
+
+        assert ok is False
+        assert kw_result.status == "FAIL"
+        assert module_result.status == "FAIL"
+
+    async def test_missing_variable_fail_event_reports_element(self):
+        modules = ModuleData()
+        modules.add_module_definition("Use Var", [("Validate Element", ["${NoSuchVar}"])])
+        runner = _make_runner(modules=modules)
+        kw_result = _kw_result(node_id="kw-1", name="Validate Element")
+        module_result = ModuleResult(
+            name="Use Var", elapsed="0.00s", status="NOT_RUN", keywords=[kw_result],
+        )
+        tc_result = _TestCaseResult(
+            id="tc-1", name="tc", elapsed="0.00s", status="NOT_RUN",
+            modules=[module_result],
+        )
+        runner.result_printer.test_state = {"tc": tc_result}
+        module_node = _mod_node(name="Use Var")
+        module_node.add_keyword(_kw_node(name="Validate Element", params=["${NoSuchVar}"]))
+
+        await runner._dry_run_module(module_node, tc_result, "tc-node-1")
+
+        fails = [e for e in runner.event_manager.events if e.status == EventStatus.FAIL]
+        assert any(
+            e.entity_type == "keyword" and e.message == "Element not found: NoSuchVar"
+            for e in fails
+        )
+
+    async def test_unknown_keyword_reason_includes_did_you_mean(self):
+        modules = ModuleData()
+        modules.add_module_definition("Use KW", [("Launhc App", [])])  # typo
+        runner = _make_runner(
+            keyword_map={"launch_app": lambda: None}, modules=modules)
+        kw_result = _kw_result(node_id="kw-1", name="Launhc App")
+        module_result = ModuleResult(
+            name="Use KW", elapsed="0.00s", status="NOT_RUN", keywords=[kw_result],
+        )
+        tc_result = _TestCaseResult(
+            id="tc-1", name="tc", elapsed="0.00s", status="NOT_RUN",
+            modules=[module_result],
+        )
+        runner.result_printer.test_state = {"tc": tc_result}
+        module_node = _mod_node(name="Use KW")
+        module_node.add_keyword(_kw_node(name="Launhc App"))
+
+        await runner._dry_run_module(module_node, tc_result, "tc-node-1")
+
+        fails = [e for e in runner.event_manager.events
+                 if e.status == EventStatus.FAIL and e.entity_type == "keyword"]
+        assert fails
+        assert "Keyword not found: Launhc App" in fails[0].message
+        assert "Did you mean 'Launch App'" in fails[0].message
+        assert runner._last_failure_reason == fails[0].message
+
+    def test_init_state_keeps_unresolved_param_visible(self):
+        """``_initialize_test_state`` must not raise on unresolved ``${var}``;
+        the raw reference stays visible in the resolved display name."""
+        modules = ModuleData()
+        modules.add_module_definition("Use Var", [("Validate Element", ["${NoSuchVar}"])])
+        runner = _make_runner(modules=modules)
+        module_node = _mod_node(name="Use Var")
+        module_node.add_keyword(_kw_node(name="Validate Element", params=["${NoSuchVar}"]))
+        tc_root = _TestCaseNode(name="tc")
+        tc_root.add_module(module_node)
+        runner.test_cases = tc_root
+        runner._initialize_test_state()
+        (tc_result,) = runner.result_printer.test_state.values()
+        assert tc_result.modules[0].keywords[0].resolved_name == (
+            "Validate Element (${NoSuchVar})"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def internal_records():
+    """Capture ``optics.internal`` records despite ``propagate = False``."""
+    from optics_framework.common.logging_config import internal_logger
+
+    captured = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    handler = _ListHandler(level=logging.DEBUG)
+    internal_logger.addHandler(handler)
+    previous_level = internal_logger.level
+    internal_logger.setLevel(logging.DEBUG)
+    yield captured
+    internal_logger.setLevel(previous_level)
+    internal_logger.removeHandler(handler)
+
+
+def _runner_with_session(session):
+    runner = _make_runner()
+    runner.session = session
+    return runner
+
+
+class TestEndOfRunDriverProbe:
+    @pytest.mark.parametrize(
+        "driver, expected",
+        [
+            (None, False),                                    # no driver at all
+            (SimpleNamespace(page=None), False),              # Playwright, terminated
+            (SimpleNamespace(page=object()), True),           # Playwright, live
+            (SimpleNamespace(driver=None), False),            # Appium/Selenium, terminated
+            (SimpleNamespace(driver=object()), True),         # Appium/Selenium, live
+            (SimpleNamespace(page=None, driver=object()), False),
+            (SimpleNamespace(), True),                        # unknown backend: fail open
+        ],
+    )
+    def test_probe_reflects_driver_handle(self, driver, expected):
+        runner = _runner_with_session(SimpleNamespace(driver=driver))
+        assert runner._end_of_run_driver_open() is expected
+
+    @pytest.mark.parametrize(
+        "handle_value, expected",
+        [(None, False), (object(), True)],
+    )
+    def test_probe_reads_handle_through_fallback_wrapper(self, handle_value, expected):
+        """``session.driver`` is an ``InstanceFallback``; its ``__getattr__``
+        hides real attribute values behind generated callables, so liveness
+        must be read off ``active_instance`` (QA finding 1)."""
+        driver = InstanceFallback([SimpleNamespace(page=handle_value)])
+        runner = _runner_with_session(SimpleNamespace(driver=driver))
+        assert runner._end_of_run_driver_open() is expected
+
+
+class TestEndOfRunArtifacts:
+    def test_torn_down_session_skips_capture_silently(
+        self, monkeypatch, internal_records
+    ):
+        """The shipped playwright template's teardown closes the page before
+        capture runs — the runner must skip with no console-facing WARNING or
+        traceback panel at all, only an internal debug log (mozark QA issue 1)."""
+        runner = _runner_with_session(
+            SimpleNamespace(
+                driver=InstanceFallback([SimpleNamespace(page=None)]),
+                config=SimpleNamespace(execution_output_path="/tmp/out"),
+                optics=MagicMock(),
+            )
+        )
+        strategy_manager_calls = []
+        monkeypatch.setattr(
+            _test_runnner, "StrategyManager",
+            lambda *a, **k: strategy_manager_calls.append(a),
+        )
+
+        runner._capture_end_of_run_artifacts()
+
+        assert strategy_manager_calls == []      # engine layer never invoked
+        warnings_ = [r for r in internal_records if r.levelno >= logging.WARNING]
+        assert warnings_ == []
+        debugs = [r for r in internal_records if r.levelno == logging.DEBUG]
+        assert any("skipped" in r.getMessage() for r in debugs)
+
+    def test_open_session_captures_screenshot_pagesource_and_detection(self, monkeypatch):
+        runner = _runner_with_session(
+            SimpleNamespace(
+                driver=SimpleNamespace(page=object()),
+                config=SimpleNamespace(execution_output_path="/tmp/out"),
+                optics=MagicMock(),
+                error_definitions=None,
+            )
+        )
+        calls = []
+        monkeypatch.setattr(_test_runnner, "StrategyManager", MagicMock())
+        monkeypatch.setattr(
+            _TestRunner, "_save_end_of_run_screenshot",
+            lambda self, sm, out: calls.append("screenshot"),
+        )
+        monkeypatch.setattr(
+            _TestRunner, "_save_end_of_run_pagesource",
+            lambda self, sm, out: (calls.append("pagesource"), ("<html></html>", "ts"))[1],
+        )
+        monkeypatch.setattr(
+            _TestRunner, "_run_end_of_run_detection",
+            lambda self, src, ts, out: calls.append("detection"),
+        )
+
+        runner._capture_end_of_run_artifacts()
+
+        assert calls == ["screenshot", "pagesource", "detection"]
+
+    def test_capture_failure_while_alive_stays_a_single_line(
+        self, monkeypatch, internal_records
+    ):
+        runner = _runner_with_session(
+            SimpleNamespace(
+                driver=SimpleNamespace(page=object()),
+                config=SimpleNamespace(execution_output_path="/tmp/out"),
+                optics=MagicMock(),
+            )
+        )
+        monkeypatch.setattr(
+            _test_runnner, "StrategyManager",
+            MagicMock(side_effect=RuntimeError("boom")),
+        )
+
+        runner._capture_end_of_run_artifacts()
+
+        warnings_ = [r for r in internal_records if r.levelno == logging.WARNING]
+        assert len(warnings_) == 1
+        assert warnings_[0].getMessage() == "End-of-run artifact capture failed: boom"
+        assert warnings_[0].exc_info is None
+
+
+
+class TestFailureReasonRecording:
+    @staticmethod
+    def _wire_module(runner, module_name, keywords=None):
+        module_result = ModuleResult(
+            name=module_name, elapsed="0.00s", status="NOT_RUN",
+            keywords=keywords or [],
+        )
+        tc_result = _TestCaseResult(
+            id="tc-1", name="tc", elapsed="0.00s", status="NOT_RUN",
+            modules=[module_result],
+        )
+        runner.result_printer.test_state = {"tc": tc_result}
+        return tc_result, module_result
+
+    async def test_fatal_keyword_exception_records_reason_on_result(self):
+        runner = _make_runner()
+        method = _Recorder(always_raise=ValueError("kaboom"))
+        kw_result = _kw_result()
+        await runner._try_execute_with_fallback(
+            method, [["a"]], _kw_node(), _mod_node(),
+            kw_result, time.time(), _tc_result(), LogCaptureBuffer(),
+        )
+        assert kw_result.status == "FAIL"
+        assert kw_result.reason == "Keyword 'Some Keyword' failed: kaboom"
+
+    async def test_unknown_module_records_reason_in_batch_mode(self):
+        runner = _make_runner(keyword_map={"known": lambda: None})
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, module_result = self._wire_module(runner, step)
+        await runner._process_module(_mod_node(name=step), tc_result, {})
+        assert module_result.status == "FAIL"
+        assert module_result.reason == f"Unknown keyword or module: '{step}'"
+
+    async def test_unknown_module_records_reason_in_dry_run(self):
+        runner = _make_runner()
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, module_result = self._wire_module(runner, step)
+        await runner._dry_run_module(_mod_node(name=step), tc_result, "tc-node-1")
+        assert module_result.status == "FAIL"
+        assert module_result.reason == f"Unknown keyword or module: '{step}'"
+
+    async def test_dry_run_keyword_failure_records_reason_on_result(self):
+        modules = ModuleData()
+        modules.add_module_definition("Use KW", [("Launhc App", [])])
+        runner = _make_runner(keyword_map={"launch_app": lambda: None}, modules=modules)
+        kw_result = _kw_result(node_id="kw-1", name="Launhc App")
+        tc_result, module_result = self._wire_module(
+            runner, "Use KW", keywords=[kw_result]
+        )
+        module_node = _mod_node(name="Use KW")
+        module_node.add_keyword(_kw_node(name="Launhc App"))
+        await runner._dry_run_module(module_node, tc_result, "tc-node-1")
+        assert kw_result.status == "FAIL"
+        assert "Keyword not found: Launhc App" in kw_result.reason
+
+
+class TestUnknownModuleSuggestion:
+    """QA finding 3: unknown steps get a single difflib-based hint."""
+
+    async def test_batch_reason_appends_closest_keyword_match(self):
+        runner = _make_runner(keyword_map={"launch_app": lambda: None})
+        tc_result, module_result = TestFailureReasonRecording._wire_module(
+            runner, "Launch Ap"
+        )
+        await runner._process_module(_mod_node(name="Launch Ap"), tc_result, {})
+        assert module_result.reason == (
+            "Unknown keyword or module: 'Launch Ap'."
+            " Did you mean 'Launch App'? (run `optics list` to see all keywords)"
+        )
+
+    async def test_no_match_appends_nothing(self):
+        runner = _make_runner(keyword_map={"completely_different": lambda: None})
+        step = "Bogus Keyword Of Doom hello"
+        tc_result, module_result = TestFailureReasonRecording._wire_module(runner, step)
+        await runner._process_module(_mod_node(name=step), tc_result, {})
+        assert module_result.reason == f"Unknown keyword or module: '{step}'"
+
+
+class TestFailureDetailsSection:
+    @staticmethod
+    def _printer():
+        return TreeResultPrinter(TerminalWidthProvider())
+
+    @staticmethod
+    def _failed_state():
+        keyword = KeywordResult(
+            id="k1", name="Press Element", resolved_name="Press Element (btn)",
+            elapsed="0.10s", status="FAIL",
+            reason="Keyword 'Press Element' failed: boom",
+        )
+        module = ModuleResult(
+            name="Open Example Pag", elapsed="0.10s", status="FAIL",
+            reason="Unknown keyword or module: 'Open Example Pag'",
+        )
+        test_case = _TestCaseResult(
+            id="t1", name="TC Broken", elapsed="0.20s", status="FAIL",
+            modules=[module],
+        )
+        return keyword, test_case
+
+    def test_lists_failed_modules_and_keywords_with_reasons(self):
+        printer = self._printer()
+        keyword, test_case = self._failed_state()
+        test_case.modules[0].keywords = [keyword]
+        printer.test_state = {"TC Broken": test_case}
+        assert printer._failure_detail_lines() == [
+            "TC Broken → step 'Open Example Pag'"
+            " — Unknown keyword or module: 'Open Example Pag'",
+            "TC Broken → step 'Press Element (btn)'"
+            " — Keyword 'Press Element' failed: boom",
+        ]
+
+    def test_not_run_steps_without_reason_are_not_listed(self):
+        printer = self._printer()
+        _, test_case = self._failed_state()
+        not_run = KeywordResult(
+            id="k2", name="Close Browser", resolved_name="Close Browser",
+            elapsed="0.00s", status="NOT_RUN", reason="",
+        )
+        test_case.modules[0].keywords = [not_run]
+        printer.test_state = {"TC Broken": test_case}
+        assert printer._failure_detail_lines() == [
+            "TC Broken → step 'Open Example Pag'"
+            " — Unknown keyword or module: 'Open Example Pag'",
+        ]
+
+    def test_panel_only_rendered_when_failures_exist(self):
+        passing = ModuleResult(
+            name="Launch App", elapsed="0.10s", status="PASS",
+            keywords=[KeywordResult(
+                id="k1", name="Launch App", resolved_name="Launch App",
+                elapsed="0.10s", status="PASS", reason="",
+            )],
+        )
+        passed_tc = _TestCaseResult(
+            id="t1", name="TC OK", elapsed="0.10s", status="PASS",
+            modules=[passing],
+        )
+
+        clean_printer = self._printer()
+        clean_printer.test_state = {"TC OK": passed_tc}
+        assert all(
+            getattr(r, "title", None) != "Failure details"
+            for r in clean_printer._render_tree().renderables
+        )
+        assert clean_printer._failure_detail_lines() == []
+
+        keyword, failed_tc = self._failed_state()
+        failed_tc.modules[0].keywords = [keyword]
+        failing_printer = self._printer()
+        failing_printer.test_state = {"TC Broken": failed_tc}
+        group = failing_printer._render_tree()
+        titles = [getattr(r, "title", None) for r in group.renderables]
+        assert "Failure details" in titles
+
+
+# --------------------------------------------------------------------------- #
+# Signature-aware param split — a 'text='/'css=' locator is the positional      #
+# element, never a keyword argument (regression: playwright sample TypeError)   #
+# --------------------------------------------------------------------------- #
+
+class TestSignatureAwareParamSplit:
+    @staticmethod
+    def _validate_like(element, timeout="10", rule="all", event_name=None):
+        pass
+
+    def test_equals_locator_dispatched_positionally(self):
+        runner = _make_runner()
+        pos, kw = runner._resolve_candidate_params(
+            self._validate_like, ("text=Example Domain",))
+        assert pos == ["text=Example Domain"]
+        assert kw == {}
+
+    def test_genuine_keyword_arg_still_routed(self):
+        runner = _make_runner()
+        pos, kw = runner._resolve_candidate_params(
+            self._validate_like, ("text=OK", "event_name=tap"))
+        assert pos == ["text=OK"]
+        assert kw == {"event_name": "tap"}

--- a/tests/units/helpers/test_autocompletion.py
+++ b/tests/units/helpers/test_autocompletion.py
@@ -1,0 +1,110 @@
+"""Unit tests for shell-autocompletion installation (``autocompletion.py``).
+
+The completion scripts under ``~/.optics`` must be generated unconditionally,
+but the rc-file mutation is consent-gated: asked only on an interactive
+stdin, and a decline — or a non-TTY stdin, which cannot answer — leaves the
+rc file untouched and prints the manual ``source`` line instead.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.helper import autocompletion
+
+MODULE = "optics_framework.helper.autocompletion"
+
+pytestmark = pytest.mark.white_box
+
+
+class FakeStdin:
+    """stdin stand-in with a switchable TTY flag."""
+
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+def _run(home, *, shell="zsh", tty=True, confirm=True):
+    """Run update_shell_rc in isolation; returns (stdout, confirm_asked)."""
+    out = io.StringIO()
+    with patch(f"{MODULE}.sys.stdin", FakeStdin(tty)), \
+            patch(f"{MODULE}.Confirm.ask", return_value=confirm) as ask:
+        with contextlib.redirect_stdout(out):
+            autocompletion.update_shell_rc(shell=shell)
+    return out.getvalue(), ask.called
+
+
+def _rc_path(home, shell):
+    return home / (".zshrc" if "zsh" in shell else ".bashrc")
+
+
+@pytest.mark.parametrize("shell, rc_name", [("zsh", ".zshrc"), ("bash", ".bashrc")])
+class TestConsentGate:
+    def test_accepted_on_tty_appends_source_line(self, home, shell, rc_name):
+        out, asked = _run(home, shell=shell, tty=True, confirm=True)
+        rc = _rc_path(home, shell)
+        content = rc.read_text(encoding="utf-8")
+        assert "Optics CLI autocompletion" in content
+        assert f"source {home / '.optics'}/optics_completion." in content
+        assert "Added autocompletion" in out
+        assert asked
+
+    def test_declined_on_tty_touches_nothing_and_prints_manual_line(
+            self, home, shell, rc_name):
+        out, asked = _run(home, shell=shell, tty=True, confirm=False)
+        assert not _rc_path(home, shell).exists()
+        assert asked
+        expected = f"source {home / '.optics'}"
+        assert expected in out
+        assert any(line.strip().startswith("source ")
+                   for line in out.splitlines())
+
+    def test_non_tty_never_asks_or_writes(self, home, shell, rc_name):
+        out, asked = _run(home, shell=shell, tty=False)
+        assert not _rc_path(home, shell).exists()
+        assert not asked
+        assert "source" in out
+
+
+class TestScriptsAlwaysGenerated:
+    @pytest.mark.parametrize("tty, confirm", [(True, True), (True, False),
+                                              (False, False)])
+    def test_completion_scripts_written_regardless_of_consent(
+            self, home, tty, confirm):
+        _run(home, tty=tty, confirm=confirm)
+        optics_dir = home / ".optics"
+        assert (optics_dir / "optics_completion.zsh").exists()
+        assert (optics_dir / "optics_completion.sh").exists()
+
+
+class TestDuplicateDetection:
+    def test_already_enabled_skips_the_question(self, home):
+        source = (home / ".optics" / "optics_completion.zsh")
+        autocompletion.write_completion_scripts()
+        rc = home / ".zshrc"
+        rc.write_text(f"source {source}\n", encoding="utf-8")
+        out, asked = _run(home, shell="zsh", tty=True, confirm=True)
+        assert not asked
+        assert "already enabled" in out
+        assert rc.read_text(encoding="utf-8").count("source ") == 1
+
+
+class TestUnsupportedShell:
+    def test_unknown_shell_reports_without_writing(self, home):
+        out, asked = _run(home, shell="fish", tty=True, confirm=True)
+        assert "Unsupported shell" in out
+        assert asked is False  # never reached the consent question
+        assert not (home / ".zshrc").exists()
+        assert not (home / ".bashrc").exists()

--- a/tests/units/helpers/test_cli.py
+++ b/tests/units/helpers/test_cli.py
@@ -1,0 +1,139 @@
+"""Unit tests for the CLI dispatch layer (``optics_framework/helper/cli.py``).
+
+Covers the argparse-level behaviours the per-command modules don't: the
+bare-``optics`` welcome branch, ``main()``'s exception-to-exit-code mapping,
+SystemExit propagation from ``DoctorCommand`` (which must bypass the generic
+``except Exception`` handler so CI can gate on ``--check``), and the thin
+forwarding wrappers (configure / quickstart / doctor). Command bodies are
+patched at cli's import-time bindings; nothing real runs.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.helper import cli
+
+pytestmark = pytest.mark.white_box
+
+
+def _run(argv):
+    """Run cli.main() against a fake argv."""
+    with patch.object(cli.sys, "argv", ["optics", *argv]):
+        cli.main()
+
+
+class TestBareInvocation:
+    def test_bare_optics_welcomes_and_marks_onboarded(self):
+        with patch.object(cli, "welcome") as welcome, \
+                patch.object(cli, "is_first_run", return_value=True), \
+                patch.object(cli, "mark_onboarded") as mark:
+            _run([])
+        welcome.assert_called_once_with(first_run=True)
+        mark.assert_called_once_with()
+
+    def test_subcommand_never_welcomes(self):
+        with patch.object(cli, "welcome") as welcome, \
+                patch.object(cli, "mark_onboarded") as mark, \
+                patch.object(cli, "run_quickstart"):
+            _run(["quickstart"])
+        welcome.assert_not_called()
+        mark.assert_not_called()
+
+    def test_returning_command_skips_welcome_branch(self):
+        # A command that returns normally must fall through main() without
+        # tripping the elif len(sys.argv) == 1 welcome branch.
+        with patch.object(cli, "welcome") as welcome, \
+                patch.object(cli, "run_doctor", return_value=0):
+            with pytest.raises(SystemExit):
+                _run(["doctor"])
+        welcome.assert_not_called()
+
+    def test_bare_optics_returning_user_gets_one_line_hint(self, capsys):
+        # Returning users (is_first_run False) don't get the full panel; they
+        # get a one-line hint and no onboarding marker write.
+        with patch.object(cli, "welcome") as welcome, \
+                patch.object(cli, "is_first_run", return_value=False), \
+                patch.object(cli, "mark_onboarded") as mark:
+            _run([])
+        welcome.assert_not_called()
+        mark.assert_not_called()
+        out = capsys.readouterr().out
+        assert "optics quickstart" in out
+        assert "optics --help" in out
+
+
+class TestExitCodeMapping:
+    def test_doctor_check_failure_exits_nonzero_via_systemexit(self):
+        # DoctorCommand raises SystemExit itself; it is not an Exception, so
+        # main()'s generic handler must leave the code untouched.
+        with patch.object(cli, "run_doctor", return_value=1):
+            with pytest.raises(SystemExit) as exc:
+                _run(["doctor", "--check"])
+        assert exc.value.code == 1
+
+    def test_keyboard_interrupt_maps_to_130(self):
+        with patch.object(cli, "run_doctor", side_effect=KeyboardInterrupt):
+            with pytest.raises(SystemExit) as exc:
+                _run(["doctor"])
+        assert exc.value.code == 130
+
+    def test_value_error_maps_to_3(self):
+        with patch.object(cli, "run_doctor", side_effect=ValueError("bad")):
+            with pytest.raises(SystemExit) as exc:
+                _run(["doctor"])
+        assert exc.value.code == 3
+
+    def test_value_error_message_reads_cleanly(self, capsys):
+        with patch.object(cli, "run_doctor", side_effect=ValueError("bad")), \
+                pytest.raises(SystemExit):
+            _run(["doctor"])
+        err = capsys.readouterr().err
+        assert err.startswith("Error: bad")
+        assert "Value error" not in err
+
+    def test_unexpected_error_maps_to_1(self):
+        with patch.object(cli, "run_doctor", side_effect=RuntimeError("boom")):
+            with pytest.raises(SystemExit) as exc:
+                _run(["doctor"])
+        assert exc.value.code == 1
+
+
+class TestSetupInstallErrors:
+    def test_invalid_engine_token_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run(["setup", "--install", "banana"])
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Invalid engine(s): banana" in out
+        assert "optics setup --list" in out
+
+    def test_malformed_version_specifier_exits_nonzero(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run(["setup", "--install", "appium=4.2"])
+        assert exc.value.code == 1
+        assert "invalid version" in capsys.readouterr().out
+
+
+class TestCommandForwarding:
+    def test_doctor_forwards_folder_and_check(self):
+        with patch.object(cli, "run_doctor", return_value=0) as run_doctor:
+            with pytest.raises(SystemExit):
+                _run(["doctor", "myproj", "--check"])
+        run_doctor.assert_called_once_with(folder="myproj", check=True)
+
+    def test_configure_forwards_folder_and_edit_flag(self):
+        with patch.object(cli, "configure_project") as configure:
+            _run(["configure", "myproj"])
+        configure.assert_called_once_with(folder="myproj", edit=False)
+
+    def test_configure_defaults_to_cwd_without_edit(self):
+        with patch.object(cli, "configure_project") as configure:
+            _run(["configure"])
+        configure.assert_called_once_with(folder=None, edit=False)
+
+    def test_quickstart_runs_the_wizard(self):
+        with patch.object(cli, "run_quickstart") as quickstart:
+            _run(["quickstart"])
+        quickstart.assert_called_once_with()

--- a/tests/units/helpers/test_config_manager.py
+++ b/tests/units/helpers/test_config_manager.py
@@ -1,0 +1,165 @@
+"""Unit tests for the project-scoped config editor (``config_manager.configure``).
+
+The old global-file editor is gone; ``configure`` now reads/writes a project's
+own ``config.yaml``. These tests pin:
+
+- the beginner path (prompt → render → write → next steps), including the
+  confirm-before-overwrite gate,
+- ``--edit`` launching the Textual editor,
+- the deprecated ``optics config`` alias forwarding to the project editor.
+
+Collaborators from the onboarding package (``project_config``, ``onboarding``)
+are patched at their source modules — ``configure`` imports them lazily inside
+the function body.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.helper import config_manager
+
+MODULE = "optics_framework.helper.config_manager"
+PROJECT_CONFIG = "optics_framework.helper.project_config"
+ONBOARDING = "optics_framework.helper.onboarding"
+CLI = "optics_framework.helper.cli"
+
+
+@pytest.fixture
+def configured_helpers():
+    """Patch the onboarding-package collaborators configure() lazily imports."""
+    with patch(f"{PROJECT_CONFIG}.prompt_project_config",
+               return_value={"driver": "appium"}) as prompt, \
+            patch(f"{PROJECT_CONFIG}.render_project_config",
+                  return_value="rendered: yaml\n") as render, \
+            patch(f"{PROJECT_CONFIG}.write_project_config") as write, \
+            patch(f"{ONBOARDING}.print_next_steps") as next_steps:
+        yield SimpleNamespace(
+            prompt=prompt, render=render, write=write, next_steps=next_steps)
+
+
+@pytest.mark.white_box
+class TestConfigureOverwriteConfirm:
+    def test_writes_config_when_no_existing_file(self, tmp_path, capsys,
+                                                 configured_helpers):
+        folder = str(tmp_path)
+        config_manager.configure(folder=folder, edit=False)
+
+        configured_helpers.prompt.assert_called_once()
+        configured_helpers.write.assert_called_once_with(folder, "rendered: yaml\n")
+        configured_helpers.next_steps.assert_called_once_with(folder, configured=True)
+        assert "Wrote" in capsys.readouterr().out
+
+    def test_confirms_before_overwriting_existing_file(self, tmp_path,
+                                                       configured_helpers):
+        folder = str(tmp_path)
+        (tmp_path / "config.yaml").write_text("old: true\n", encoding="utf-8")
+
+        with patch(f"{MODULE}.Confirm.ask", return_value=True) as ask:
+            config_manager.configure(folder=folder, edit=False)
+
+        ask.assert_called_once()
+        configured_helpers.write.assert_called_once_with(folder, "rendered: yaml\n")
+
+    def test_aborts_without_writing_when_overwrite_declined(self, tmp_path,
+                                                            capsys,
+                                                            configured_helpers):
+        folder = str(tmp_path)
+        (tmp_path / "config.yaml").write_text("old: true\n", encoding="utf-8")
+
+        with patch(f"{MODULE}.Confirm.ask", return_value=False):
+            config_manager.configure(folder=folder, edit=False)
+
+        configured_helpers.write.assert_not_called()
+        configured_helpers.next_steps.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_defaults_to_current_directory(self, monkeypatch, tmp_path,
+                                           configured_helpers):
+        monkeypatch.chdir(tmp_path)
+        config_manager.configure()
+        configured_helpers.write.assert_called_once_with(str(tmp_path),
+                                                         "rendered: yaml\n")
+
+    def test_edit_true_launches_project_tui(self, tmp_path):
+        with patch(f"{MODULE}.ProjectConfigTUI") as tui_cls:
+            config_manager.configure(folder=str(tmp_path), edit=True)
+        tui_cls.assert_called_once_with(str(tmp_path))
+        tui_cls.return_value.run.assert_called_once()
+
+
+@pytest.mark.white_box
+class TestOverwriteAskedBeforeQuestions:
+    """The overwrite gate must come FIRST — a decline must waste no answers
+    (regression: every Q&A used to be asked, THEN discarded on decline)."""
+
+    def test_decline_never_prompts_any_question(self, tmp_path,
+                                                configured_helpers):
+        folder = str(tmp_path)
+        (tmp_path / "config.yaml").write_text("old: true\n", encoding="utf-8")
+
+        with patch(f"{MODULE}.Confirm.ask", return_value=False):
+            config_manager.configure(folder=folder, edit=False)
+
+        configured_helpers.prompt.assert_not_called()
+
+    def test_confirm_fires_before_the_question_block(self, tmp_path,
+                                                     configured_helpers):
+        folder = str(tmp_path)
+        order = []
+
+        def record_confirm(*_a, **_kw):
+            order.append("confirm")
+            return True
+
+        configured_helpers.prompt.side_effect = (
+            lambda *_a, **_kw: order.append("prompt") or {"driver": "appium"})
+        (tmp_path / "config.yaml").write_text("old: true\n", encoding="utf-8")
+
+        with patch(f"{MODULE}.Confirm.ask", side_effect=record_confirm):
+            config_manager.configure(folder=folder, edit=False)
+
+        assert order == ["confirm", "prompt"]
+
+    def test_no_existing_file_skips_confirm_entirely(self, tmp_path,
+                                                     configured_helpers):
+        with patch(f"{MODULE}.Confirm.ask") as ask:
+            config_manager.configure(folder=str(tmp_path), edit=False)
+        ask.assert_not_called()
+
+    def test_defaults_to_current_directory(self, monkeypatch, tmp_path,
+                                           configured_helpers):
+        monkeypatch.chdir(tmp_path)
+        config_manager.configure()
+        configured_helpers.write.assert_called_once_with(str(tmp_path),
+                                                         "rendered: yaml\n")
+
+    def test_edit_true_launches_project_tui(self, tmp_path):
+        with patch(f"{MODULE}.ProjectConfigTUI") as tui_cls:
+            config_manager.configure(folder=str(tmp_path), edit=True)
+        tui_cls.assert_called_once_with(str(tmp_path))
+        tui_cls.return_value.run.assert_called_once()
+
+
+@pytest.mark.white_box
+class TestConfigAliasDeprecation:
+    """``optics config`` now forwards to the guided project configuration.
+
+    cli.py binds ``configure`` at import time (``configure_project``), so the
+    patch target is cli's binding, not config_manager's."""
+
+    def test_prints_deprecation_and_forwards_to_guided_config(self, capsys):
+        from optics_framework.helper.cli import ConfigCommand
+
+        with patch(f"{CLI}.configure_project") as configure:
+            ConfigCommand().execute(SimpleNamespace())
+        out = capsys.readouterr().out
+        assert "deprecated" in out.lower()
+        assert "configure" in out
+        configure.assert_called_once()
+        _, kwargs = configure.call_args
+        assert kwargs.get("edit") is False
+        assert kwargs.get("folder") == os.getcwd()

--- a/tests/units/helpers/test_doctor.py
+++ b/tests/units/helpers/test_doctor.py
@@ -1,0 +1,640 @@
+"""Unit tests for ``optics doctor`` (``optics_framework/helper/doctor.py``).
+
+Environment probes are exercised through their seams — shutil.which, the
+metadata ``version`` lookup, subprocess.run and the socket — so the suite never
+needs adb, Appium or a browser installed. Project validation runs against real
+config.yaml files on disk and doubles as a guard against doctor mutating the
+project it inspects (no execution_output/ may appear).
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+from importlib.metadata import PackageNotFoundError
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from optics_framework.helper import doctor, project_config
+from optics_framework.helper.doctor import Check
+from optics_framework.helper.setup import ALL_ENGINES, DISTRIBUTION_NAME
+
+pytestmark = pytest.mark.white_box
+
+MODULE = "optics_framework.helper.doctor"
+
+# The real header `adb devices` prints. Tests must quote adb verbatim —
+# paraphrasing it here is exactly how the header-matching bug slipped through.
+ADB_HEADER = "List of devices attached"
+
+ANDROID_ANSWERS = {
+    "platform": "android",
+    "device_name": "emu-1",
+    "platform_name": "Android",
+    "app_package": "com.example.app",
+    "app_activity": "com.example.MainActivity",
+    "appium_url": "http://127.0.0.1:4723",
+    "ocr": False,
+    "log_level": "INFO",
+}
+
+IOS_ANSWERS = {
+    "platform": "ios",
+    "device_name": "iPhone 15",
+    "platform_name": "iOS",
+    "bundle_id": "com.example.app",
+    "appium_url": "http://127.0.0.1:4723",
+    "ocr": False,
+    "log_level": "INFO",
+}
+
+
+def _render(func, *args, **kwargs):
+    """Run a reporting function with a buffered console; returns (result, text)."""
+    buf = io.StringIO()
+    with patch(f"{MODULE}._console", Console(file=buf, width=200)):
+        result = func(*args, **kwargs)
+    return result, buf.getvalue()
+
+
+def _write_config(tmp_path, answers=None, raw=None) -> str:
+    folder = str(tmp_path / "demo")
+    os.makedirs(folder, exist_ok=True)
+    text = raw if raw is not None else project_config.render_project_config(
+        answers if answers is not None else ANDROID_ANSWERS)
+    with open(os.path.join(folder, "config.yaml"), "w", encoding="utf-8") as fh:
+        fh.write(text)
+    return folder
+
+
+# --------------------------------------------------------------------------- #
+# check_core                                                                   #
+# --------------------------------------------------------------------------- #
+
+class TestCheckCore:
+    def test_reports_installed_version(self):
+        with patch(f"{MODULE}.version", return_value="9.9.9"):
+            rows = doctor.check_core()
+        optics_row = next(r for r in rows if r.name == DISTRIBUTION_NAME)
+        assert optics_row.status == "ok"
+        assert "9.9.9" in optics_row.detail
+
+    def test_missing_package_is_warn_not_fail(self):
+        with patch(f"{MODULE}.version", side_effect=PackageNotFoundError):
+            rows = doctor.check_core()
+        optics_row = rows[-1]
+        assert optics_row.status == "warn"
+        assert "pip install" in optics_row.hint
+
+    def test_python_row_never_fails(self):
+        with patch(f"{MODULE}.version", side_effect=PackageNotFoundError):
+            rows = doctor.check_core()
+        python_row = rows[0]
+        assert python_row.name == "python"
+        assert python_row.status == "ok"
+
+
+# --------------------------------------------------------------------------- #
+# check_engines                                                                #
+# --------------------------------------------------------------------------- #
+
+class TestCheckEngines:
+    def test_one_row_per_engine(self):
+        with patch(f"{MODULE}.version", side_effect=PackageNotFoundError):
+            rows = doctor.check_engines()
+        assert sorted(r.name for r in rows) == sorted(e.name for e in ALL_ENGINES.values())
+
+    def test_missing_engine_warns_with_install_hint(self):
+        with patch(f"{MODULE}.version", side_effect=PackageNotFoundError):
+            rows = doctor.check_engines()
+        appium = next(r for r in rows if r.name == "Appium")
+        assert appium.status == "warn"
+        assert appium.hint == "optics setup --install appium"
+
+    def test_installed_engine_reports_package_and_version(self):
+        def fake_version(package):
+            if package == "appium-python-client":
+                return "5.0.0"
+            raise PackageNotFoundError(package)
+
+        with patch(f"{MODULE}.version", side_effect=fake_version):
+            rows = doctor.check_engines()
+        appium = next(r for r in rows if r.name == "Appium")
+        assert appium.status == "ok"
+        assert "appium-python-client 5.0.0" in appium.detail
+
+
+# --------------------------------------------------------------------------- #
+# check_mobile                                                                 #
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def no_socket(monkeypatch):
+    """Simulate "nothing listening": any connect attempt raises OSError."""
+    def refuse(*_args, **_kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(doctor.socket, "create_connection", refuse)
+
+
+class TestCheckMobile:
+    def test_no_adb_warns(self, no_socket):
+        with patch(f"{MODULE}.shutil.which", return_value=None):
+            rows = doctor.check_mobile()
+        assert [r.name for r in rows] == ["adb", "appium server"]
+        assert rows[0].status == "warn"
+        assert rows[1].status == "warn"
+
+    def test_connected_devices_are_parsed(self, no_socket, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/adb")
+        out = ("* daemon not running; starting now at tcp:5037\n"
+               "* daemon started successfully\n"
+               f"{ADB_HEADER}\n"
+               "emu-5554\tdevice\ndeadbeef\toffline\nx\tunauthorized\n")
+        stub = SimpleNamespace(stdout=out)
+        with patch.object(doctor.subprocess, "run", return_value=stub) as run, \
+                patch.object(doctor.socket, "create_connection"):
+            rows = doctor.check_mobile()
+        devices_row = next(r for r in rows if r.name == "adb devices")
+        assert devices_row.status == "ok"
+        assert "emu-5554" in devices_row.detail
+        assert "deadbeef" not in devices_row.detail
+        assert run.call_args.kwargs["shell"] is False
+
+    def test_no_devices_warns(self, no_socket, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/adb")
+        stub = SimpleNamespace(stdout=f"{ADB_HEADER}\n\n")
+        with patch.object(doctor.subprocess, "run", return_value=stub), \
+                patch.object(doctor.socket, "create_connection"):
+            rows = doctor.check_mobile()
+        row = next(r for r in rows if r.name == "adb devices")
+        assert row.status == "warn"
+        assert "no devices attached" in row.detail
+
+    def test_output_without_header_is_not_mistaken_for_zero_devices(
+            self, no_socket, monkeypatch):
+        # An adb error banner has no device-list header; reporting the serial
+        # count would be wrong either way — surface the unexpected output.
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/adb")
+        stub = SimpleNamespace(stdout="error: no devices/emulators found")
+        with patch.object(doctor.subprocess, "run", return_value=stub), \
+                patch.object(doctor.socket, "create_connection"):
+            rows = doctor.check_mobile()
+        row = next(r for r in rows if r.name == "adb devices")
+        assert row.status == "warn"
+        assert "unexpected adb output" in row.detail
+        assert "no devices attached" not in row.detail
+
+    def test_adb_failure_degrades_to_warning(self, no_socket, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: "/usr/bin/adb")
+        with patch.object(doctor.subprocess, "run",
+                          side_effect=subprocess.SubprocessError("kaboom")):
+            rows = doctor.check_mobile()
+        assert next(r for r in rows if r.name == "adb devices").status == "warn"
+
+    def test_appium_reachable_is_ok(self, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+        with patch.object(doctor.socket, "create_connection") as connect:
+            rows = doctor.check_mobile("10.0.0.5", 5555)
+        appium_row = rows[-1]
+        assert appium_row.status == "ok"
+        assert "10.0.0.5:5555" in appium_row.detail
+        connect.assert_called_once_with(("10.0.0.5", 5555), timeout=doctor._SOCKET_TIMEOUT_S)
+
+
+# --------------------------------------------------------------------------- #
+# check_web                                                                    #
+# --------------------------------------------------------------------------- #
+
+class TestCheckWeb:
+    @pytest.fixture(autouse=True)
+    def isolated_home(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self.home = tmp_path
+
+    def test_uninstalled_packages_warn(self, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+        with patch(f"{MODULE}.version", side_effect=PackageNotFoundError):
+            rows = doctor.check_web()
+        assert all(r.status == "warn" for r in rows)
+        hints = {r.hint for r in rows}
+        assert any("optics setup --install playwright" in h for h in hints)
+
+    @pytest.mark.parametrize(
+        "browser_dir", [["Library/Caches/ms-playwright"], [".cache/ms-playwright"]]
+    )
+    def test_chromium_download_detected(self, browser_dir, monkeypatch):
+        cache = self.home
+        for part in browser_dir:
+            cache = cache / part
+        (cache / "chromium-1200").mkdir(parents=True)
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+        with patch(f"{MODULE}.version", return_value="1.49.0"):
+            rows = doctor.check_web()
+        pw = next(r for r in rows if r.name == "playwright browser")
+        assert pw.status == "ok"
+
+    def test_playwright_without_browser_download_warns(self, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+        with patch(f"{MODULE}.version", return_value="1.49.0"):
+            rows = doctor.check_web()
+        pw = next(r for r in rows if r.name == "playwright browser")
+        assert pw.status == "warn"
+        assert "playwright install chromium" in pw.hint
+
+    def test_selenium_with_driver_on_path_is_ok(self, monkeypatch):
+        monkeypatch.setattr(doctor.shutil, "which",
+                            lambda name: "/usr/bin/chromedriver" if name == "chromedriver" else None)
+        with patch(f"{MODULE}.version", return_value="4.20.0"):
+            rows = doctor.check_web()
+        selenium_row = next(r for r in rows if r.name == "selenium webdriver")
+        assert selenium_row.status == "ok"
+
+
+# --------------------------------------------------------------------------- #
+# validate_project                                                             #
+# --------------------------------------------------------------------------- #
+
+class TestValidateProject:
+    def test_valid_rendered_config_all_ok(self, tmp_path):
+        folder = _write_config(tmp_path)
+        rows = doctor.validate_project(folder)
+        assert rows, "expected at least one row"
+        assert all(r.status == "ok" for r in rows)
+        assert all(r.name.startswith("config:") for r in rows)
+
+    def test_no_enabled_driver_fails(self, tmp_path):
+        starter = "\n".join(
+            line.replace("enabled: true", "enabled: false")
+            for line in project_config.render_project_config(ANDROID_ANSWERS).splitlines()
+        )
+        folder = _write_config(tmp_path, raw=starter + "\n")
+        rows = doctor.validate_project(folder)
+        assert any(r.status == "fail" and "no driver enabled" in r.detail for r in rows)
+
+    def test_multiple_enabled_drivers_warn(self, tmp_path):
+        # The framework deliberately supports multi-driver fallback
+        # (InstanceFallback), so >1 enabled driver stays a warning — but the
+        # "exactly one" guidance must still surface.
+        raw = (
+            "driver_sources:\n"
+            "  - appium:\n"
+            "      enabled: true\n"
+            "      url: 'http://127.0.0.1:4723'\n"
+            "      capabilities:\n"
+            "        deviceName: emu-1\n"
+            "        platformName: Android\n"
+            "        appPackage: com.example.app\n"
+            "        appActivity: com.example.MainActivity\n"
+            "  - playwright:\n"
+            "      enabled: true\n"
+            "      capabilities:\n"
+            "        browser: chromium\n"
+            "elements_sources:\n"
+            "  - appium_find_element:\n"
+            "      enabled: true\n"
+            "  - playwright_find_element:\n"
+            "      enabled: true\n"
+        )
+        folder = _write_config(tmp_path, raw=raw)
+        rows = doctor.validate_project(folder)
+        driver_row = next(r for r in rows if r.name == "config: driver")
+        assert driver_row.status == "warn"
+        assert "2 drivers enabled" in driver_row.detail
+        assert "appium" in driver_row.detail
+        assert "playwright" in driver_row.detail
+
+    def test_driver_without_matching_source_fails(self, tmp_path):
+        raw = (
+            "driver_sources:\n"
+            "  - appium:\n"
+            "      enabled: true\n"
+            "      url: 'http://127.0.0.1:4723'\n"
+            "elements_sources:\n"
+            "  - appium_find_element:\n"
+            "      enabled: false\n"
+        )
+        folder = _write_config(tmp_path, raw=raw)
+        rows = doctor.validate_project(folder)
+        assert any(r.status == "fail" and "element source" in r.name for r in rows)
+
+    def test_appium_without_url_fails(self, tmp_path):
+        raw = (
+            "driver_sources:\n"
+            "  - appium:\n"
+            "      enabled: true\n"
+            "      capabilities:\n"
+            "        deviceName: emu-1\n"
+            "        platformName: Android\n"
+            "        appPackage: com.example.app\n"
+            "        appActivity: com.example.MainActivity\n"
+            "elements_sources:\n"
+            "  - appium_find_element:\n"
+            "      enabled: true\n"
+        )
+        folder = _write_config(tmp_path, raw=raw)
+        rows = doctor.validate_project(folder)
+        assert any(r.status == "fail" and "url is missing" in r.detail for r in rows)
+
+    def test_ios_settings_row_ok_with_bundle_id(self, tmp_path):
+        folder = _write_config(tmp_path, answers=IOS_ANSWERS)
+        rows = doctor.validate_project(folder)
+        settings = next(r for r in rows if r.name == "config: appium settings")
+        assert settings.status == "ok"
+
+    def test_ios_settings_row_fails_without_bundle_id(self, tmp_path):
+        raw = (
+            "driver_sources:\n"
+            "  - appium:\n"
+            "      enabled: true\n"
+            "      url: 'http://127.0.0.1:4723'\n"
+            "      capabilities:\n"
+            "        automationName: XCUITest\n"
+            "        deviceName: iPhone 15\n"
+            "        platformName: iOS\n"
+            "elements_sources:\n"
+            "  - appium_find_element:\n"
+            "      enabled: true\n"
+        )
+        folder = _write_config(tmp_path, raw=raw)
+        rows = doctor.validate_project(folder)
+        settings = next(r for r in rows if r.name == "config: appium settings")
+        assert settings.status == "fail"
+        assert "bundleId missing in capabilities" in settings.detail
+
+    def test_android_settings_still_require_app_package_and_activity(self, tmp_path):
+        raw = (
+            "driver_sources:\n"
+            "  - appium:\n"
+            "      enabled: true\n"
+            "      url: 'http://127.0.0.1:4723'\n"
+            "      capabilities:\n"
+            "        automationName: UiAutomator2\n"
+            "        deviceName: emu-1\n"
+            "        platformName: Android\n"
+            "elements_sources:\n"
+            "  - appium_find_element:\n"
+            "      enabled: true\n"
+        )
+        folder = _write_config(tmp_path, raw=raw)
+        rows = doctor.validate_project(folder)
+        settings = next(r for r in rows if r.name == "config: appium settings")
+        # Historical severity for a missing android capability is a warning.
+        assert settings.status == "warn"
+        assert "appPackage missing in capabilities" in settings.detail
+        assert "appActivity missing in capabilities" in settings.detail
+
+    def test_missing_config_file_fails(self, tmp_path):
+        rows = doctor.validate_project(str(tmp_path / "nowhere"))
+        assert rows[0].status == "fail"
+        assert "no config.yaml" in rows[0].detail
+
+    def test_unparseable_yaml_fails(self, tmp_path):
+        folder = _write_config(tmp_path, raw="driver_sources: [oops\n")
+        rows = doctor.validate_project(folder)
+        assert any(r.status == "fail" for r in rows)
+
+    def test_creates_no_execution_output_dir(self, tmp_path):
+        folder = _write_config(tmp_path)
+        before = sorted(os.listdir(folder))
+        doctor.validate_project(folder)
+        after = sorted(os.listdir(folder))
+        assert before == after
+        assert "execution_output" not in after
+
+
+# --------------------------------------------------------------------------- #
+# _split_host_port                                                             #
+# --------------------------------------------------------------------------- #
+
+class TestSplitHostPort:
+    @pytest.mark.parametrize("url, expected", [
+        ("http://10.1.2.3:5555", ("10.1.2.3", 5555)),
+        ("https://appium.corp.local:4443/wd/hub", ("appium.corp.local", 4443)),
+        ("10.0.0.5:4723", ("10.0.0.5", 4723)),  # schemeless host:port
+        ("127.0.0.1", ("127.0.0.1", 4723)),     # bare host keeps the default port
+        ("localhost:8080/", ("localhost", 8080)),
+    ])
+    def test_parses_host_and_port(self, url, expected):
+        assert doctor._split_host_port(url) == expected
+
+    @pytest.mark.parametrize("url", [
+        None,
+        "",
+        "   ",
+        "host:notaport",   # non-numeric port → urlparse raises ValueError
+        "host:99999",      # out-of-range port → ValueError
+    ])
+    def test_unusable_url_falls_back_to_none(self, url):
+        assert doctor._split_host_port(url) is None
+
+
+# --------------------------------------------------------------------------- #
+# run_doctor                                                                   #
+# --------------------------------------------------------------------------- #
+
+def _stub_env_rows():
+    return [Check("python", "ok", "3.12.1"),
+            Check("Appium", "warn", "not installed", "optics setup --install appium")]
+
+
+class TestRunDoctor:
+    @pytest.fixture
+    def quiet_env(self, monkeypatch):
+        """Replace every environment probe with one canned warning row."""
+        monkeypatch.setattr(doctor, "check_core", _stub_env_rows)
+        monkeypatch.setattr(doctor, "check_engines", lambda: [])
+        monkeypatch.setattr(doctor, "check_web", lambda: [])
+        captured = {}
+
+        def fake_check_mobile(host="127.0.0.1", port=4723):
+            captured["target"] = (host, port)
+            return [Check("appium server", "warn", f"{host}:{port}")]
+
+        monkeypatch.setattr(doctor, "check_mobile", fake_check_mobile)
+        return captured
+
+    def test_zero_when_environment_has_only_warnings(self, quiet_env):
+        code, out = _render(doctor.run_doctor)
+        assert code == 0
+        assert "⚠️" in out
+
+    def test_nonzero_when_critical_row_fails(self, quiet_env, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "validate_project",
+            lambda _f: [Check("config: driver", "fail", "no driver enabled")])
+        code, _ = _render(doctor.run_doctor, "/some/project", check=True)
+        assert code == 1
+
+    def test_check_false_always_returns_zero(self, quiet_env, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "validate_project",
+            lambda _f: [Check("config: driver", "fail", "no driver enabled")])
+        code, _ = _render(doctor.run_doctor, "/some/project")
+        assert code == 0
+
+    def test_zero_when_project_validates(self, quiet_env, tmp_path):
+        folder = _write_config(tmp_path)
+        code, _ = _render(doctor.run_doctor, folder, check=True)
+        assert code == 0
+
+    def test_validation_failure_ignored_without_check(self, quiet_env, monkeypatch):
+        sentinel = [Check("config: file", "fail", "no config.yaml in /gone")]
+        validator = MagicMock(return_value=sentinel)
+        monkeypatch.setattr(doctor, "validate_project", validator)
+        code, _ = _render(doctor.run_doctor, "/gone", check=False)
+        validator.assert_called_once_with("/gone")
+        # check=False must stay green even though validation failed.
+        assert code == 0
+
+    def test_mobile_probe_uses_project_appium_url(self, quiet_env, tmp_path):
+        folder = _write_config(tmp_path, answers={
+            **ANDROID_ANSWERS, "appium_url": "http://10.1.2.3:5555"})
+        _render(doctor.run_doctor, folder)
+        assert quiet_env["target"] == ("10.1.2.3", 5555)
+
+    def test_mobile_probe_defaults_for_non_appium_project(self, quiet_env, tmp_path):
+        folder = _write_config(tmp_path, answers={
+            **ANDROID_ANSWERS, "platform": "web-selenium"})
+        _render(doctor.run_doctor, folder)
+        assert quiet_env["target"] == ("127.0.0.1", 4723)
+
+    def test_report_prints_glyphs(self, quiet_env, tmp_path):
+        folder = tmp_path / "broken"
+        folder.mkdir()
+        _, out = _render(doctor.run_doctor, str(folder))
+        assert "❌" in out
+        assert "config:" in out
+
+
+class TestMissingProjectRow:
+    """A bare `optics doctor` must speak about the absent project instead of
+    printing only machine rows (and the absence itself is a warning, never a
+    --check failure)."""
+
+    def test_bare_run_in_empty_dir_warns_about_missing_project(
+            self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        with patch(f"{MODULE}.check_core", _stub_env_rows), \
+                patch(f"{MODULE}.check_engines", return_value=[]), \
+                patch(f"{MODULE}.check_web", return_value=[]), \
+                patch(f"{MODULE}.check_mobile", return_value=[]):
+            code, out = _render(doctor.run_doctor)
+        assert 'project' in out
+        assert "No config.yaml found here" in out
+        assert "`optics quickstart`" in out
+
+    def test_missing_project_row_does_not_fail_check(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        with patch(f"{MODULE}.check_core", _stub_env_rows), \
+                patch(f"{MODULE}.check_engines", return_value=[]), \
+                patch(f"{MODULE}.check_web", return_value=[]), \
+                patch(f"{MODULE}.check_mobile", return_value=[]):
+            code, _ = _render(doctor.run_doctor, check=True)
+        assert code == 0
+
+    def test_no_project_row_when_cwd_has_config(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.yaml").write_text("driver_sources: []\n",
+                                              encoding="utf-8")
+        with patch(f"{MODULE}.check_core", _stub_env_rows), \
+                patch(f"{MODULE}.check_engines", return_value=[]), \
+                patch(f"{MODULE}.check_web", return_value=[]), \
+                patch(f"{MODULE}.check_mobile", return_value=[]):
+            _, out = _render(doctor.run_doctor)
+        assert "No config.yaml found here" not in out
+
+    def test_explicit_folder_keeps_its_own_fail_row(self, tmp_path):
+        folder = str(tmp_path / "empty")
+        os.makedirs(folder)
+        with patch(f"{MODULE}.check_core", _stub_env_rows), \
+                patch(f"{MODULE}.check_engines", return_value=[]), \
+                patch(f"{MODULE}.check_web", return_value=[]), \
+                patch(f"{MODULE}.check_mobile", return_value=[]):
+            code, out = _render(doctor.run_doctor, folder, check=True)
+        assert "No config.yaml found here" not in out
+        assert "config:" in out
+        assert code == 1
+
+
+class TestGatedClosingMessage:
+    """Warnings on an ENABLED driver's must-haves replace the reassurance
+    with a targeted call-to-action listing exactly those hints."""
+
+    APPIUM_HINT = "Start it in another terminal with the `appium` command."
+    DEVICE_HINT = "Connect a device or start an emulator (USB debugging on)."
+    SELENIUM_HINT = "Install a browser with a matching driver (e.g. chromedriver)."
+    PLAYWRIGHT_HINT = ("playwright install chromium  "
+                       "(or: optics setup --install playwright)")
+
+    def _run_with_rows(self, tmp_path, *, env_rows, web_rows=None,
+                       answers=None):
+        folder = _write_config(tmp_path, answers=answers)
+        web = web_rows if web_rows is not None else []
+        with patch(f"{MODULE}.check_core",
+                   return_value=[Check("python", "ok", "3.12")]), \
+                patch(f"{MODULE}.check_engines", return_value=[]), \
+                patch(f"{MODULE}.check_web", return_value=web), \
+                patch(f"{MODULE}.check_mobile", return_value=env_rows):
+            return _render(doctor.run_doctor, folder)
+
+    def test_appium_server_and_device_warns_are_called_out(self, tmp_path):
+        rows = [
+            Check("adb devices", "warn", "no devices attached", self.DEVICE_HINT),
+            Check("appium server", "warn", "not reachable at 127.0.0.1:4723",
+                  self.APPIUM_HINT),
+        ]
+        _, out = self._run_with_rows(tmp_path, env_rows=rows)
+        assert "⚠️ Before your first real run:" in out
+        assert f"  • {self.DEVICE_HINT}" in out
+        assert f"  • {self.APPIUM_HINT}" in out
+        assert "Good enough to start" not in out
+
+    def test_selenium_driver_warn_is_called_out(self, tmp_path):
+        _, out = self._run_with_rows(
+            tmp_path, env_rows=[],
+            web_rows=[Check("selenium webdriver", "warn",
+                            "package installed, but no WebDriver binary on PATH",
+                            self.SELENIUM_HINT)],
+            answers={**ANDROID_ANSWERS, "platform": "web-selenium"})
+        assert "⚠️ Before your first real run:" in out
+        assert f"  • {self.SELENIUM_HINT}" in out
+
+    def test_playwright_browser_warn_is_called_out(self, tmp_path):
+        _, out = self._run_with_rows(
+            tmp_path, env_rows=[],
+            web_rows=[Check("playwright browser", "warn",
+                            "package installed, but no Chromium download detected",
+                            self.PLAYWRIGHT_HINT)],
+            answers={**ANDROID_ANSWERS, "platform": "web-playwright"})
+        assert "⚠️ Before your first real run:" in out
+        assert f"  • {self.PLAYWRIGHT_HINT}" in out
+
+    def test_warning_for_other_drivers_keeps_reassurance(self, tmp_path):
+        _, out = self._run_with_rows(
+            tmp_path, env_rows=[],
+            web_rows=[Check("playwright browser", "warn", "missing",
+                            self.PLAYWRIGHT_HINT)])
+        assert "Good enough to start" in out
+        assert "Before your first real run" not in out
+
+    def test_ok_driver_requirements_keep_reassurance(self, tmp_path):
+        rows = [
+            Check("adb devices", "ok", "1 connected: emu-5554"),
+            Check("appium server", "ok", "reachable at 127.0.0.1:4723"),
+            Check("EasyOCR", "warn", "easyocr not installed",
+                  "optics setup --install easyocr"),
+        ]
+        _, out = self._run_with_rows(tmp_path, env_rows=rows)
+        assert "Good enough to start" in out
+
+    def test_counts_line_survives_gating(self, tmp_path):
+        rows = [
+            Check("adb devices", "warn", "no devices attached", self.DEVICE_HINT),
+            Check("appium server", "warn", "not reachable", self.APPIUM_HINT),
+        ]
+        _, out = self._run_with_rows(tmp_path, env_rows=rows)
+        assert "warning(s)" in out

--- a/tests/units/helpers/test_execute.py
+++ b/tests/units/helpers/test_execute.py
@@ -1,0 +1,375 @@
+"""Unit tests for the CSV/YAML CLI entry points (``optics_framework/helper/execute.py``).
+
+Covers the exit-code contract of ``execute_main`` / ``dryrun_main`` (non-zero when
+any returned test case did not PASS), the friendly pre-session gate that stops
+the run when no driver is enabled in the project's ``config.yaml`` — before any
+``SessionManager`` is constructed — and the execute-only environment preflight
+that probes Selenium/Appium servers and attached Android devices before any
+test runs. Heavy collaborators are patched; nothing real executes.
+"""
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.common.config_handler import Config, DependencyConfig
+from optics_framework.helper import execute as execute_module
+from optics_framework.helper.execute import (
+    BaseRunner,
+    execute_main,
+    dryrun_main,
+)
+
+pytestmark = pytest.mark.white_box
+
+
+# --------------------------------------------------------------------------- #
+# Exit-code mapping                                                            #
+# --------------------------------------------------------------------------- #
+
+def _tc(status):
+    return SimpleNamespace(status=status)
+
+
+class _StubArgs:
+    def __init__(self, **kwargs):
+        pass
+
+
+def _runner_cls(results):
+    class _StubRunner:
+        def __init__(self, args):
+            pass
+
+        async def execute(self):
+            return results
+    return _StubRunner
+
+
+class TestExitCodeMapping:
+    def test_all_pass_exits_zero(self):
+        results = {"tc": _tc("PASS")}
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "ExecuteRunner", _runner_cls(results)):
+            execute_main("proj")
+
+    def test_any_fail_exits_nonzero(self):
+        results = {"ok": _tc("PASS"), "bad": _tc("FAIL")}
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "ExecuteRunner", _runner_cls(results)):
+            with pytest.raises(SystemExit) as exc:
+                execute_main("proj")
+        assert exc.value.code == 1
+
+    def test_dry_run_any_fail_exits_nonzero(self):
+        results = {"bad": _tc("FAIL")}
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "DryRunRunner", _runner_cls(results)):
+            with pytest.raises(SystemExit) as exc:
+                dryrun_main("proj")
+        assert exc.value.code == 1
+
+    def test_non_dict_result_never_exits(self):
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "ExecuteRunner", _runner_cls(None)):
+            execute_main("proj")
+
+    def test_empty_results_exit_zero(self):
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "DryRunRunner", _runner_cls({})):
+            dryrun_main("proj")
+
+
+# --------------------------------------------------------------------------- #
+# No-enabled-driver gate                                                       #
+# --------------------------------------------------------------------------- #
+
+def _bare_runner(config):
+    runner = BaseRunner.__new__(BaseRunner)
+    runner.config = config
+    return runner
+
+
+class TestHasEnabledDriver:
+    def test_true_when_any_driver_enabled(self):
+        config = Config(driver_sources=[{
+            "selenium": DependencyConfig(enabled=False),
+            "appium": DependencyConfig(enabled=True),
+        }])
+        assert _bare_runner(config)._has_enabled_driver() is True
+
+    def test_false_when_all_disabled(self):
+        config = Config(driver_sources=[{
+            "selenium": DependencyConfig(enabled=False),
+        }])
+        assert _bare_runner(config)._has_enabled_driver() is False
+
+
+def _make_project(tmp_path, config_text):
+    (tmp_path / "test_cases").mkdir()
+    (tmp_path / "modules").mkdir()
+    (tmp_path / "test_cases" / "test_cases.csv").write_text(
+        "test_case,test_step\nTC One,Launch App\n"
+    )
+    (tmp_path / "modules" / "modules.csv").write_text(
+        "module_name,module_step\nLaunch App,Launch App,\n"
+    )
+    (tmp_path / "config.yaml").write_text(config_text)
+
+
+_ALL_DISABLED_CONFIG = """\
+driver_sources:
+  - selenium:
+      enabled: false
+      capabilities: {}
+elements_sources:
+  - selenium_find_element:
+      enabled: false
+      capabilities: {}
+"""
+
+
+class TestEmptyProjectGuard:
+    def test_empty_test_cases_exits_with_guidance(self, tmp_path, capsys):
+        runner = BaseRunner.__new__(BaseRunner)
+        runner.folder_path = str(tmp_path)
+        runner.test_cases_data = {}
+        with pytest.raises(SystemExit) as exc:
+            runner._filter_and_build_execution_queue()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "No test cases to run" in err
+        assert "optics init" in err
+        assert "Unexpected error" not in err
+        assert "linked list" not in err
+
+
+class TestNoEnabledDriverGate:
+    @pytest.mark.parametrize("main", [execute_main, dryrun_main])
+    def test_gate_prints_guidance_and_skips_session(self, tmp_path, capsys, main):
+        _make_project(tmp_path, _ALL_DISABLED_CONFIG)
+        with patch.object(execute_module, "SessionManager") as session_manager:
+            with pytest.raises(SystemExit) as exc:
+                main(str(tmp_path))
+        assert exc.value.code == 1
+        session_manager.assert_not_called()
+        out = capsys.readouterr().out
+        assert f"No driver enabled in {tmp_path / 'config.yaml'}" in out
+        assert f"optics configure {tmp_path}" in out
+        assert "Unexpected error" not in out
+
+
+
+def _config_for(driver: str, **dep_kwargs) -> Config:
+    return Config(driver_sources=[{driver: DependencyConfig(enabled=True, **dep_kwargs)}])
+
+
+class TestProbeTcp:
+    def test_open_port_returns_true(self):
+        server = socket.socket()
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        try:
+            assert execute_module._probe_tcp(
+                f"http://127.0.0.1:{port}", default_port=4723) is True
+        finally:
+            server.close()
+
+    def test_default_port_used_when_url_has_none(self):
+        server = socket.socket()
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        try:
+            assert execute_module._probe_tcp(
+                "http://127.0.0.1", default_port=port) is True
+        finally:
+            server.close()
+
+    def test_closed_port_returns_false(self):
+        assert execute_module._probe_tcp(
+            "http://127.0.0.1:1", default_port=4723, timeout=0.5) is False
+
+    @pytest.mark.parametrize("url", [None, "", "   ", "http://:4723/wd/hub"])
+    def test_missing_or_unparseable_url_returns_false(self, url):
+        assert execute_module._probe_tcp(url, default_port=4723) is False
+
+
+def _fake_adb_run(stdout):
+    def _run(*args, **kwargs):
+        return SimpleNamespace(stdout=stdout)
+    return _run
+
+
+class TestAdbDeviceCount:
+    def test_none_when_adb_not_installed(self):
+        with patch.object(execute_module.shutil, "which", return_value=None):
+            assert execute_module._adb_device_count() is None
+
+    def test_counts_only_device_state_lines(self):
+        stdout = ("* daemon not running; starting now *\n"
+                  "List of devices attached\n"
+                  "emulator-5554\tdevice\n"
+                  "abc123\tdevice\n")
+        with patch.object(execute_module.shutil, "which", return_value="/usr/bin/adb"), \
+                patch.object(execute_module.subprocess, "run", _fake_adb_run(stdout)):
+            assert execute_module._adb_device_count() == 2
+
+    def test_ignores_offline_entries(self):
+        stdout = "List of devices attached\nemulator-5554\toffline\n"
+        with patch.object(execute_module.shutil, "which", return_value="/usr/bin/adb"), \
+                patch.object(execute_module.subprocess, "run", _fake_adb_run(stdout)):
+            assert execute_module._adb_device_count() == 0
+
+    def test_headerless_output_is_zero_not_a_device(self):
+        stdout = "error: device not found\n"
+        with patch.object(execute_module.shutil, "which", return_value="/usr/bin/adb"), \
+                patch.object(execute_module.subprocess, "run", _fake_adb_run(stdout)):
+            assert execute_module._adb_device_count() == 0
+
+    def test_none_when_adb_cannot_execute(self):
+        def _boom(*args, **kwargs):
+            raise OSError("no exec")
+        with patch.object(execute_module.shutil, "which", return_value="/usr/bin/adb"), \
+                patch.object(execute_module.subprocess, "run", _boom):
+            assert execute_module._adb_device_count() is None
+
+
+
+class TestPreflightGate:
+    def test_playwright_skips_silently_without_probes(self):
+        config = _config_for("playwright")
+        with patch.object(execute_module, "_probe_tcp") as probe, \
+                patch.object(execute_module, "_adb_device_count") as adb:
+            execute_module._preflight_or_exit(config)
+        probe.assert_not_called()
+        adb.assert_not_called()
+
+    def test_appium_unreachable_aborts_with_fix(self, capsys):
+        config = _config_for("appium", url="http://127.0.0.1:9999")
+        with patch.object(execute_module, "_probe_tcp", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                execute_module._preflight_or_exit(config, folder_path="/proj")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "No Appium server reachable at http://127.0.0.1:9999" in err
+        assert "appium" in err
+        assert "optics execute /proj" in err
+
+    def test_appium_reachable_non_android_passes_without_adb_check(self):
+        config = _config_for("appium", url="http://127.0.0.1:4723",
+                             capabilities={"platformName": "iOS"})
+        with patch.object(execute_module, "_probe_tcp", return_value=True), \
+                patch.object(execute_module, "_adb_device_count") as adb:
+            execute_module._preflight_or_exit(config)
+        adb.assert_not_called()
+
+    def test_android_with_attached_device_passes(self):
+        config = _config_for("appium", capabilities={"platformName": "Android"})
+        with patch.object(execute_module, "_probe_tcp", return_value=True), \
+                patch.object(execute_module, "_adb_device_count", return_value=1):
+            execute_module._preflight_or_exit(config)
+
+    def test_android_without_devices_aborts(self, capsys):
+        config = _config_for("appium", capabilities={"platformName": "Android"})
+        with patch.object(execute_module, "_probe_tcp", return_value=True), \
+                patch.object(execute_module, "_adb_device_count", return_value=0):
+            with pytest.raises(SystemExit) as exc:
+                execute_module._preflight_or_exit(config)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "No Android device/emulator attached" in err
+        assert "adb devices" in err
+
+    def test_android_without_adb_aborts(self, capsys):
+        config = _config_for("appium", capabilities={"platformName": "android"})
+        with patch.object(execute_module, "_probe_tcp", return_value=True), \
+                patch.object(execute_module, "_adb_device_count", return_value=None):
+            with pytest.raises(SystemExit) as exc:
+                execute_module._preflight_or_exit(config)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "adb" in err
+        assert "platform-tools" in err
+
+    def test_appium_default_url_used_when_config_url_missing(self, capsys):
+        config = _config_for("appium")
+        seen = {}
+
+        def _fake_probe(url, default_port, timeout=2.0):
+            seen["url"] = url
+            return False
+
+        with patch.object(execute_module, "_probe_tcp", side_effect=_fake_probe):
+            with pytest.raises(SystemExit):
+                execute_module._preflight_or_exit(config)
+        assert seen["url"] == "http://127.0.0.1:4723"
+
+    def test_selenium_unreachable_aborts_with_fix(self, capsys):
+        config = _config_for("selenium", url="http://localhost:4444/wd/hub")
+        with patch.object(execute_module, "_probe_tcp", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                execute_module._preflight_or_exit(config)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "No Selenium/WebDriver server reachable at http://localhost:4444/wd/hub" in err
+
+    def test_selenium_reachable_passes(self):
+        config = _config_for("selenium")
+        with patch.object(execute_module, "_probe_tcp", return_value=True):
+            execute_module._preflight_or_exit(config)
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE"])
+    def test_skip_env_bypasses_every_probe(self, monkeypatch, value):
+        monkeypatch.setenv("OPTICS_SKIP_PREFLIGHT", value)
+        config = _config_for("appium", capabilities={"platformName": "Android"})
+        with patch.object(execute_module, "_probe_tcp") as probe, \
+                patch.object(execute_module, "_adb_device_count") as adb:
+            execute_module._preflight_or_exit(config)
+        probe.assert_not_called()
+        adb.assert_not_called()
+
+    def test_no_enabled_driver_is_left_to_the_existing_gate(self):
+        config = Config(driver_sources=[{"selenium": DependencyConfig(enabled=False)}])
+        with patch.object(execute_module, "_probe_tcp") as probe:
+            execute_module._preflight_or_exit(config)
+        probe.assert_not_called()
+
+    def test_none_config_steps_aside(self):
+        execute_module._preflight_or_exit(None)
+
+
+class TestPreflightWiring:
+    def test_execute_main_preflights_before_running(self):
+        order = []
+        sentinel_config = object()
+
+        class _RunnerWithConfig:
+            def __init__(self, args):
+                self.config = sentinel_config
+
+            async def execute(self):
+                order.append("execute")
+                return {}
+
+        def _spy_preflight(config, folder_path="<folder>"):
+            assert config is sentinel_config
+            order.append("preflight")
+
+        with patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "ExecuteRunner", _RunnerWithConfig), \
+                patch.object(execute_module, "_preflight_or_exit",
+                             side_effect=_spy_preflight):
+            execute_main("proj")
+        assert order == ["preflight", "execute"]
+
+    def test_dry_run_never_preflights(self):
+        with patch.object(execute_module, "_preflight_or_exit") as preflight, \
+                patch.object(execute_module, "RunnerArgs", _StubArgs), \
+                patch.object(execute_module, "DryRunRunner", _runner_cls({})):
+            dryrun_main("proj")
+        preflight.assert_not_called()

--- a/tests/units/helpers/test_generate.py
+++ b/tests/units/helpers/test_generate.py
@@ -16,6 +16,7 @@ explicit drift guard.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -512,6 +513,11 @@ class TestGenerateTestFile:
         generate_test_file(str(csv_project), framework="pytest", output_filename="my_suite.py")
         assert (csv_project / "generated" / "Tests" / "my_suite.py").exists()
 
+    def test_custom_output_nested_path(self, csv_project):
+        generate_test_file(
+            str(csv_project), framework="pytest", output_filename="sub/dir/my_suite.py")
+        assert (csv_project / "generated" / "Tests" / "sub" / "dir" / "my_suite.py").exists()
+
     def test_copies_input_templates(self, csv_project):
         templates = csv_project / "input_templates"
         templates.mkdir()
@@ -524,16 +530,16 @@ class TestGenerateTestFile:
     @pytest.mark.parametrize(
         "missing", ["config.yaml", "test_cases.csv", "modules.csv", "elements.csv"]
     )
-    def test_missing_required_file_aborts_without_output(self, csv_project, caplog, missing):
+    def test_missing_required_file_aborts_without_output(self, csv_project, missing):
         (csv_project / missing).unlink()
-        generate_test_file(str(csv_project), framework="pytest")
+        with pytest.raises(ValueError, match="missing"):
+            generate_test_file(str(csv_project), framework="pytest")
         assert not (csv_project / "generated").exists()
-        assert "Error" in caplog.text or "Missing" in caplog.text
 
-    def test_unsupported_framework_aborts(self, csv_project, caplog):
-        generate_test_file(str(csv_project), framework="junit")
+    def test_unsupported_framework_aborts(self, csv_project):
+        with pytest.raises(ValueError, match="Unsupported framework"):
+            generate_test_file(str(csv_project), framework="junit")
         assert not (csv_project / "generated" / "Tests").exists()
-        assert "Unsupported framework" in caplog.text
 
 
 # --------------------------------------------------------------------------- #
@@ -557,3 +563,11 @@ class TestFileWriter:
         (tmp_path / "generated").mkdir()
         FileWriter().copy_input_templates(str(tmp_path), str(tmp_path / "generated"))
         assert not (tmp_path / "generated" / "Tests" / "input_templates").exists()
+
+    def test_copy_input_templates_absent_is_quiet_at_info(self, tmp_path, caplog):
+        """A missing input_templates folder is normal for small projects — nothing
+        at INFO or above may reach the console (a debug-level note is fine)."""
+        with caplog.at_level(logging.INFO, logger="optics_framework.helper.generate"):
+            FileWriter().copy_input_templates(str(tmp_path), str(tmp_path / "generated"))
+
+        assert caplog.records == []

--- a/tests/units/helpers/test_initialize.py
+++ b/tests/units/helpers/test_initialize.py
@@ -1,0 +1,325 @@
+"""Unit tests for ``optics_framework.helper.initialize`` and the CLI init flow.
+
+Covers:
+- ``create_project`` scaffolding with an already-resolved name (the positional
+  vs ``--name`` resolution happens in ``cli.InitCommand.execute``; create_project
+  itself just consumes ``args.name``).
+- The interactive template picker: ``_template_choices`` is built from
+  ``samples/metadata.json`` (the ``displayName`` field), with a "Blank project"
+  sentinel; stdin-driven ``_pick_template`` runs against patched input.
+- The CLI positional-name resolution contract in ``cli.InitCommand.execute``
+  (positional wins; positional and ``--name`` that differ raise; ``--name``
+  alone soft-deprecates).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from optics_framework.helper import initialize as init_mod
+from optics_framework.helper.initialize import (
+    _pick_template,
+    _template_choices,
+    create_project,
+)
+
+pytestmark = pytest.mark.white_box
+
+CLI = "optics_framework.helper.cli"
+
+
+def _args(name, **kw):
+    """A minimal args namespace matching the create_project attribute contract."""
+    return SimpleNamespace(
+        name=name,
+        path=kw.get("path"),
+        force=kw.get("force", False),
+        template=kw.get("template"),
+        git_init=kw.get("git_init", False),
+    )
+
+
+class TestCreateProject:
+    def test_scaffolds_blank_project_when_no_template(self, tmp_path):
+        project = tmp_path / "myproj"
+        # pytest's stdin is not a TTY, so the interactive picker is skipped and
+        # the blank scaffold is built directly.
+        with patch(f"{init_mod.__name__}._pick_template") as pick, \
+                patch(f"{init_mod.__name__}.print_next_steps") as next_steps:
+            create_project(_args("myproj", path=str(tmp_path)))
+
+        pick.assert_not_called()
+        assert project.is_dir()
+        assert (project / "config.yaml").exists()
+        next_steps.assert_called_once_with(str(project), configured=False)
+
+    def test_template_copy_marks_configured(self, tmp_path):
+        project = tmp_path / "fromsample"
+        with patch(f"{init_mod.__name__}._copy_template", return_value=True) as copy, \
+                patch(f"{init_mod.__name__}.print_next_steps") as next_steps:
+            create_project(_args("fromsample", path=str(tmp_path), template="contact"))
+
+        copy.assert_called_once_with(str(project), "contact")
+        next_steps.assert_called_once_with(str(project), configured=True)
+
+    def test_show_next_steps_false_suppresses_block(self, tmp_path):
+        project = tmp_path / "quiet"
+        with patch(f"{init_mod.__name__}.print_next_steps") as next_steps:
+            create_project(_args("quiet", path=str(tmp_path)),
+                           show_next_steps=False)
+
+        assert (project / "config.yaml").exists()
+        next_steps.assert_not_called()
+
+    def test_show_next_steps_defaults_to_true(self, tmp_path):
+        with patch(f"{init_mod.__name__}.print_next_steps") as next_steps:
+            create_project(_args("loud", path=str(tmp_path)))
+
+        next_steps.assert_called_once_with(str(tmp_path / "loud"),
+                                           configured=False)
+
+
+class TestBlankProjectGuidance:
+    """A blank project's test_cases.csv ships empty; its guidance output must
+    say where the first steps go and how to discover them (one line appended
+    to the existing next-steps block — no new block)."""
+
+    def test_blank_project_prints_csv_and_list_hint(self, tmp_path, capsys):
+        with patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("blank", path=str(tmp_path)))
+        out = capsys.readouterr().out
+        assert "test_cases/test_cases.csv" in out
+        assert "`optics list`" in out
+
+    def test_template_project_prints_no_extra_hint(self, tmp_path, capsys):
+        with patch(f"{init_mod.__name__}._copy_template", return_value=True), \
+                patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("templated", path=str(tmp_path),
+                                 template="contact"))
+        assert "test_cases/test_cases.csv" not in capsys.readouterr().out
+
+    def test_suppressed_next_steps_skips_the_hint_too(self, tmp_path, capsys):
+        with patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("quiet", path=str(tmp_path)),
+                           show_next_steps=False)
+        assert "test_cases/test_cases.csv" not in capsys.readouterr().out
+
+    def test_force_overwrites_existing(self, tmp_path):
+        project = tmp_path / "exists"
+        project.mkdir()
+        (project / "old.txt").write_text("old", encoding="utf-8")
+        with patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("exists", path=str(tmp_path), force=True))
+        assert not (project / "old.txt").exists()
+        assert (project / "config.yaml").exists()
+
+    def test_existing_dir_without_force_raises_and_keeps_contents(self, tmp_path):
+        project = tmp_path / "exists"
+        project.mkdir()
+        (project / "keep.txt").write_text("keep", encoding="utf-8")
+        args = _args("exists", path=str(tmp_path))
+        with patch(f"{init_mod.__name__}.print_next_steps"):
+            with pytest.raises(ValueError, match="already exists"):
+                create_project(args)
+        assert (project / "keep.txt").exists()
+
+    def test_unknown_template_raises_before_creating_anything(self, tmp_path):
+        args = _args("tmpl2", path=str(tmp_path), template="nope")
+        with patch(f"{init_mod.__name__}._check_and_prepare_directory") as prepare, \
+                patch(f"{init_mod.__name__}.print_next_steps"):
+            with pytest.raises(ValueError,
+                               match="Template 'nope' not found.*Available templates"):
+                create_project(args)
+        prepare.assert_not_called()
+        assert not (tmp_path / "tmpl2").exists()
+
+
+class TestInteractivePicker:
+    """create_project's own picker: TTY-gated and opt-out via pick_template."""
+
+    @staticmethod
+    def _on_tty(monkeypatch):
+        class FakeStdin:
+            def isatty(self):
+                return True
+
+        monkeypatch.setattr(init_mod.sys, "stdin", FakeStdin())
+
+    def test_tty_without_template_uses_picker_result(self, tmp_path, monkeypatch):
+        self._on_tty(monkeypatch)
+        project = tmp_path / "picked"
+        with patch(f"{init_mod.__name__}._pick_template", return_value="") as pick, \
+                patch(f"{init_mod.__name__}._copy_template", return_value=True) as copy, \
+                patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("picked", path=str(tmp_path)))
+        pick.assert_called_once()
+        copy.assert_not_called()  # "" means blank → scaffold, not copy
+        assert (project / "config.yaml").exists()
+
+    def test_pick_template_false_never_prompts_even_on_tty(self, tmp_path, monkeypatch):
+        # Regression pin for the quickstart double-prompt: an embedded caller
+        # that already asked its own template question passes
+        # pick_template=False, so template=None deterministically means blank.
+        self._on_tty(monkeypatch)
+        project = tmp_path / "embedded"
+        with patch(f"{init_mod.__name__}._pick_template") as pick, \
+                patch(f"{init_mod.__name__}.print_next_steps"):
+            create_project(_args("embedded", path=str(tmp_path)),
+                           pick_template=False)
+        pick.assert_not_called()
+        assert (project / "config.yaml").exists()
+
+    def test_cancelled_picker_creates_no_directory(self, tmp_path, monkeypatch):
+        self._on_tty(monkeypatch)
+        with patch(f"{init_mod.__name__}._pick_template", return_value=None):
+            create_project(_args("ghost", path=str(tmp_path)))
+        assert not (tmp_path / "ghost").exists()
+
+
+class TestTemplateChoices:
+    def test_choices_built_from_metadata_display_names(self):
+        choices = _template_choices()
+        # First entry is always the Blank-project sentinel.
+        assert choices[0] == ("(Blank project)", "")
+        # The rest are (displayName, folderName) pairs from metadata.json.
+        names = [display for display, _ in choices]
+        assert "Contacts" in names  # displayName for the contact sample
+
+    def test_choices_include_folder_name_mapping(self):
+        mapping = dict(_template_choices())
+        assert mapping["Contacts"] == "contact"
+
+    def test_choices_fallback_when_metadata_missing(self, tmp_path, monkeypatch):
+        # Point _samples_dir at an empty dir: no metadata.json, no samples.
+        monkeypatch.setattr(init_mod, "_samples_dir", lambda: tmp_path)
+        choices = _template_choices()
+        # Only the Blank sentinel survives when there's no metadata/samples.
+        assert choices == [("(Blank project)", "")]
+
+    def test_choices_fallback_on_malformed_metadata(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(init_mod, "_samples_dir", lambda: tmp_path)
+        (tmp_path / "metadata.json").write_text("{ not valid json", encoding="utf-8")
+        choices = _template_choices()
+        assert choices[0] == ("(Blank project)", "")
+
+
+class TestPickTemplate:
+    """stdin-driven picker; ``input`` is patched so no real interaction occurs."""
+
+    def test_blank_selection_returns_empty_string(self):
+        with patch("builtins.input", return_value="1"):
+            assert _pick_template() == ""
+
+    def test_cancel_returns_none(self):
+        with patch("builtins.input", return_value=""):
+            assert _pick_template() is None
+
+    def test_selecting_a_sample_returns_its_folder(self):
+        # Index 2 is the first real sample (after Blank at index 1).
+        with patch("builtins.input", return_value="2"):
+            assert _pick_template() == "contact"
+
+    def test_non_numeric_input_reprompts(self):
+        with patch("builtins.input", side_effect=["abc", "2"]):
+            assert _pick_template() == "contact"
+
+    def test_out_of_range_input_reprompts(self):
+        with patch("builtins.input", side_effect=["99", "1"]):
+            assert _pick_template() == ""
+
+
+# --------------------------------------------------------------------------- #
+# CLI positional-name resolution                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestInitPositionalResolution:
+    """The positional vs ``--name`` resolution lives in ``cli.InitCommand.execute``."""
+
+    def _make_args(self, positional=None, flag=None, **kw):
+        return SimpleNamespace(
+            name_positional=positional,
+            name_flag=flag,
+            path=kw.get("path"),
+            force=kw.get("force", False),
+            template=kw.get("template"),
+            git_init=kw.get("git_init", False),
+        )
+
+    def test_positional_wins_over_flag_when_equal(self, tmp_path):
+        from optics_framework.helper.cli import InitCommand
+
+        with patch(f"{CLI}.create_project") as create:
+            InitCommand().execute(self._make_args(positional="x", flag="x",
+                                                  path=str(tmp_path)))
+        create.assert_called_once()
+        assert create.call_args.args[0].name == "x"
+
+    def test_positional_and_flag_differ_raises(self, tmp_path):
+        from optics_framework.helper.cli import InitCommand
+
+        cmd = InitCommand()
+        args = self._make_args(positional="a", flag="b", path=str(tmp_path))
+        with patch(f"{CLI}.create_project"):
+            with pytest.raises(ValueError, match="Conflicting project names"):
+                cmd.execute(args)
+
+    def test_flag_only_soft_deprecates(self, tmp_path, capsys):
+        from optics_framework.helper.cli import InitCommand
+
+        with patch(f"{CLI}.create_project") as create:
+            InitCommand().execute(self._make_args(flag="legacy", path=str(tmp_path)))
+        out = capsys.readouterr().out
+        assert "deprecated" in out.lower()
+        assert create.call_args.args[0].name == "legacy"
+
+    def test_interactive_prompt_when_tty(self, tmp_path):
+        from optics_framework.helper.cli import InitCommand
+
+        args = self._make_args(path=str(tmp_path))
+        with patch(f"{CLI}.create_project") as create, \
+                patch("builtins.input", return_value="talked"), \
+                patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = True
+            InitCommand().execute(args)
+        assert create.call_args.args[0].name == "talked"
+
+    def test_no_name_anywhere_noninteractive_raises(self, tmp_path):
+        from optics_framework.helper.cli import InitCommand
+
+        cmd = InitCommand()
+        args = self._make_args(path=str(tmp_path))
+        with patch(f"{CLI}.create_project"), \
+                patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = False
+            stdin.readline.return_value = ""
+            with pytest.raises(ValueError, match="project name is required"):
+                cmd.execute(args)
+
+    def test_piped_stdin_supplies_project_name(self, tmp_path):
+        # Regression pin: `printf 'demo\n' | optics init` must read the name
+        # from the pipe instead of failing with exit 3.
+        from optics_framework.helper.cli import InitCommand
+
+        with patch(f"{CLI}.create_project") as create, \
+                patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = False
+            stdin.readline.return_value = "demo\n"
+            InitCommand().execute(self._make_args(path=str(tmp_path)))
+        assert create.call_args.args[0].name == "demo"
+
+    def test_existing_project_without_force_raises(self, tmp_path):
+        # The CLI-level refusal must raise (main() maps ValueError → exit 3),
+        # not print and return with exit 0.
+        from optics_framework.helper.cli import InitCommand
+
+        (tmp_path / "dup").mkdir()
+        cmd = InitCommand()
+        args = self._make_args(positional="dup", path=str(tmp_path))
+        with patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = False
+            stdin.readline.return_value = ""
+            with pytest.raises(ValueError, match="already exists"):
+                cmd.execute(args)

--- a/tests/units/helpers/test_live_keywords.py
+++ b/tests/units/helpers/test_live_keywords.py
@@ -1,0 +1,229 @@
+"""Unit tests for ``LiveController.run_keyword`` keyword resolution.
+
+Covers display-form -> snake_case matching ("Launch App" -> ``launch_app``),
+shlex-correct argument parsing (quoted/spaced args), the actionable
+unknown-keyword message (with closest-match suggestion), the friendly
+signature hint for ValueError/TypeError failures, and the graceful
+empty-input guard — all against a bare controller shell (no device/session),
+like the other live unit tests. The TUI-side command routing (bare quit/exit
+aliases and the unknown-/command hint) is tested here too against a stubbed
+prompt_toolkit app.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from optics_framework.common.models import ElementData
+from optics_framework.helper import live_tui
+from optics_framework.helper.live import ActionStatus, LiveController
+
+pytestmark = pytest.mark.white_box
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def _validate_stub(element, timeout="10"):
+    """Stand-in for Verifier.validate_element: fails like int(timeout_str) would."""
+    raise ValueError("invalid literal for int() with base 10: 'Domain'")
+
+
+def _launch_stub(url, timeout="30"):
+    """Stand-in whose signature can't accept three positional args."""
+    raise AssertionError("should never be called")
+
+
+def _controller(keyword_map):
+    ctrl = LiveController.__new__(LiveController)
+    ctrl.keyword_map = keyword_map
+    ctrl.recorded = []
+    ctrl.saved = True
+    return ctrl
+
+
+def test_display_form_resolves_to_snake_case():
+    rec = _Recorder()
+    ctrl = _controller({"launch_app": rec})
+
+    result = ctrl.run_keyword("Launch App https://example.com")
+
+    assert result.status is ActionStatus.PASS
+    assert result.keyword == "launch_app"
+    assert rec.calls == [(("https://example.com",), {})]
+    assert ctrl.recorded == [("launch_app", ["https://example.com"])]
+    assert ctrl.saved is False
+
+
+def test_snake_case_still_resolves():
+    rec = _Recorder()
+    ctrl = _controller({"launch_app": rec})
+
+    result = ctrl.run_keyword("launch_app https://example.com")
+
+    assert result.status is ActionStatus.PASS
+    assert result.keyword == "launch_app"
+    assert rec.calls == [(("https://example.com",), {})]
+
+
+def test_longest_match_keeps_params_intact():
+    single, multi = _Recorder(), _Recorder()
+    ctrl = _controller({"scroll": single, "scroll_from_element": multi})
+
+    result = ctrl.run_keyword("Scroll From Element up")
+
+    assert result.keyword == "scroll_from_element"
+    assert multi.calls == [(("up",), {})]
+    assert single.calls == []
+
+
+def test_unknown_keyword_error_is_actionable_and_untruncated():
+    ctrl = _controller({"launch_app": _Recorder()})
+
+    result = ctrl.run_keyword("Frobnicate Now hard")
+
+    assert result.status is ActionStatus.FAIL
+    assert result.message == (
+        "Unknown keyword: 'Frobnicate Now'. Keywords use snake_case — "
+        "run `optics list` (e.g. launch_app, validate_element)."
+    )
+    assert ctrl.recorded == []
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_empty_input_fails_gracefully(raw):
+    ctrl = _controller({"launch_app": _Recorder()})
+
+    result = ctrl.run_keyword(raw)
+
+    assert result.status is ActionStatus.FAIL
+    assert result.message == "Empty input"
+
+
+def test_equals_locator_from_element_is_positional():
+    """A ${element} resolving to 'text=...' must be dispatched as the positional
+    locator, not split into a keyword argument (the runner/live '=' bug)."""
+    rec = _Recorder()
+    ctrl = _controller({"validate_element": rec})
+    ctrl._elements_loaded = True
+    ctrl.session = SimpleNamespace(
+        elements=ElementData(elements={"Heading": ["text=Example Domain"]}))
+
+    result = ctrl.run_keyword("validate_element ${Heading}")
+
+    assert result.status is ActionStatus.PASS
+    assert rec.calls == [(("text=Example Domain",), {})]
+
+
+def test_quoted_argument_with_space_stays_one_param():
+    """shlex parsing: a quoted multi-word argument reaches the keyword as one value."""
+    rec = _Recorder()
+    ctrl = _controller({"enter_text": rec})
+    ctrl._elements_loaded = True
+    ctrl.session = SimpleNamespace(
+        elements=ElementData(elements={"user": ["id=user_field"]}))
+
+    result = ctrl.run_keyword('enter_text ${user} "hello world"')
+
+    assert result.status is ActionStatus.PASS
+    assert rec.calls == [(("id=user_field", "hello world"), {})]
+
+
+def test_unbalanced_quote_falls_back_to_whitespace_split():
+    """shlex ValueError (unbalanced quote) degrades to str.split instead of a parse error."""
+    rec = _Recorder()
+    ctrl = _controller({"launch_app": rec})
+
+    result = ctrl.run_keyword('launch_app https://example.com "quoted')
+
+    assert result.status is ActionStatus.PASS
+    assert rec.calls == [(("https://example.com", '"quoted'), {})]
+
+
+def test_value_error_surfaces_as_friendly_signature_hint():
+    """A spaced-out argument landing in an int-typed param reads as usage, not a crash."""
+    ctrl = _controller({"validate_element": _validate_stub})
+
+    result = ctrl.run_keyword("validate_element text=Example Domain")
+
+    assert result.status is ActionStatus.FAIL
+    assert result.message == (
+        "Couldn't run 'validate_element': expected <element> [timeout] — "
+        "check `optics list` or Tab-complete for the signature."
+    )
+    assert ctrl.recorded == []
+
+
+def test_type_error_surfaces_as_friendly_signature_hint():
+    ctrl = _controller({"launch_app": _launch_stub})
+
+    result = ctrl.run_keyword("launch_app one two three")
+
+    assert result.status is ActionStatus.FAIL
+    assert result.message == (
+        "Couldn't run 'launch_app': expected <url> [timeout] — "
+        "check `optics list` or Tab-complete for the signature."
+    )
+
+
+def test_unknown_keyword_suggests_closest_match():
+    ctrl = _controller({"launch_app": _Recorder()})
+
+    result = ctrl.run_keyword("launche_app now")
+
+    assert result.status is ActionStatus.FAIL
+    assert result.message.endswith(" Did you mean 'launch_app'?")
+    assert result.message.startswith("Unknown keyword: 'launche_app now'")
+
+
+
+class _FakeApp:
+    def __init__(self):
+        self.exited = False
+
+    def exit(self):
+        self.exited = True
+
+
+def _tui_with_stubbed_app(monkeypatch):
+    """A real LiveTUI over a bare controller; get_app/_info stubbed so no tty is needed."""
+    controller = SimpleNamespace(saved=True, recorded=[])
+    tui = live_tui.LiveTUI(controller)
+    app = _FakeApp()
+    messages: list[str] = []
+    monkeypatch.setattr(live_tui, "get_app", lambda: app)
+    monkeypatch.setattr(tui, "_info", lambda msg, raw="": messages.append(msg))
+    return tui, app, messages
+
+
+@pytest.mark.parametrize("word", ["quit", "exit", "Quit"])
+def test_bare_quit_and_exit_behave_like_slash_quit(monkeypatch, word):
+    tui, app, messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui._submit(word)
+
+    assert app.exited is True
+    assert messages == []
+
+
+def test_unknown_slash_command_hints_available_commands(monkeypatch):
+    tui, app, messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui._submit("/frobnicate")
+
+    assert app.exited is False
+    assert len(messages) == 1
+    assert "/help" in messages[0]
+    assert "/quit" in messages[0]
+
+
+def test_status_hint_leads_with_help_and_quit():
+    """On an 80-column terminal the hint truncates from the right — exit/help must survive."""
+    hint = live_tui._STATUS_HINT
+
+    assert hint.startswith("/help · /quit · ")
+    assert hint.index("/help") < hint.index("Tab complete") < hint.index("Ctrl-N AI mode")

--- a/tests/units/helpers/test_live_save.py
+++ b/tests/units/helpers/test_live_save.py
@@ -2,16 +2,19 @@
 
 These exercise the CSV serialisation directly, without a device or session: a
 lightweight subclass overrides ``__init__`` to set only the attributes ``save``
-touches (``folder_path``, ``_artifacts_dir``, ``recorded``, ``saved``). The output
-is validated both structurally and by round-tripping through ``CSVDataReader`` so it
-stays compatible with the batch runner.
+touches (``folder_path``, ``_artifacts_dir``, ``recorded``, ``saved``, plus a
+stub ``session`` holding the session's known elements). The output is validated
+both structurally and by round-tripping through ``CSVDataReader`` so it stays
+compatible with the batch runner.
 """
 import csv
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from optics_framework.common.error import Code, OpticsError
+from optics_framework.common.models import ElementData
 from optics_framework.common.runner.data_reader import CSVDataReader
 from optics_framework.helper.live import LiveController, SaveConflictError, SaveResult
 
@@ -26,11 +29,15 @@ class _Controller(LiveController):
     touches are initialized.
     """
 
-    def __init__(self, folder: str):  # noqa: super-init-not-called
+    def __init__(self, folder: str, elements: ElementData | None = None):  # noqa: super-init-not-called
         self.folder_path = folder
         self._artifacts_dir = os.path.join(folder, "no_artifacts")  # absent -> no snapshot
         self.recorded = []
         self.saved = False
+        # save() merges these into the project's tracked elements CSV; the flag
+        # short-circuits ensure_elements_loaded's own project walk.
+        self._elements_loaded = True
+        self.session = SimpleNamespace(elements=elements if elements is not None else ElementData())
 
 
 @pytest.fixture
@@ -172,3 +179,66 @@ def test_saved_files_round_trip_through_csv_reader(c):
         "TC one": ["mod_a"],
         "TC two": ["mod_b"],
     }
+
+
+def _seed_elements_csv(tmp_path, content: str) -> str:
+    """Create the scaffold-convention ``test_data/elements.csv``; returns its path."""
+    elements_dir = tmp_path / "test_data"
+    elements_dir.mkdir()
+    elements_path = elements_dir / "elements.csv"
+    elements_path.write_text(content, encoding="utf-8")
+    return str(elements_path)
+
+
+def test_save_merges_new_elements_into_existing_test_data_csv(tmp_path):
+    elements_path = _seed_elements_csv(
+        tmp_path, "Element_Name,Element_ID\nHeading,//h1[@id='top']\n"
+    )
+    # "heading" differs only in case from the tracked "Heading" -> skipped;
+    # Submit_Button is genuinely new -> appended.
+    c = _Controller(str(tmp_path), ElementData(elements={
+        "heading": ["//h1[@id='top']"],
+        "Submit_Button": ["//button[@type='submit']"],
+    }))
+    c.recorded = [("launch_app", [])]
+
+    result = c.save("TC", "mod")
+
+    assert result.elements_path == elements_path
+    # Only the new row was added; original content/formatting (LF endings) intact.
+    with open(elements_path, encoding="utf-8") as fh:
+        assert fh.read() == (
+            "Element_Name,Element_ID\n"
+            "Heading,//h1[@id='top']\n"
+            "Submit_Button,//button[@type='submit']\n"
+        )
+    assert not (tmp_path / "elements").exists()  # no second elements folder scattered
+
+
+def test_save_without_existing_elements_csv_creates_stub(c):
+    c.recorded = [("launch_app", [])]
+
+    result = c.save("TC", "mod")
+
+    assert result.elements_path == os.path.join(c.folder_path, "elements", "elements.csv")
+    assert os.path.isfile(result.elements_path)
+    assert _rows(result.elements_path) == []  # header-only stub, as documented
+
+
+def test_resave_appends_no_duplicate_element_rows(tmp_path):
+    elements_path = _seed_elements_csv(tmp_path, "Element_Name,Element_ID\nHeading,//h1\n")
+    c = _Controller(str(tmp_path), ElementData(elements={
+        "Heading": ["//h1"],
+        "Submit_Button": ["//button[@type='submit']"],
+    }))
+    c.recorded = [("launch_app", [])]
+    first = c.save("TC", "mod")
+
+    c.recorded = [("scroll", [])]
+    second = c.save("TC", "mod", allow_append=True)  # same module -> conflict path opted in
+
+    assert second.elements_path == first.elements_path == elements_path
+    assert _rows(second.elements_path) == [
+        {"Element_Name": "Heading", "Element_ID": "//h1"},
+        {"Element_Name": "Submit_Button", "Element_ID": "//button[@type='submit']"},
+    ]

--- a/tests/units/helpers/test_onboarding.py
+++ b/tests/units/helpers/test_onboarding.py
@@ -1,0 +1,171 @@
+"""Unit tests for the onboarding helpers (``optics_framework/helper/onboarding.py``).
+
+The first-run marker lives under HOME, so every filesystem test points HOME at
+a tmp_path. Output-producing functions are rendered through a Console writing
+to an in-memory buffer; no real terminal is touched.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from optics_framework.helper import onboarding
+from optics_framework.helper.version import VERSION
+
+pytestmark = pytest.mark.white_box
+
+MODULE = "optics_framework.helper.onboarding"
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Point HOME at a fresh temp dir so the real ~/.optics is never touched.
+
+    OPTICS_HOME is cleared so an ambient value on the test runner can't
+    redirect the marker away from the isolated HOME and invalidate the
+    HOME-based assertions below."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPTICS_HOME", raising=False)
+    return tmp_path
+
+
+def _capture(func, *args, **kwargs) -> str:
+    """Render a printing helper into a string via a wide fixed-width console
+    (fixed width so panel borders never wrap mid-phrase)."""
+    buf = io.StringIO()
+    console = Console(file=buf, width=200)
+    with patch(f"{MODULE}._console", console):
+        func(*args, **kwargs)
+    return buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# First-run marker                                                             #
+# --------------------------------------------------------------------------- #
+
+class TestIsFirstRun:
+    def test_true_when_marker_missing(self):
+        assert onboarding.is_first_run() is True
+
+    def test_false_after_mark_onboarded(self):
+        onboarding.mark_onboarded()
+        assert onboarding.is_first_run() is False
+
+    def test_marker_is_version_stamped_json(self):
+        onboarding.mark_onboarded()
+        marker = os.path.join(os.path.expanduser("~"), ".optics", ".onboarded")
+        with open(marker, encoding="utf-8") as fh:
+            assert json.load(fh) == {"version": VERSION}
+
+    def test_true_when_marker_corrupt(self):
+        marker_dir = os.path.join(os.path.expanduser("~"), ".optics")
+        os.makedirs(marker_dir)
+        with open(os.path.join(marker_dir, ".onboarded"), "w", encoding="utf-8") as fh:
+            fh.write("not-json{")
+        assert onboarding.is_first_run() is True
+
+    @pytest.mark.parametrize("payload", ["null", "5", "[]", '"onboarded"'])
+    def test_only_a_json_object_counts_as_onboarded(self, payload):
+        # mark_onboarded writes {"version": ...}; any other parseable JSON is
+        # not a real marker and must not suppress first-run guidance.
+        marker_dir = os.path.join(os.path.expanduser("~"), ".optics")
+        os.makedirs(marker_dir)
+        with open(os.path.join(marker_dir, ".onboarded"), "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        assert onboarding.is_first_run() is True
+
+
+class TestMarkOnboarded:
+    def test_creates_optics_dir(self):
+        home = os.path.expanduser("~")
+        assert not os.path.exists(os.path.join(home, ".optics"))
+        onboarding.mark_onboarded()
+        assert os.path.isfile(os.path.join(home, ".optics", ".onboarded"))
+
+    def test_never_raises_when_home_not_writable(self):
+        # A *file* sitting where ~/.optics must be a directory makes both
+        # makedirs and open fail with OSError — mark_onboarded must swallow it.
+        home = os.path.expanduser("~")
+        with open(os.path.join(home, ".optics"), "w", encoding="utf-8") as fh:
+            fh.write("blocker")
+        onboarding.mark_onboarded()  # must not raise
+        assert onboarding.is_first_run() is True
+
+
+class TestOpticsHomeOverride:
+    """OPTICS_HOME redirects the marker off the default ~/.optics — needed for
+    read-only HOME, containers, CI."""
+
+    def test_marker_lands_in_optics_home(self, tmp_path, monkeypatch):
+        custom = tmp_path / "optics-state"
+        monkeypatch.setenv("OPTICS_HOME", str(custom))
+        onboarding.mark_onboarded()
+        assert os.path.isfile(os.path.join(str(custom), ".onboarded"))
+        assert onboarding.is_first_run() is False
+
+    def test_optics_home_wins_over_home(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        custom = tmp_path / "optics-state"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("OPTICS_HOME", str(custom))
+        onboarding.mark_onboarded()
+        assert os.path.exists(os.path.join(str(custom), ".onboarded"))
+        assert not os.path.exists(os.path.join(str(home), ".optics"))
+
+    def test_falls_back_to_home_when_optics_home_unset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("OPTICS_HOME", raising=False)
+        onboarding.mark_onboarded()
+        assert os.path.isfile(os.path.join(str(tmp_path), ".optics", ".onboarded"))
+
+
+# --------------------------------------------------------------------------- #
+# Welcome banner                                                               #
+# --------------------------------------------------------------------------- #
+
+class TestWelcome:
+    def test_shows_golden_path_commands(self):
+        out = _capture(onboarding.welcome)
+        assert "optics quickstart" in out
+        assert "optics doctor" in out
+        assert "optics --help" in out
+
+    def test_describes_optics_in_one_line(self):
+        out = _capture(onboarding.welcome)
+        assert "phones" in out or "browsers" in out
+
+    def test_first_run_prepends_greeting(self):
+        out = _capture(onboarding.welcome, first_run=True)
+        assert "First time here?" in out
+
+    def test_no_greeting_without_first_run(self):
+        out = _capture(onboarding.welcome, first_run=False)
+        assert "First time here?" not in out
+
+    def test_banner_carries_version(self):
+        out = _capture(onboarding.welcome)
+        assert f"v{VERSION}" in out
+
+
+# --------------------------------------------------------------------------- #
+# Next steps                                                                   #
+# --------------------------------------------------------------------------- #
+
+class TestPrintNextSteps:
+    def test_unconfigured_offers_configure_then_dry_run(self):
+        out = _capture(onboarding.print_next_steps, "/tmp/demo", configured=False)
+        assert "optics configure /tmp/demo" in out
+        assert "optics dry_run /tmp/demo" in out
+        assert "optics execute" not in out
+
+    def test_configured_skips_configure(self):
+        out = _capture(onboarding.print_next_steps, "/tmp/demo", configured=True)
+        assert "optics configure" not in out
+        assert "optics dry_run /tmp/demo" in out
+        assert "optics execute /tmp/demo" in out

--- a/tests/units/helpers/test_project_config.py
+++ b/tests/units/helpers/test_project_config.py
@@ -1,0 +1,312 @@
+"""Unit tests for the project-config builder (``optics_framework/helper/project_config.py``).
+
+The renderer is exercised as a pure function per platform and re-parsed with
+``yaml.safe_load`` to prove the generated text is real, loadable YAML where
+exactly one driver and its matching elements sources are enabled. The prompt
+flow is tested against scripted rich prompts (no interaction).
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from optics_framework.helper import project_config
+from optics_framework.helper.project_config import (
+    _ELEMENTS_SOURCES_BY_DRIVER,
+)
+
+pytestmark = pytest.mark.white_box
+
+MODULE = "optics_framework.helper.project_config"
+
+_DRIVER_BY_PLATFORM = {
+    "android": "appium",
+    "ios": "appium",
+    "web-selenium": "selenium",
+    "web-playwright": "playwright",
+}
+
+
+def _enabled_names(config: dict, key: str) -> list[str]:
+    """Names whose entry carries ``enabled: true`` under a dependency section."""
+    return [
+        name
+        for entry in config.get(key) or []
+        if isinstance(entry, dict)
+        for name, cfg in entry.items()
+        if isinstance(cfg, dict) and cfg.get("enabled") is True
+    ]
+
+
+def _appium_entry(config: dict) -> dict:
+    """The appium entry (url + capabilities) under driver_sources."""
+    return next(
+        entry["appium"] for entry in config["driver_sources"]
+        if isinstance(entry, dict) and "appium" in entry
+    )
+
+
+def _answers_for(platform: str, *, ocr: bool = False) -> dict:
+    answers = {"platform": platform, "ocr": ocr, "log_level": "INFO"}
+    if platform == "android":
+        answers.update(
+            device_name="emu-1",
+            platform_name="Android",
+            app_package=f"com.example.{platform}",
+            app_activity="com.example.MainActivity",
+            appium_url="http://127.0.0.1:4723",
+        )
+    elif platform == "ios":
+        answers.update(
+            device_name="emu-1",
+            platform_name="iOS",
+            bundle_id=f"com.example.{platform}",
+            appium_url="http://127.0.0.1:4723",
+        )
+    elif platform == "web-selenium":
+        answers["selenium_url"] = "http://127.0.0.1:4444/wd/hub"
+    else:  # web-playwright
+        answers.update(browser="firefox", headless=True)
+    return answers
+
+
+# --------------------------------------------------------------------------- #
+# render_project_config                                                        #
+# --------------------------------------------------------------------------- #
+
+class TestRenderProjectConfig:
+    @pytest.mark.parametrize("platform", list(_DRIVER_BY_PLATFORM))
+    def test_exactly_one_driver_and_matching_sources_enabled(self, platform):
+        text = project_config.render_project_config(_answers_for(platform))
+        config = yaml.safe_load(text)
+        driver = _DRIVER_BY_PLATFORM[platform]
+
+        assert _enabled_names(config, "driver_sources") == [driver]
+        expected = sorted(_ELEMENTS_SOURCES_BY_DRIVER[driver])
+        assert sorted(_enabled_names(config, "elements_sources")) == expected
+        # Every other listed source stays disabled, not deleted.
+        all_sources = {s for group in _ELEMENTS_SOURCES_BY_DRIVER.values() for s in group}
+        disabled = all_sources - set(expected)
+        flat = [name for e in config["elements_sources"] for name in e]
+        assert set(disabled) <= set(flat)
+
+    def test_android_answers_land_in_appium_capabilities(self):
+        answers = _answers_for("android")
+        config = yaml.safe_load(project_config.render_project_config(answers))
+        appium = _appium_entry(config)
+        assert appium["url"] == answers["appium_url"]
+        caps = appium["capabilities"]
+        assert caps["deviceName"] == "emu-1"
+        assert caps["platformName"] == "Android"
+        assert caps["appPackage"] == "com.example.android"
+        assert caps["appActivity"] == "com.example.MainActivity"
+        assert caps["automationName"] == "UiAutomator2"
+
+    def test_ios_answers_use_bundle_id(self):
+        answers = _answers_for("ios")
+        text = project_config.render_project_config(answers)
+        # Android-only launch capabilities must not leak into an iOS config.
+        assert "bundleId" in text
+        assert "appPackage" not in text
+        assert "appActivity" not in text
+        appium = _appium_entry(yaml.safe_load(text))
+        assert appium["url"] == answers["appium_url"]
+        caps = appium["capabilities"]
+        assert caps["bundleId"] == "com.example.ios"
+        assert caps["automationName"] == "XCUITest"
+        assert caps["deviceName"] == "emu-1"
+        assert caps["platformName"] == "iOS"
+
+    def test_ios_prompt_flow_asks_bundle_id_not_app_package(self):
+        ask_values = [
+            "ios",                    # platform
+            "iPhone 16",              # device name
+            "iOS",                    # platform name
+            "com.acme.ios",           # bundle id
+            "http://127.0.0.1:4723",  # appium url
+            "INFO",                   # log level
+        ]
+        with patch(f"{MODULE}.Prompt.ask", side_effect=ask_values), \
+                patch(f"{MODULE}.Confirm.ask", return_value=False):
+            answers = project_config.prompt_project_config()
+        assert answers == {
+            "platform": "ios",
+            "device_name": "iPhone 16",
+            "platform_name": "iOS",
+            "bundle_id": "com.acme.ios",
+            "appium_url": "http://127.0.0.1:4723",
+            "ocr": False,
+            "log_level": "INFO",
+        }
+
+    def test_selenium_url_used(self):
+        config = yaml.safe_load(
+            project_config.render_project_config(_answers_for("web-selenium")))
+        selenium = next(
+            entry["selenium"] for entry in config["driver_sources"]
+            if isinstance(entry, dict) and "selenium" in entry
+        )
+        assert selenium["url"] == "http://127.0.0.1:4444/wd/hub"
+
+    def test_playwright_browser_and_headless_used(self):
+        config = yaml.safe_load(
+            project_config.render_project_config(_answers_for("web-playwright")))
+        pw = next(
+            entry["playwright"] for entry in config["driver_sources"]
+            if isinstance(entry, dict) and "playwright" in entry
+        )
+        assert pw["capabilities"]["browser"] == "firefox"
+        assert pw["capabilities"]["headless"] is True
+
+    @pytest.mark.parametrize("ocr, expected", [(True, True), (False, False)])
+    def test_ocr_toggles_easyocr_only(self, ocr, expected):
+        text = project_config.render_project_config(_answers_for("android", ocr=ocr))
+        config = yaml.safe_load(text)
+        assert _enabled_names(config, "text_detection") == (["easyocr"] if expected else [])
+        assert _enabled_names(config, "image_detection") == []
+
+    def test_missing_keys_fall_back_to_defaults(self):
+        text = project_config.render_project_config({})
+        config = yaml.safe_load(text)
+        assert _enabled_names(config, "driver_sources") == ["appium"]
+        assert config["log_level"] == "INFO"
+
+    def test_unknown_platform_falls_back_to_android(self):
+        text = project_config.render_project_config({"platform": "toaster"})
+        assert _enabled_names(yaml.safe_load(text), "driver_sources") == ["appium"]
+
+    def test_output_keeps_explanatory_comments(self):
+        text = project_config.render_project_config({})
+        assert "# Optics Framework project configuration." in text
+        assert "# Install:" in text or "optics setup --install" in text
+
+    def test_header_does_not_name_the_calling_command(self):
+        # Both `optics quickstart` and `optics configure` write rendered
+        # configs, so the provenance line must not credit either command.
+        text = project_config.render_project_config({})
+        assert "quickstart" not in text
+        assert "configure" not in text
+
+
+# --------------------------------------------------------------------------- #
+# write_project_config                                                         #
+# --------------------------------------------------------------------------- #
+
+class TestWriteProjectConfig:
+    def test_writes_config_yaml_into_folder(self, tmp_path):
+        folder = str(tmp_path / "nested" / "demo")
+        path = project_config.write_project_config(folder, "hello: true\n")
+        assert path == os.path.join(folder, "config.yaml")
+        with open(path, encoding="utf-8") as fh:
+            assert fh.read() == "hello: true\n"
+
+    def test_overwrites_unconditionally(self, tmp_path):
+        folder = str(tmp_path / "demo")
+        project_config.write_project_config(folder, "old\n")
+        project_config.write_project_config(folder, "new\n")
+        with open(os.path.join(folder, "config.yaml"), encoding="utf-8") as fh:
+            assert fh.read() == "new\n"
+
+
+# --------------------------------------------------------------------------- #
+# prompt_project_config                                                        #
+# --------------------------------------------------------------------------- #
+
+class TestPromptProjectConfig:
+    @pytest.mark.parametrize(
+        "domain, expected_choices, expected_default",
+        [
+            ("mobile", ["android", "ios"], "android"),
+            ("web", ["web-playwright", "web-selenium"], "web-playwright"),
+            (None, list(_DRIVER_BY_PLATFORM), "android"),
+        ],
+    )
+    def test_platform_choices_follow_domain(
+            self, domain, expected_choices, expected_default):
+        with patch(f"{MODULE}.Prompt.ask", return_value="ios") as ask, \
+                patch(f"{MODULE}.Confirm.ask", return_value=False):
+            project_config.prompt_project_config(domain=domain)
+        first_question = ask.call_args_list[0]
+        assert first_question.kwargs["choices"] == expected_choices
+        assert first_question.kwargs["default"] == expected_default
+
+    def test_android_question_flow(self):
+        ask_values = [
+            "android",              # platform
+            "emu-42",               # device name
+            "Android",              # platform name
+            "com.acme.app",         # app package
+            "com.acme.MainActivity",  # app activity
+            "http://127.0.0.1:4723",  # appium url
+            "DEBUG",                # log level
+        ]
+        with patch(f"{MODULE}.Prompt.ask", side_effect=ask_values), \
+                patch(f"{MODULE}.Confirm.ask", return_value=True):
+            answers = project_config.prompt_project_config()
+        assert answers == {
+            "platform": "android",
+            "device_name": "emu-42",
+            "platform_name": "Android",
+            "app_package": "com.acme.app",
+            "app_activity": "com.acme.MainActivity",
+            "appium_url": "http://127.0.0.1:4723",
+            "ocr": True,
+            "log_level": "DEBUG",
+        }
+
+    def test_web_playwright_question_flow(self):
+        ask_values = ["web-playwright", "webkit", "WARNING"]
+        confirm_values = [True, False]  # headless, ocr
+        with patch(f"{MODULE}.Prompt.ask", side_effect=ask_values), \
+                patch(f"{MODULE}.Confirm.ask", side_effect=confirm_values):
+            answers = project_config.prompt_project_config()
+        assert answers == {
+            "platform": "web-playwright",
+            "browser": "webkit",
+            "headless": True,
+            "ocr": False,
+            "log_level": "WARNING",
+        }
+
+    def test_prompted_answers_round_trip_through_renderer(self):
+        ask_values = [
+            "web-selenium", "http://grid.local:4444/wd/hub", "ERROR",
+        ]
+        with patch(f"{MODULE}.Prompt.ask", side_effect=ask_values), \
+                patch(f"{MODULE}.Confirm.ask", return_value=False):
+            answers = project_config.prompt_project_config()
+        config = yaml.safe_load(project_config.render_project_config(answers))
+        assert _enabled_names(config, "driver_sources") == ["selenium"]
+        assert config["log_level"] == "ERROR"
+
+
+class TestConfirmBlankLineDefault:
+    """Regression pin for a QA observation: rich Confirm.ask was reported to
+    reject an empty line with "Please enter Y or N" on piped stdin, even when
+    a default was shown. Against the pinned rich (14.x) a blank line DOES
+    return the default — this test fails if a future upgrade regresses it,
+    which would justify replacing Confirm.ask with a local y/n helper."""
+
+    @staticmethod
+    def _blank_input(monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+    def test_blank_line_returns_default_false(self, monkeypatch):
+        self._blank_input(monkeypatch)
+        from rich.prompt import Confirm
+        assert Confirm.ask("Run headless?", default=False) is False
+
+    def test_blank_line_returns_default_true(self, monkeypatch):
+        self._blank_input(monkeypatch)
+        from rich.prompt import Confirm
+        assert Confirm.ask("Install now?", default=True) is True
+
+    def test_y_and_n_still_parse_case_insensitively(self, monkeypatch):
+        from rich.prompt import Confirm
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "Y")
+        assert Confirm.ask("x?", default=False) is True
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "n")
+        assert Confirm.ask("x?", default=True) is False

--- a/tests/units/helpers/test_quickstart.py
+++ b/tests/units/helpers/test_quickstart.py
@@ -1,0 +1,396 @@
+"""Unit tests for the quickstart wizard (``optics_framework/helper/quickstart.py``).
+
+Every collaborator is mocked: rich prompts are scripted, project creation /
+engine install / doctor / onboarding output are stubs. Project paths live
+under pytest's tmp_path so even the simulated scaffolding stays hermetic. The
+central guarantee under test is that the wizard scaffolds and advises — it
+must never invoke ``execute_main`` or ``dryrun_main``, which are patched with
+recording spies.
+"""
+from __future__ import annotations
+
+import io
+import os
+import types
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from optics_framework.helper import quickstart
+
+pytestmark = pytest.mark.white_box
+
+MODULE = "optics_framework.helper.quickstart"
+EXECUTE_MODULE = "optics_framework.helper.execute"
+
+ANDROID_ANSWERS = {
+    "platform": "android", "device_name": "emu-1",
+    "platform_name": "Android", "app_package": "com.example.app",
+    "app_activity": "com.example.MainActivity",
+    "appium_url": "http://127.0.0.1:4723",
+    "ocr": False, "log_level": "INFO",
+}
+
+
+class Scripted:
+    """Callable returning scripted values in order; fails loudly on overrun.
+
+    Every invocation is recorded (``calls``) so tests can also assert on the
+    question text, which never reaches ``out`` — rich renders prompts to the
+    real console, not this module's buffered one."""
+
+    def __init__(self, values):
+        self._values = list(values)
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        if not self._values:
+            raise AssertionError("prompt called more times than scripted")
+        self.calls.append((args, kwargs))
+        return self._values.pop(0)
+
+
+class Spy:
+    """Recording stand-in for functions the wizard must never call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+class Harness:
+    """Patch every side-effecting collaborator and script the prompts.
+
+    ``spies`` records what the wizard did; ``out`` holds what it printed. The
+    fake ``create_project`` mirrors the real function by leaving a config.yaml
+    behind whenever a sample template was chosen."""
+
+    def __init__(self, ask_values, confirm_values, *,
+                 answers=None,
+                 install_result=(True, "Engines installed successfully!")):
+        self.out = io.StringIO()
+        self.prompts = Scripted(ask_values)
+        self.confirms = Scripted(confirm_values)
+        self.spies = types.SimpleNamespace(
+            create_project=None, create_project_kwargs=None,
+            write=None, run_doctor=None,
+            next_steps=None, install=None, prompt_domain=None,
+            execute_main=Spy(), dryrun_main=Spy())
+        answers = answers or ANDROID_ANSWERS
+        stack = self._stack = ExitStack()
+
+        def fake_write(folder, text):
+            self.spies.write = (folder, text)
+            return os.path.join(folder, "config.yaml")
+
+        def fake_create(args, *, show_next_steps=True, pick_template=True):
+            self.spies.create_project = args
+            self.spies.create_project_kwargs = {
+                "show_next_steps": show_next_steps,
+                "pick_template": pick_template,
+            }
+            if args.template:
+                folder = os.path.join(args.path, args.name)
+                os.makedirs(folder, exist_ok=True)
+                with open(os.path.join(folder, "config.yaml"), "w",
+                          encoding="utf-8"):
+                    pass
+
+        def fake_doctor(*args, **kwargs):
+            self.spies.run_doctor = (args, kwargs)
+
+        def fake_next_steps(path, **kwargs):
+            self.spies.next_steps = (path, kwargs)
+
+        def fake_install(requests):
+            self.spies.install = requests
+            return install_result
+
+        def fake_prompt(*, domain=None):
+            self.spies.prompt_domain = domain
+            return dict(answers)
+
+        for target, replacement in [
+            (f"{MODULE}._console", Console(file=self.out, width=200)),
+            (f"{MODULE}.Prompt.ask", self.prompts),
+            (f"{MODULE}.Confirm.ask", self.confirms),
+            (f"{MODULE}.project_config.prompt_project_config", fake_prompt),
+            (f"{MODULE}.project_config.render_project_config",
+             lambda a: "rendered-config"),
+            (f"{MODULE}.project_config.write_project_config", fake_write),
+            (f"{MODULE}.initialize.create_project", fake_create),
+            (f"{MODULE}.initialize.available_templates", lambda: ["contact"]),
+            (f"{MODULE}.doctor.run_doctor", fake_doctor),
+            (f"{MODULE}.onboarding.welcome", lambda *a, **k: None),
+            (f"{MODULE}.onboarding.is_first_run", lambda: False),
+            (f"{MODULE}.onboarding.print_next_steps", fake_next_steps),
+            (f"{MODULE}.resolve_engines", _fake_resolve),
+            (f"{MODULE}.install_extras", fake_install),
+            # Guards: the wizard must never drive or dry-run anything itself.
+            (f"{EXECUTE_MODULE}.execute_main", self.spies.execute_main),
+            (f"{EXECUTE_MODULE}.dryrun_main", self.spies.dryrun_main),
+        ]:
+            stack.enter_context(patch(target, replacement))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        self._stack.close()
+
+    def run(self):
+        quickstart.run_quickstart()
+
+
+def _fake_resolve(tokens):
+    """Mirror setup.resolve_engines: bundle tokens expand to their engines."""
+    bundles = {"mobile": ["Appium"], "web": ["Playwright", "Selenium"]}
+    names: list[str] = []
+    for token in tokens:
+        names.extend(bundles.get(token, [token]))
+    return ([types.SimpleNamespace(engine=types.SimpleNamespace(name=name))
+             for name in names], [])
+
+
+# --------------------------------------------------------------------------- #
+# Happy path                                                                   #
+# --------------------------------------------------------------------------- #
+
+class TestHappyPath:
+    def test_creates_project_with_expected_args(self, tmp_path):
+        base = str(tmp_path)
+        with Harness(["mobile", "1", "demo", base], [True]) as h:
+            h.run()
+        args = h.spies.create_project
+        assert (args.name, args.path) == ("demo", base)
+        assert (args.force, args.template, args.git_init) == (False, None, False)
+        # The wizard owns both embedded-call concerns: no re-prompting picker,
+        # and no next-steps block (its own final block is the single source).
+        assert h.spies.create_project_kwargs == {
+            "show_next_steps": False, "pick_template": False}
+
+    def test_writes_rendered_config_into_project(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert h.spies.write == (str(tmp_path / "demo"), "rendered-config")
+
+    def test_verifies_with_doctor_then_prints_next_steps(self, tmp_path):
+        folder = str(tmp_path / "demo")
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert h.spies.run_doctor == ((), {"folder": folder})
+        assert h.spies.next_steps == (folder, {"configured": True})
+
+    def test_installs_mobile_engine_for_mobile_domain(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert [r.engine.name for r in h.spies.install] == ["Appium"]
+
+    def test_never_invokes_execute_or_dry_run(self, tmp_path):
+        with Harness(["web", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert h.spies.execute_main.calls == []
+        assert h.spies.dryrun_main.calls == []
+
+
+class TestWebDomain:
+    def test_offers_both_web_engines(self, tmp_path):
+        with Harness(["web", "1", "site", str(tmp_path)], [True]) as h:
+            h.run()
+        assert sorted(r.engine.name for r in h.spies.install) == [
+            "Playwright", "Selenium"]
+
+
+# --------------------------------------------------------------------------- #
+# Domain threading into config building                                        #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("domain", ["mobile", "web"])
+def test_chosen_domain_is_passed_to_prompt_project_config(tmp_path, domain):
+    # prompt_project_config itself restricts the platform choices to the
+    # domain (asserted in test_project_config); here we pin that the wizard
+    # actually forwards its answer.
+    with Harness([domain, "1", "demo", str(tmp_path)], [True]) as h:
+        h.run()
+    assert h.spies.prompt_domain == domain
+
+
+# --------------------------------------------------------------------------- #
+# Engine installation outcomes                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestEngineInstall:
+    def test_declined_install_skips_install_extras(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [False]) as h:
+            h.run()
+        assert h.spies.install is None
+        # The domain doubles as a `setup` bundle token — the hint must stay
+        # copy-pasteable.
+        assert "optics setup --install mobile" in h.out.getvalue()
+
+    def test_failed_install_prints_message_and_virtualenv_hint(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True],
+                     install_result=(False, "Installation failed: boom")) as h:
+            h.run()  # must not raise
+        out = h.out.getvalue()
+        assert "boom" in out
+        assert "virtualenv" in out.lower()
+
+    def test_success_message_shown(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True],
+                     install_result=(True,
+                                     "Engines installed successfully!")) as h:
+            h.run()
+        assert "installed successfully" in h.out.getvalue().lower()
+
+
+# --------------------------------------------------------------------------- #
+# Template handling                                                            #
+# --------------------------------------------------------------------------- #
+
+class TestTemplates:
+    def test_sample_template_choice_is_forwarded(self, tmp_path):
+        # Menu numbering: 1 = blank, 2 = 'contact' (stubbed templates list).
+        # Confirms: install engines? yes; overwrite template config? yes.
+        with Harness(["mobile", "2", "demo", str(tmp_path)],
+                     [True, True]) as h:
+            h.run()
+        assert h.spies.create_project.template == "contact"
+
+    def test_blank_choice_maps_to_no_template(self, tmp_path):
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert h.spies.create_project.template is None
+
+    def test_template_config_kept_when_overwrite_declined(self, tmp_path):
+        # Confirms: 1) install engines? yes  2) overwrite template config? no.
+        with Harness(["mobile", "2", "demo", str(tmp_path)], [True, False]) as h:
+            h.run()
+        assert h.spies.write is None
+        assert "Keeping the template's config" in h.out.getvalue()
+        # The journey still finishes after keeping the template's config.
+        assert h.spies.next_steps == (str(tmp_path / "demo"),
+                                      {"configured": True})
+
+    def test_blank_project_writes_config_without_overwrite_prompt(self, tmp_path):
+        # Blank scaffolding also produces a starter config.yaml; only the
+        # template branch may ask before overwriting it.
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert h.spies.write is not None
+
+
+class TestTemplateDomainMismatch:
+    """A mobile-only sample offered to a web user (or vice versa) must be
+    flagged, not silently scaffolded into the wrong engine's config.
+
+    The question text lives in the recorded Confirm.ask calls — rich renders
+    prompts to the real console, not the wizard's buffered one."""
+
+    def _mismatch_questions(self, h):
+        return [args[0] for args, _ in h.confirms.calls if "sample targets" in str(args)]
+
+    def test_mismatch_is_flagged_and_accepted_on_confirm(self, tmp_path):
+        with Harness(["web", "2", "demo", str(tmp_path)], [True, True, True]) as h:
+            h.run()
+        questions = self._mismatch_questions(h)
+        assert len(questions) == 1
+        assert "The 'contact' sample targets mobile" in questions[0]
+        assert "but you chose web" in questions[0]
+        assert "Use it anyway?" in questions[0]
+        assert h.spies.create_project.template == "contact"
+
+    def test_mismatch_declined_loops_back_to_template_choice(self, tmp_path):
+        with Harness(["web", "2", "1", "demo", str(tmp_path)], [True, False]) as h:
+            h.run()
+        assert len(self._mismatch_questions(h)) == 1
+        assert h.spies.create_project.template is None
+
+    def test_web_sample_offered_to_mobile_user_is_flagged(self, tmp_path):
+        with Harness(["mobile", "3", "1", "demo", str(tmp_path)], [True, False]) as h:
+            with patch(f"{MODULE}.initialize.available_templates",
+                       return_value=["contact", "gmail_web"]):
+                h.run()
+        questions = self._mismatch_questions(h)
+        assert len(questions) == 1
+        assert "The 'gmail_web' sample targets web" in questions[0]
+        assert h.spies.create_project.template is None
+
+    def test_matching_sample_never_asks(self, tmp_path):
+        with Harness(["mobile", "2", "demo", str(tmp_path)],
+                     [True, True]) as h:
+            h.run()
+        assert self._mismatch_questions(h) == []
+
+    def test_blank_choice_never_asks(self, tmp_path):
+        with Harness(["web", "1", "demo", str(tmp_path)], [True]) as h:
+            h.run()
+        assert self._mismatch_questions(h) == []
+
+
+# --------------------------------------------------------------------------- #
+# Existing project directory                                                   #
+# --------------------------------------------------------------------------- #
+
+class TestExistingProject:
+    """The wizard must never write into an already-existing project."""
+
+    def test_existing_dir_reprompts_and_uses_new_name(self, tmp_path):
+        existing = tmp_path / "demo"
+        existing.mkdir()
+        (existing / "config.yaml").write_text("keep", encoding="utf-8")
+        # Prompts: domain, template, name (collides), base, re-prompt (new).
+        with Harness(["mobile", "1", "demo", str(tmp_path), "fresh"],
+                     [True]) as h:
+            h.run()
+        args = h.spies.create_project
+        assert (args.name, args.path) == ("fresh", str(tmp_path))
+        assert (existing / "config.yaml").read_text(encoding="utf-8") == "keep"
+        assert h.spies.write == (str(tmp_path / "fresh"), "rendered-config")
+        out = h.out.getvalue()
+        assert "already exists" in out
+        # quickstart has no --force flag, so its warning must not mention one.
+        assert "--force" not in out
+
+    def test_eof_on_rename_prompt_aborts_without_touching_existing(self, tmp_path):
+        existing = tmp_path / "demo"
+        existing.mkdir()
+        (existing / "config.yaml").write_text("keep", encoding="utf-8")
+        with Harness(["mobile", "1", "demo", str(tmp_path)], [True]) as h:
+            with patch(f"{MODULE}.Prompt.ask",
+                       side_effect=["mobile", "1", "demo", str(tmp_path),
+                                    EOFError]):
+                with pytest.raises(SystemExit) as exc:
+                    h.run()
+        assert exc.value.code == 1
+        assert (existing / "config.yaml").read_text(encoding="utf-8") == "keep"
+        assert h.spies.create_project is None
+        assert h.spies.write is None
+
+
+# --------------------------------------------------------------------------- #
+# Guard                                                                        #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "domain, template_choice",
+    [("mobile", "1"), ("web", "1"), ("web", "2")],
+)
+def test_wizard_completes_without_execute_or_dry_run(
+        tmp_path, domain, template_choice):
+    mismatch_confirm = template_choice != "1" and domain == "web"
+    overwrite_confirm = template_choice != "1"
+    confirms = [True]
+    if mismatch_confirm:
+        confirms.append(True)
+    if overwrite_confirm:
+        confirms.append(True)
+    with Harness([domain, template_choice, "demo", str(tmp_path)],
+                 confirms) as h:
+        h.run()
+    assert h.spies.execute_main.calls == []
+    assert h.spies.dryrun_main.calls == []

--- a/tests/units/helpers/test_setup.py
+++ b/tests/units/helpers/test_setup.py
@@ -7,11 +7,15 @@ the extras declared in ``pyproject.toml``.
 """
 from __future__ import annotations
 
+import asyncio
+import io
+import re
 import subprocess
 import sys
+import threading
 import tomllib
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import call, MagicMock, patch
 
 import pytest
 
@@ -24,6 +28,7 @@ from optics_framework.helper.setup import (
     InstallRequest,
     SetupError,
     _BUNDLES,
+    _TAIL_LINES,
     _alias_index,
     _norm,
     _split_token,
@@ -203,9 +208,12 @@ class TestSplitToken:
 # --------------------------------------------------------------------------- #
 
 class TestInstallExtras:
+    """Capture mode (``stream=False``, the TUI path): subprocess mocked —
+    no real pip/network. The streamed CLI variants live in TestStreamedInstall."""
+
     def test_returns_false_on_empty(self):
         with patch(f"{MODULE}.subprocess.run") as run:
-            ok, message = install_extras([])
+            ok, message = install_extras([], stream=False)
         run.assert_not_called()
         assert ok is False
         assert "No engines selected" in message
@@ -213,7 +221,7 @@ class TestInstallExtras:
     def test_success_returns_true_and_message(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run"):
-            ok, message = install_extras(_reqs("Appium"))
+            ok, message = install_extras(_reqs("Appium"), stream=False)
         assert ok is True
         assert "installed successfully" in message.lower()
 
@@ -221,7 +229,7 @@ class TestInstallExtras:
         engines = _reqs("Appium")
         with patch(f"{MODULE}._installed_version", return_value="1.2.3"), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(engines)
+            install_extras(engines, stream=False)
         run.assert_called_once_with(
             [sys.executable, "-m", "pip", "install", f"{DISTRIBUTION_NAME}[appium]==1.2.3"],
             capture_output=True, text=True, check=True, shell=False,
@@ -230,7 +238,7 @@ class TestInstallExtras:
     def test_unpinned_when_version_unknown(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(_reqs("Appium"))
+            install_extras(_reqs("Appium"), stream=False)
         args = run.call_args.args[0]
         assert args[-1] == f"{DISTRIBUTION_NAME}[appium]"
 
@@ -238,7 +246,7 @@ class TestInstallExtras:
         engines = _reqs("Selenium", "Appium", "Selenium")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(engines)
+            install_extras(engines, stream=False)
         spec = run.call_args.args[0][-1]
         assert spec == f"{DISTRIBUTION_NAME}[appium,selenium]"
 
@@ -246,7 +254,7 @@ class TestInstallExtras:
         reqs = [InstallRequest(engine=ALL_ENGINES["Appium"], version="==4.2.0")]
         with patch(f"{MODULE}._installed_version", return_value="1.2.3"), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(reqs)
+            install_extras(reqs, stream=False)
         assert run.call_args.args[0] == [
             sys.executable, "-m", "pip", "install",
             f"{DISTRIBUTION_NAME}[appium]==1.2.3", "appium-python-client==4.2.0",
@@ -255,14 +263,14 @@ class TestInstallExtras:
     def test_no_version_appends_nothing(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(_reqs("Appium"))
+            install_extras(_reqs("Appium"), stream=False)
         # extras spec only, no trailing concrete package.
         assert run.call_args.args[0][-1] == f"{DISTRIBUTION_NAME}[appium]"
 
     def test_playwright_triggers_browser_install(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(_reqs("Playwright"))
+            install_extras(_reqs("Playwright"), stream=False)
         assert run.call_count == 2
         assert run.call_args_list[1] == call(
             [sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"],
@@ -272,14 +280,14 @@ class TestInstallExtras:
     def test_non_playwright_skips_browser_install(self):
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run") as run:
-            install_extras(_reqs("Appium"))
+            install_extras(_reqs("Appium"), stream=False)
         assert run.call_count == 1
 
     def test_failure_returns_message_with_stderr(self):
         err = subprocess.CalledProcessError(1, "pip", stderr="boom: could not resolve")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            ok, message = install_extras(_reqs("Appium"))
+            ok, message = install_extras(_reqs("Appium"), stream=False)
         assert ok is False
         assert "Installation failed" in message
         assert "boom: could not resolve" in message
@@ -288,9 +296,91 @@ class TestInstallExtras:
         err = subprocess.CalledProcessError(1, "pip", output="stdout detail", stderr="")
         with patch(f"{MODULE}._installed_version", return_value=None), \
                 patch(f"{MODULE}.subprocess.run", side_effect=err):
-            ok, message = install_extras(_reqs("Appium"))
+            ok, message = install_extras(_reqs("Appium"), stream=False)
         assert ok is False
         assert "stdout detail" in message
+
+
+# --------------------------------------------------------------------------- #
+# install_extras — streamed CLI path                                           #
+# --------------------------------------------------------------------------- #
+
+def _popen_result(lines: list[str], returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = io.StringIO("".join(f"{line}\n" for line in lines))
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+class TestStreamedInstall:
+    """Stream mode (default, the ``optics setup --install`` CLI path): output is
+    echoed live and a short tail is quoted on failure."""
+
+    def test_streams_output_and_returns_success(self, capsys):
+        proc = _popen_result(["Collecting appium-python-client", "Downloading appium..."])
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.Popen", return_value=proc) as popen:
+            ok, message = install_extras(_reqs("Appium"))
+        assert popen.call_args.args[0] == [
+            sys.executable, "-m", "pip", "install", f"{DISTRIBUTION_NAME}[appium]",
+        ]
+        assert popen.call_args.kwargs == dict(
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1, shell=False,
+        )
+        captured = capsys.readouterr()
+        assert "Collecting appium-python-client" in captured.out
+        assert "Downloading appium..." in captured.out
+        assert ok is True
+        assert message == "Engines installed successfully!"
+
+    def test_filters_requirement_already_satisfied_noise(self, capsys):
+        proc = _popen_result([
+            "Requirement already satisfied: certifi in /venv (2024.1)",
+            "Collecting appium-python-client",
+        ])
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.Popen", return_value=proc):
+            ok, _ = install_extras(_reqs("Appium"))
+        out = capsys.readouterr().out
+        assert "Requirement already satisfied" not in out
+        assert "Collecting appium-python-client" in out
+        assert ok is True
+
+    def test_version_pin_reaches_pip_argv(self):
+        reqs = [InstallRequest(engine=ALL_ENGINES["Appium"], version="==5.0.0")]
+        proc = _popen_result([])
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.Popen", return_value=proc) as popen:
+            ok, _ = install_extras(reqs)
+        argv = popen.call_args.args[0]
+        assert f"{DISTRIBUTION_NAME}[appium]" in argv
+        assert "appium-python-client==5.0.0" in argv
+        assert ok is True
+
+    def test_playwright_browser_install_also_streams(self):
+        procs = [_popen_result(["pip done"]), _popen_result(["browser downloaded"])]
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.Popen", side_effect=procs) as popen:
+            ok, _ = install_extras(_reqs("Playwright"))
+        assert popen.call_count == 2
+        assert popen.call_args_list[1].args[0][-1] == "chromium"
+        assert ok is True
+
+    def test_failure_quotes_tail_and_reports_failure(self, capsys):
+        lines = [f"line-{n}" for n in range(_TAIL_LINES + 5)]
+        proc = _popen_result(lines, returncode=1)
+        with patch(f"{MODULE}._installed_version", return_value=None), \
+                patch(f"{MODULE}.subprocess.Popen", return_value=proc):
+            ok, message = install_extras(_reqs("Appium"))
+        captured = capsys.readouterr()
+        assert all(f"line-{n}\n" in captured.out for n in range(len(lines)))
+        assert ok is False
+        assert "Installation failed" in message
+        # Only the buffered tail is quoted — early lines are not retained.
+        assert f"line-{len(lines) - 1}" in message
+        assert "line-0" not in message
 
 
 # --------------------------------------------------------------------------- #
@@ -386,3 +476,56 @@ class TestEngineInstallerApp:
                 assert "failed" in str(status.render()).lower()
                 # Install re-enabled so the user can retry after a failure.
                 assert app.query_one("#install", Button).disabled is False
+
+    async def test_install_ticker_shows_elapsed_time_then_final_status(self):
+        release = threading.Event()
+
+        def slow_install(requests, stream=False):
+            release.wait(timeout=10)
+            return True, "Engines installed successfully!"
+
+        app = EngineInstallerApp()
+        with patch(f"{MODULE}.install_extras", side_effect=slow_install) as inst:
+            async with app.run_test() as pilot:
+                app.selected_engines = {"Appium": ALL_ENGINES["Appium"]}
+                await pilot.click("#install")
+                # Let the 1 Hz ticker fire at least once mid-install.
+                await asyncio.sleep(1.3)
+                status = str(app.query_one("#status", Static).render())
+                assert re.search(r"Installing Appium… \d+s", status)
+                release.set()
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+                status = str(app.query_one("#status", Static).render())
+                assert "installed successfully" in status.lower()
+        assert inst.call_args.kwargs == {"stream": False}
+
+
+class TestKeyboardEscape:
+    """The picker must not be a keyboard trap (regression: q, Esc-less
+    Ctrl+C did nothing — only the on-screen Quit button or Ctrl+Q worked)."""
+
+    def test_q_and_ctrl_c_bindings_map_to_quit(self):
+        bindings = {}
+        for binding in EngineInstallerApp.BINDINGS:
+            key, action = binding[:2]
+            bindings[key] = action
+        assert bindings.get("q") == "quit"
+        assert bindings.get("ctrl+c") == "quit"
+        from textual.app import App
+        default_keys = {b.key for b in App.BINDINGS}
+        assert "ctrl+q" in default_keys
+
+    async def test_footer_is_composed_so_binding_is_visible(self):
+        from textual.widgets import Footer
+        app = EngineInstallerApp()
+        async with app.run_test():
+            assert app.query_one(Footer) is not None
+
+    @pytest.mark.parametrize("key", ["q", "ctrl+c"])
+    async def test_key_quits_the_app(self, key):
+        app = EngineInstallerApp()
+        async with app.run_test() as pilot:
+            await pilot.press(key)
+            await pilot.pause()
+        assert not app.is_running


### PR DESCRIPTION
## What

Overhauls the first-run experience so a brand-new, non-coder user can go from
`pip install optics-framework` to a runnable project without guessing.

**New surface**
- `optics quickstart` — guided wizard: pick a target, install the right engine,
  scaffold a project, generate a platform-correct `config.yaml`, run `doctor`,
  print next steps.
- `optics doctor [folder] [--check]` — environment + project health check
  (Python, engines, adb/Appium, browsers, config validation); side-effect free;
  `--check` exits non-zero on a broken project.
- `optics configure [folder] [--edit]` — **project-scoped** config: a guided
  Q&A, or a full-field TUI over the project's own `config.yaml`.
- Bare `optics` prints a welcome + golden path and stamps a first-run marker.
- Friendlier `optics init` (positional name, template picker) and post-install
  next-steps for `optics setup`; refreshed shell completions + docs.

**Config model change**
- Removes the dead global-config layer (`~/.optics/global_config.yaml`), which
  the runner never read. Configuration is now always project-specific.

## Commit layout (6 commits)

1. **feat(cli): onboarding golden-path modules** — `onboarding`, `quickstart`,
   `doctor`, `project_config` + tests.
2. **feat(cli): project-scoped configure, interactive init, engine setup** —
   `config_manager`, `initialize`, `setup`, `cli`, `autocompletion`,
   `config_handler` + tests.
3. **fix: honest failures and execution reporting** — runner / JUnit / execute /
   data-reader hardening + tests.
4. **fix: code generation, live session and MCP hardening** — `generate`,
   `live`, `mcp_server`, samples + tests.
5. **docs: onboarding-overhaul documentation**.
6. **fix: stop flushing JSON event log on every event** — drop the per-event `_flush_json` that made the JSON log O(n^2); written once at `close` instead.

## Correctness & UX fixes (from two end-to-end QA shakedowns)

- **Locator parsing (blocker):** a resolved locator containing `=`
  (`text=`, `css=`, `id=`, `xpath=`) was mis-parsed as a keyword argument, so
  `Validate Element` failed with `TypeError: unexpected keyword argument 'text'`
  — breaking the shipped Playwright sample and `optics live`. Param splitting is
  now signature-aware (`DataReader.split_params_by_signature`): a `key=value`
  token is a keyword argument only when `key` is a real parameter of the target
  keyword; genuine kwargs (`event_name=`, `timeout=`) still route correctly.
- **Config editor edited the wrong row (blocker):** in `configure --edit`, arrow
  keys moved the highlight while Space toggled the first field. The editor now
  edits the highlighted row (ListView owns navigation), the quit dialog honours
  its `(y/n)` keys, and the window is titled `optics configure`.
- **Silent failures made explainable:** a typo'd keyword or an unresolved
  `${var}` now carries its reason to the JUnit `<failure message>` (previously
  empty) and the failing `<kw>`, is logged, and an unknown keyword gets a
  `Did you mean …?` suggestion.
- **Empty-project dead-end:** `dry_run`/`execute` on a freshly-scaffolded
  (empty) project print an actionable "add a test case or start from a template"
  message instead of a raw `E0702/E0701` linked-list traceback.
- **Honest results/exit codes:** unknown keyword/module → FAIL (dry-run + batch);
  unresolved `${var}` → per-keyword FAIL instead of an aborted run; failing runs
  and bad CLI input exit non-zero; no-driver projects get an actionable message.
- **`optics generate`:** a nested `--output a/b/x.py` creates its parent
  directories instead of crashing; missing required inputs raise (non-zero exit)
  instead of logging an error yet exiting 0.
- **`optics config` alias:** forwards to the guided configuration (the
  full-screen editor's alternate buffer hid the deprecation notice and could
  fabricate a `config.yaml` on save).
- **`optics quickstart`:** an empty answer at the duplicate-name prompt is
  re-asked instead of resolving to the working directory and looping forever.
- **`optics setup`:** drops pip's `Requirement already satisfied` noise from the
  streamed output; prints concrete next steps.
- **Artifacts:** `logs.json` written when `json_log` is set; canonical
  `junit_output.xml`; end-of-run capture skipped cleanly when the session closed.
- **Live / setup / UX:** longest-match keyword resolution, actionable messages,
  install-progress feedback, `INFO` sample logs, console-log gating.

## Testing

- Full unit suite green (968 passed, 2 pre-existing xfails). Each of the 5
  commits builds and tests green on its own.
- Verified end-to-end against a locally-built wheel in an isolated venv as a
  pip-only user (real installs of appium / selenium / playwright + Chromium),
  including a real Playwright web `execute`.

## Known follow-ups (not blocking)

- **Required-file discovery / `generate` elements:** unify required-file discovery across init/generate/execute and make `elements` optional in `optics generate` (API-only projects) — tracked in #474.
- **Mobile "false green":** `launch_app` reports PASS in ~0.00s with no Appium
  server/device and no advance warning at execute time; needs a real device to
  fix and verify safely.
- **`gmail_web` sample:** ships Selenium + EasyOCR enabled, so `dry_run` requires
  EasyOCR installed, and the sample's own config overrides a quickstart platform
  choice.
- **Playwright teardown:** a raw `NoneType … 'screenshot'` traceback can print
  after a green web run (the guard belongs in the Playwright screenshot source).
- `optics quickstart` "web" offers to install both Selenium and Playwright.
- `configure --edit` TUI editing of a dependency-list field still drops
  `url` / caps (inherited from the previous editor).
- iOS scaffold sets `bundleId` / `deviceName` / `platformName` only (real devices
  may need `platformVersion` / `udid`).
- `mcp` / `serve` extras aren't in the `optics setup` catalog or `doctor`.
- Real mobile (`execute` against a device) not exercisable in the QA environment.

## Closes

- Closes #468 — CLI usage guide now documents `optics live` and `optics mcp`
- Closes #469 — unexpected errors print exception type + recovery hint instead of a bare one-liner
- Closes #470 — `init --force` wording says it deletes/recreates; missing-files error suggests `optics init`


