### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/optics_framework/helper/version.py
+++ b/optics_framework/helper/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.9.3"
+VERSION = "1.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "optics-framework"
-version = "1.9.3"
+version = "1.10.0"
 description = "A flexible and modular test automation framework that can be used to automate any mobile application."
 authors = ["Lalitanand Dandge <lalit@mozark.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Bump the package version `1.9.3` -> `1.10.0` (minor).

- `pyproject.toml`
- `optics_framework/helper/version.py`

## Why

Releases the merged onboarding overhaul as a minor: `optics quickstart`, `optics doctor`, and project-scoped `optics configure` are new user-facing CLI surfaces, and the dead global-config layer was removed (a behavior change).

## Checklist

- [x] `pyproject.toml` and `optics_framework/helper/version.py` both bumped
- [x] pre-commit green on changed files