### PR TITLE
ci(docs): add per-PR rendered documentation previews on GitHub Pages

### DIFF
--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ["Build-mkdocs-docs"]
     types: [completed]
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: read
@@ -110,4 +112,41 @@ jobs:
                 body,
               });
               core.info(`Created preview comment on PR #${prNumber}.`);
+            }
+
+  remove-preview:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9
+        with:
+          action: remove
+          comment: false
+          pr-number: ${{ github.event.pull_request.number }}
+          pages-base-url: https://mozarkai.github.io/optics-framework
+      - env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const marker = "<!-- pr-preview-comment -->";
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            for (const c of comments) {
+              if (c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+                core.info(`Deleted preview comment ${c.id}.`);
+              }
             }

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -1,0 +1,113 @@
+name: Documentation PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Build-mkdocs-docs"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-preview:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - id: download
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          if_no_artifact_found: ignore
+      - id: validate
+        if: steps.download.outputs.found_artifact == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const fs = require("fs");
+            const headSha = context.payload.workflow_run.head_sha;
+
+            function skip(reason) {
+              core.warning(`Documentation preview not published: ${reason}`);
+              core.setOutput("publish", "false");
+            }
+
+            let prNum;
+            try {
+              prNum = Number(fs.readFileSync("./pr_num/pr_num", "utf8").trim());
+            } catch (err) {
+              skip("the pr_num artifact could not be read.");
+              return;
+            }
+            if (!Number.isSafeInteger(prNum) || prNum <= 0) {
+              skip("the artifact carries a malformed PR number.");
+              return;
+            }
+
+            let pr;
+            try {
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNum,
+              })).data;
+            } catch (err) {
+              skip(`PR #${prNum} could not be retrieved (status ${err.status}).`);
+              return;
+            }
+
+            if (pr.head.sha !== headSha) {
+              skip(`documentation was built from ${headSha}, but PR #${prNum} is now at ${pr.head.sha}.`);
+              return;
+            }
+
+            core.setOutput("publish", "true");
+            core.setOutput("pr_number", String(prNum));
+      - id: preview
+        if: steps.validate.outputs.publish == 'true'
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9
+        with:
+          action: deploy
+          comment: false
+          source-dir: docs-site
+          pr-number: ${{ steps.validate.outputs.pr_number }}
+          pages-base-url: https://mozarkai.github.io/optics-framework
+      - if: steps.validate.outputs.publish == 'true' && steps.preview.outputs.preview-url != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          PR_NUMBER: ${{ steps.validate.outputs.pr_number }}
+          PREVIEW_URL: ${{ steps.preview.outputs.preview-url }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const previewUrl = process.env.PREVIEW_URL;
+            const diffUrl = previewUrl + "pr-diff/";
+            const marker = "<!-- pr-preview-comment -->";
+            const body = `${marker}\n## Documentation preview\n\n- **Rendered docs:** ${previewUrl}\n- **What changed (side-by-side source diff):** ${diffUrl}\n\n_Updated automatically when the docs build succeeds; removed when the PR is closed._`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated preview comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created preview comment on PR #${prNumber}.`);
+            }

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -32,6 +32,25 @@ jobs:
             mkdocs-material==$MKDOCS_MATERIAL_VERSION "mkdocstrings[python]==$MKDOCSTRINGS_VERSION" \
             mkdocstrings-python==$MKDOCSTRINGS_PYTHON_VERSION mkdocs-minify-plugin==$MKDOCS_MINIFY_PLUGIN_VERSION
       - run: mkdocs build
