### PR TITLE
docs: expand non-coder use case description in introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -13,7 +13,7 @@ This framework was designed primarily for the following use cases:
    That rely on more than one element identifier and multiple fallbacks to ensure maximum recovery
 
 3. **Enable Non-Coders to Build Test Automation Scripts**
-   No programming knowledge required to create and execute tests
+   No programming knowledge is required to create and execute tests, since entire suites are described as plain-language CSV/YAML steps that anyone on the team can read, review, and extend without touching code
 
 ## Supported Platforms
 


### PR DESCRIPTION
## Summary
Extends the sentence under the *Enable Non-Coders to Build Test Automation Scripts* use case in `docs/introduction.md` to explain that suites are described as plain-language CSV/YAML steps.

Purely a docs wording change — no code touched.

## Purpose
Demo PR to exercise the freshly merged #473 (per-PR rendered documentation previews on GitHub Pages). The docs build + preview comment should appear once the docs workflow completes.