### PR TITLE
fix(ci,docs): correct preview URLs and make pr-diff pages fit the viewport

### DIFF
--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -76,7 +76,7 @@ jobs:
           comment: false
           source-dir: docs-site
           pr-number: ${{ steps.validate.outputs.pr_number }}
-          pages-base-url: https://mozarkai.github.io/optics-framework
+          pages-base-url: mozarkai.github.io/optics-framework
       - if: steps.validate.outputs.publish == 'true' && steps.preview.outputs.preview-url != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
@@ -127,7 +127,7 @@ jobs:
           action: remove
           comment: false
           pr-number: ${{ github.event.pull_request.number }}
-          pages-base-url: https://mozarkai.github.io/optics-framework
+          pages-base-url: mozarkai.github.io/optics-framework
       - env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/scripts/generate_pr_diff.py
+++ b/scripts/generate_pr_diff.py
@@ -73,6 +73,44 @@ def render_url(path: str) -> str:
     return rel + "/"
 
 
+DIFF_CSS = """
+        body{margin:0;background:#f6f8fa;color:#1f2328;font:14px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}
+        .diff-shell{max-width:1600px;margin:0 auto;padding:16px}
+        table.diff[rules='groups']{table-layout:fixed;width:100%;border-collapse:collapse;border:1px solid #d1d9e0;border-radius:6px;background:#fff;margin:12px 0;font-size:12px;line-height:1.6}
+        table.diff[rules='groups'] colgroup:nth-of-type(1),table.diff[rules='groups'] colgroup:nth-of-type(4){width:14px}
+        table.diff[rules='groups'] colgroup:nth-of-type(2),table.diff[rules='groups'] colgroup:nth-of-type(5){width:52px}
+        table.diff th,table.diff td{vertical-align:top;overflow-wrap:anywhere}
+        table.diff td[nowrap]{white-space:pre-wrap;padding:1px 8px}
+        table.diff th.diff_header{text-align:left;padding:8px 10px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:13px;font-weight:600;border-bottom:1px solid #d1d9e0;background:#f6f8fa;color:#1f2328}
+        table.diff thead th{position:sticky;top:0;z-index:1}
+        td.diff_header{padding:1px 6px;text-align:right;color:#59636e;background:#f6f8fa;user-select:none}
+        td.diff_next{text-align:center;font-size:10px;line-height:1.4;background-color:#f6f8fa}
+        .diff_add{background-color:#dafbe1}
+        .diff_chg{background-color:#fff8c5}
+        .diff_sub{background-color:#ffebe9}
+        a{color:#0969da}
+        @media (prefers-color-scheme:dark){
+          body{background:#0d1117;color:#e6edf3}
+          table.diff[rules='groups']{background:#161b22;border-color:#30363d}
+          table.diff th.diff_header{border-bottom:1px solid #30363d;background:#1c2129;color:#e6edf3}
+          td.diff_header{color:#9198a1;background:#161b22}
+          td.diff_next{background-color:#21262d}
+          .diff_add{background-color:rgba(46,160,67,.25)}
+          .diff_chg{background-color:rgba(187,128,9,.25)}
+          .diff_sub{background-color:rgba(248,81,73,.22)}
+          a{color:#58a6ff}
+        }
+"""
+
+
+def fit_diff_page(page: str, title: str) -> str:
+    page = page.replace("<title></title>", f"<title>{html.escape(title)}</title>", 1)
+    page = page.replace("&nbsp;", " ")
+    page = page.replace("</style>", f"</style>\n<style>{DIFF_CSS}</style>", 1)
+    page = page.replace("<body>", '<body>\n<div class="diff-shell">', 1)
+    return page.replace("</body>", "</div>\n</body>", 1)
+
+
 def write_diff_page(status: str, path: str, old_path: str, base: str) -> str:
     slug = slug_for(path)
     old = [] if status == "A" else file_lines(base, old_path)
@@ -84,10 +122,12 @@ def write_diff_page(status: str, path: str, old_path: str, base: str) -> str:
     else:
         fromdesc = f"{path} @ main"
     todesc = f"{path} (deleted)" if status == "D" else f"{path} @ PR head"
-    page = difflib.HtmlDiff(wrapcolumn=100).make_file(
+    page = difflib.HtmlDiff().make_file(
         old, new, fromdesc=fromdesc, todesc=todesc, context=True, numlines=4
     )
-    (OUT_DIR / f"{slug}.html").write_text(page, encoding="utf-8")
+    (OUT_DIR / f"{slug}.html").write_text(
+        fit_diff_page(page, f"{path} – docs diff"), encoding="utf-8"
+    )
     return slug
 
 


### PR DESCRIPTION
Follow-ups to #473, surfaced while testing it with #478.

## Double `https://` in preview comment
`rossjrw/pr-preview-action` builds its `preview-url` output as `https://[pages-base-url]/...` — it prepends the scheme itself. We passed `https://mozarkai.github.io/optics-framework`, so PR comments linked to `https://https://mozarkai.github.io/...`. Fixed by passing the bare `mozarkai.github.io/optics-framework` in both the deploy and remove-preview jobs.

## pr-diff pages overflowed horizontally
`difflib.HtmlDiff(wrapcolumn=100)` hard-wraps lines at 100 columns and emits `nowrap` cells whose spaces are all `&nbsp;`, so the table was far wider than the window. The layout is now CSS-driven:

- `table-layout: fixed` with equal content columns — true 50/50 before/after split at any window width
- `&nbsp;` restored to regular spaces + `pre-wrap` / `overflow-wrap: anywhere` — prose wraps at word boundaries, long URLs still break
- narrow line-number/jump gutters, sticky pane headers, GitHub-style highlight palette, `prefers-color-scheme: dark` support
- page `<title>` set to the diffed path

Verified locally by generating the diff for the #478 change and rendering at 1440px and 500px: no horizontal overflow, columns equal, wrapping clean in both color schemes.