+      - if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.event.pull_request.base.sha }}" --depth=1
+      - if: github.event_name == 'pull_request'
+        env:
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_PR_BASE: ${{ github.event.pull_request.base.sha }}
+        run: python scripts/generate_pr_diff.py
+      - if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: docs-site
+          path: site/
+      - if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr_num
+      - if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: pr_num
+          path: pr_num
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/scripts/generate_pr_diff.py
+++ b/scripts/generate_pr_diff.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import difflib
+import html
+import os
+import subprocess  # nosec
+import sys
+from pathlib import Path
+
+DOCS_PREFIX = "docs/"
+OUT_DIR = Path("site/pr-diff")
+STATUS_LABEL = {"A": "added", "M": "modified", "D": "deleted", "R": "renamed"}
+RENDERABLE = {"A", "M", "R"}
+
+
+def git(*args: str) -> str:
+    return subprocess.run(  # nosec
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def changed_entries(base: str) -> list[tuple[str, str, str]]:
+    out = git("diff", "--name-status", f"{base}..HEAD", "--", "docs/")
+    entries: list[tuple[str, str, str]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0][0]
+        if status == "R":
+            old_path, path = parts[1], parts[2]
+        else:
+            old_path = path = parts[-1]
+        if path.startswith(DOCS_PREFIX) and path.endswith(".md"):
+            entries.append((status, path, old_path))
+    return sorted(entries, key=lambda e: e[1])
+
+
+def other_changed(base: str) -> list[str]:
+    out = git("diff", "--name-only", f"{base}..HEAD")
+    return [
+        p
+        for p in out.splitlines()
+        if p.strip() and not (p.startswith(DOCS_PREFIX) and p.endswith(".md"))
+    ]
+
+
+def file_lines(ref: str, path: str) -> list[str]:
+    try:
+        return git("show", f"{ref}:{path}").splitlines(keepends=True)
+    except subprocess.CalledProcessError:
+        return []
+
+
+def slug_for(path: str) -> str:
+    rel = path[len(DOCS_PREFIX):]
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    if rel == "index":
+        rel = "home"
+    return rel.replace("/", "-")
+
+
+def render_url(path: str) -> str:
+    rel = path[len(DOCS_PREFIX):]
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    if rel == "index":
+        return ""
+    if rel.endswith("/index"):
+        rel = rel[: -len("/index")]
+    return rel + "/"
+
+
+def write_diff_page(status: str, path: str, old_path: str, base: str) -> str:
+    slug = slug_for(path)
+    old = [] if status == "A" else file_lines(base, old_path)
+    new = [] if status == "D" else file_lines("HEAD", path)
+    if status == "A":
+        fromdesc = f"{path} (new file)"
+    elif status == "R":
+        fromdesc = f"{old_path} @ main"
+    else:
+        fromdesc = f"{path} @ main"
+    todesc = f"{path} (deleted)" if status == "D" else f"{path} @ PR head"
+    page = difflib.HtmlDiff(wrapcolumn=100).make_file(
+        old, new, fromdesc=fromdesc, todesc=todesc, context=True, numlines=4
+    )
+    (OUT_DIR / f"{slug}.html").write_text(page, encoding="utf-8")
+    return slug
+
+
+def write_index(
+    rows: list[tuple[str, str, str, str]],
+    others: list[str],
+    pr_number: str,
+) -> None:
+    badge_css = (
+        ".badge{padding:2px 8px;border-radius:4px;font-size:12px;"
+        "font-weight:600;color:#fff}"
+        ".a{background:#1a7f37}.m{background:#0969da}"
+        ".d{background:#cf222e}.r{background:#8250df}"
+        "body{font:14px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;"
+        "margin:2rem auto;max-width:900px;color:#1f2328}"
+        "table{border-collapse:collapse;width:100%}"
+        "th,td{padding:6px 10px;text-align:left;border-bottom:1px solid #d0d7de}"
+        "code{background:#f6f8fa;padding:1px 4px;border-radius:3px}"
+        ".note{background:#fff8c5;border:1px solid #e3c841;padding:10px 14px;"
+        "border-radius:6px;margin-top:1rem}"
+    )
+    pr_label = f" for PR #{pr_number}" if pr_number else ""
+    body_parts = [
+        f"<h1>Documentation diff{html.escape(pr_label)}</h1>",
+        "<p>Side-by-side source diffs of the docs pages this PR changes. "
+        'Each row links to the <em>source diff</em> and, where the page still '
+        'exists, to the <em>rendered</em> page in the full preview.</p>',
+    ]
+    if rows:
+        body_parts.append("<table><thead><tr>"
+                          "<th>Change</th><th>Page</th>"
+                          "<th>Source diff</th><th>Rendered</th>"
+                          "</tr></thead><tbody>")
+        for status, path, slug, url in rows:
+            label = STATUS_LABEL.get(status, status)
+            cls = status.lower()
+            rendered = (
+                f'<a href="../{url}">view</a>'
+                if status in RENDERABLE
+                else "&mdash;"
+            )
+            body_parts.append(
+                f'<tr><td><span class="badge {cls}">{label}</span></td>'
+                f"<td><code>{html.escape(path)}</code></td>"
+                f'<td><a href="{slug}.html">source diff</a></td>'
+                f"<td>{rendered}</td></tr>"
+            )
+        body_parts.append("</tbody></table>")
+    else:
+        body_parts.append(
+            "<p>No <code>docs/**/*.md</code> pages were changed in this PR.</p>"
+        )
+    if others:
+        listed = ", ".join(html.escape(p) for p in others[:20])
+        more = f" (and {len(others)-20} more)" if len(others) > 20 else ""
+        body_parts.append(
+            "<div class=\"note\"><strong>Other changes in this PR</strong> affect "
+            "rendering (e.g. <code>mkdocs.yml</code>, API sources, theme) but are "
+            "not page-by-page diffed. See the full rendered preview for their "
+            f"effect: changed files — {listed}{more}.</div>"
+        )
+    body = "\n".join(body_parts)
+    doc = (
+        "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'>"
+        "<title>Documentation diff</title><style>" + badge_css + "</style>"
+        "</head><body>" + body + "</body></html>"
+    )
+    (OUT_DIR / "index.html").write_text(doc, encoding="utf-8")
+
+
+def main() -> int:
+    base = os.environ.get("GITHUB_PR_BASE")
+    if not base:
+        print("GITHUB_PR_BASE (PR base SHA) is required", file=sys.stderr)
+        return 2
+    pr_number = os.environ.get("GITHUB_PR_NUMBER", "")
+    entries = changed_entries(base)
+    others = other_changed(base)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    rows: list[tuple[str, str, str, str]] = []
+    for status, path, old_path in entries:
+        slug = write_diff_page(status, path, old_path, base)
+        rows.append((status, path, slug, render_url(path)))
+    write_index(rows, others, pr_number)
+    print(
+        f"pr-diff: {len(rows)} page(s) diffed, "
+        f"{len(others)} other changed file(s) noted."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What happens when this merges

Every PR — including forks — gets a sticky comment with two live links:

- **Rendered docs:** the full site as it'll appear post-merge, at `…/pr-preview/pr-<N>/`.
- **Side-by-side source diff:** one HTML page per changed `docs/**/*.md` (old ← new, inline highlights), plus an index with deep links into the rendered preview, at `…/pr-preview/pr-<N>/pr-diff/`.

Closing/merging the PR removes both the preview and the comment. Push-to-`main` full-site deploys are unchanged.

## How

- **Build job** (`publish_docs.yml`, unprivileged, `contents: read`): on PRs, runs `mkdocs build`, generates the diff pages via `scripts/generate_pr_diff.py` (stdlib `difflib.HtmlDiff`, diffs against `github.event.pull_request.base.sha`), and uploads `site/` + the PR number as artifacts.
- **Deploy job** (`doc-preview.yml`, `workflow_run`): re-validates `pr.head.sha === workflow_run.head_sha` (skips stale/spoofed), deploys via `rossjrw/pr-preview-action` to `gh-pages`, posts the two-link comment (paginated, idempotent).
- **Cleanup** (`pull_request_target: [closed]`): removes the path + deletes the comment.

`workflow_run` / `pull_request_target` run with the base repo's write token and never execute fork code — the fork-PR-safe split (Zephyr pattern). All third-party actions pinned to SHAs (Scorecard-clean).

## Before it works

- Settings → Actions → Workflow permissions = **Read and write**.
- Pages source stays **Deploy from a branch** → `gh-pages`.

## Verify post-merge

Open a fork PR touching `docs/**` → build uploads → `deploy-preview` fires → comment with both links → close removes them. (Can't self-test: `workflow_run` reads the workflow file from `main`.)

## Follow-ups

- Gate previews to `docs/**`/`mkdocs.yml` only (skip code-only PRs).
- Optional `concurrency: pr-preview-${{ github.event.workflow_run.head_sha }}`.
