### PR TITLE
ci(docs): make preview links reliable and survive main deploys

### DIFF
--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -66,6 +66,20 @@ jobs:
               return;
             }
 
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNum,
+              per_page: 100,
+            });
+            const touchesDocs = files.some(
+              (file) => file.filename === "mkdocs.yml" || file.filename.startsWith("docs/")
+            );
+            if (!touchesDocs) {
+              skip("the PR does not change any documentation files.");
+              return;
+            }
+
             core.setOutput("publish", "true");
             core.setOutput("pr_number", String(prNum));
       - id: preview
@@ -77,7 +91,22 @@ jobs:
           source-dir: docs-site
           pr-number: ${{ steps.validate.outputs.pr_number }}
           pages-base-url: mozarkai.github.io/optics-framework
-      - if: steps.validate.outputs.publish == 'true' && steps.preview.outputs.preview-url != ''
+      - id: wait-pages
+        if: steps.validate.outputs.publish == 'true' && steps.preview.outputs.preview-url != ''
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview-url }}
+        run: |
+          for attempt in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$PREVIEW_URL" || true)
+            if [ "$code" = "200" ]; then
+              echo "Preview is served (attempt $attempt)."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Pages did not serve $PREVIEW_URL within 5 minutes (last HTTP status: $code)." >&2
+          exit 1
+      - if: steps.wait-pages.conclusion == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           PR_NUMBER: ${{ steps.validate.outputs.pr_number }}

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -82,4 +82,14 @@ jobs:
           pip install --no-cache-dir --only-binary=:all: --no-binary=jsmin,csscompressor \
             mkdocs-material==$MKDOCS_MATERIAL_VERSION "mkdocstrings[python]==$MKDOCSTRINGS_VERSION" \
             mkdocstrings-python==$MKDOCSTRINGS_PYTHON_VERSION mkdocs-minify-plugin==$MKDOCS_MINIFY_PLUGIN_VERSION
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build --site-dir /tmp/docs-site
+      - name: Publish site to gh-pages, preserving PR previews
+        run: |
+          git fetch --depth=1 origin gh-pages
+          git checkout --detach origin/gh-pages
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name 'pr-preview' -exec rm -rf {} +
+          cp -a /tmp/docs-site/. .
+          touch .nojekyll
+          git add -A
+          git diff --cached --quiet || git commit -m "Deploy docs from ${GITHUB_SHA}"
+          git push origin HEAD:gh-pages


### PR DESCRIPTION
Fixes #480
Fixes #481

## Problem

- Preview comments linked a `404` because GitHub Pages hadn't finished deploying when the comment was posted.
- Every push to `main` ran `mkdocs gh-deploy --force`, wiping all `pr-preview/` directories from `gh-pages`.
- The preview comment was posted on every CI run, even when the PR touched no documentation files.

## Changes

### `.github/workflows/doc-preview.yml`
- Skip the preview deploy and the PR comment entirely unless the PR actually changes documentation files (`docs/**` or `mkdocs.yml`), checked via `pulls.listFiles` in the validate step.
- After deploying, poll the preview URL until it serves HTTP 200 (max 5 min); on timeout the job fails instead of linking a dead page.
- The comment step only runs if the wait-for-Pages check succeeded.

### `.github/workflows/publish_docs.yml`
- Replace `mkdocs gh-deploy --force` with `mkdocs build` + overlay onto the existing `gh-pages` tree, preserving `pr-preview/` and `.nojekyll`.
- Non-forced push so concurrent deploys fail loudly instead of silently clobbering each other.

## Verification

Overlay logic verified against a live clone of `gh-pages`: site files replaced, `pr-preview/` intact.