### PR TITLE
fix(docs): scope pr-preview diff to PR-introduced changes only

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,6 +14,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: 3.x
@@ -33,11 +35,12 @@ jobs:
             mkdocstrings-python==$MKDOCSTRINGS_PYTHON_VERSION mkdocs-minify-plugin==$MKDOCS_MINIFY_PLUGIN_VERSION
       - run: mkdocs build
       - if: github.event_name == 'pull_request'
-        run: git fetch origin "${{ github.event.pull_request.base.sha }}" --depth=1
+        run: git fetch origin "${{ github.event.pull_request.base.ref }}"
       - if: github.event_name == 'pull_request'
         env:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_PR_BASE: ${{ github.event.pull_request.base.sha }}
+          GITHUB_PR_BASE: origin/${{ github.event.pull_request.base.ref }}
+          GITHUB_PR_HEAD: ${{ github.event.pull_request.head.sha }}
         run: python scripts/generate_pr_diff.py
       - if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1

--- a/scripts/generate_pr_diff.py
+++ b/scripts/generate_pr_diff.py
@@ -20,8 +20,8 @@ def git(*args: str) -> str:
     ).stdout
 
 
-def changed_entries(base: str) -> list[tuple[str, str, str]]:
-    out = git("diff", "--name-status", f"{base}..HEAD", "--", "docs/")
+def changed_entries(base: str, head: str) -> list[tuple[str, str, str]]:
+    out = git("diff", "--name-status", f"{base}..{head}", "--", "docs/")
     entries: list[tuple[str, str, str]] = []
     for line in out.splitlines():
         if not line.strip():
@@ -37,8 +37,8 @@ def changed_entries(base: str) -> list[tuple[str, str, str]]:
     return sorted(entries, key=lambda e: e[1])
 
 
-def other_changed(base: str) -> list[str]:
-    out = git("diff", "--name-only", f"{base}..HEAD")
+def other_changed(base: str, head: str) -> list[str]:
+    out = git("diff", "--name-only", f"{base}..{head}")
     return [
         p
         for p in out.splitlines()
@@ -111,16 +111,16 @@ def fit_diff_page(page: str, title: str) -> str:
     return page.replace("</body>", "</div>\n</body>", 1)
 
 
-def write_diff_page(status: str, path: str, old_path: str, base: str) -> str:
+def write_diff_page(status: str, path: str, old_path: str, base: str, head: str) -> str:
     slug = slug_for(path)
     old = [] if status == "A" else file_lines(base, old_path)
-    new = [] if status == "D" else file_lines("HEAD", path)
+    new = [] if status == "D" else file_lines(head, path)
     if status == "A":
         fromdesc = f"{path} (new file)"
     elif status == "R":
-        fromdesc = f"{old_path} @ main"
+        fromdesc = f"{old_path} @ base"
     else:
-        fromdesc = f"{path} @ main"
+        fromdesc = f"{path} @ base"
     todesc = f"{path} (deleted)" if status == "D" else f"{path} @ PR head"
     page = difflib.HtmlDiff().make_file(
         old, new, fromdesc=fromdesc, todesc=todesc, context=True, numlines=4
@@ -201,15 +201,24 @@ def write_index(
 def main() -> int:
     base = os.environ.get("GITHUB_PR_BASE")
     if not base:
-        print("GITHUB_PR_BASE (PR base SHA) is required", file=sys.stderr)
+        print("GITHUB_PR_BASE (PR base ref/SHA) is required", file=sys.stderr)
         return 2
+    head = os.environ.get("GITHUB_PR_HEAD", "HEAD")
     pr_number = os.environ.get("GITHUB_PR_NUMBER", "")
-    entries = changed_entries(base)
-    others = other_changed(base)
+    # Diff only what this PR introduces. pull_request.base.sha is frozen at PR
+    # open/sync time and goes stale, and the pull_request checkout is the merge
+    # commit (current base branch + head); diffing either against the merge
+    # surfaces main's forward progress as "PR changes". Resolve the merge-base
+    # of (base, head) -- the true fork point -- and diff that..head.
+    merge_base = git("merge-base", base, head).strip()
+    if merge_base:
+        base = merge_base
+    entries = changed_entries(base, head)
+    others = other_changed(base, head)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     rows: list[tuple[str, str, str, str]] = []
     for status, path, old_path in entries:
-        slug = write_diff_page(status, path, old_path, base)
+        slug = write_diff_page(status, path, old_path, base, head)
         rows.append((status, path, slug, render_url(path)))
     write_index(rows, others, pr_number)
     print(


### PR DESCRIPTION
fix(docs): scope pr-preview diff to PR-introduced changes only

generate_pr_diff.py diffed `pull_request.base.sha..HEAD`, which surfaced
main's forward progress as "PR changes" for any PR that fell behind main:

  - github.event.pull_request.base.sha is frozen at PR open/sync time and
    goes stale (it is not the current base branch tip);
  - actions/checkout for a pull_request checks out the merge commit
    refs/pull/<n>/merge (current base + head), so HEAD bundled current main.

The script thus diffed a stale fork point against a HEAD carrying current
main, listing ~all of main's recent commits as PR changes -- e.g. a file
main added showed up as "new file @ PR head" though the PR never touched
it. For PR #462 this was 34 files (3 real + 31 noise).

Resolve the merge-base of (base, head) and diff that..head; pass the PR
head SHA explicitly (GITHUB_PR_HEAD) so the new side is the actual PR head,
not the merge. The workflow now fetches origin/<base.ref> (current) as
GITHUB_PR_BASE and uses fetch-depth: 0 so the merge-base and file reads
resolve. Side-by-side labels are honest: `@ base` (merge-base) and
`@ PR head`.

Verified locally against #462: pr-diff now reports 1 docs page
(configuration.md) + 2 other files (templatematch.py,
test_templatematch.py) -- the PR's own changes only.

The rendered docs preview is unchanged: it still builds from the PR merge
(current main + head), i.e. the docs as they render after the PR merges,
which is the intended preview semantic.
