### PR TITLE
fix(docs): API reference params + CLI layer architecture

### DIFF
--- a/docs/architecture/cli_layer.md
+++ b/docs/architecture/cli_layer.md
@@ -6,12 +6,14 @@ The Optics Framework provides a command-line interface (CLI) that enables users 
 
 The CLI layer provides:
 
-1. **Project Management** - Initialize and manage test projects
-2. **Test Execution** - Execute and validate test cases
-3. **Driver Setup** - Install and configure drivers
-4. **Code Generation** - Generate test framework code
-5. **API Server** - Start the REST API server
-6. **Configuration** - Manage framework configuration
+1. **Onboarding** - `optics quickstart`, `optics doctor`, and `optics configure` take a new user from a fresh install to a runnable project and a healthy setup
+2. **Project Management** - `optics init` scaffolds a project from a template
+3. **Test Execution** - `optics execute` and `optics dry_run` run and validate test cases
+4. **Engine Setup** - `optics setup` installs driver, OCR, and LLM backends by name
+5. **Code Generation** - `optics generate` emits pytest or Robot Framework code
+6. **Interactive & Agent Surfaces** - `optics live` for interactive sessions and `optics mcp` for AI-agent control
+7. **API Server** - `optics serve` starts the REST API
+8. **Listing & Completion** - `optics list` prints keywords; `optics completion` installs shell completions
 
 ## CLI Architecture
 
@@ -25,11 +27,13 @@ graph TB
     F --> G[Core Framework]
 
     D --> H[Init Command]
-    D --> I[Execute Command]
-    D --> J[Setup Command]
-    D --> K[Generate Command]
-    D --> L[Server Command]
-    D --> M[Config Command]
+    D --> I[Quickstart Command]
+    D --> J[Execute / Dry Run]
+    D --> K[Setup Command]
+    D --> L[Generate Command]
+    D --> M[Server / Live / MCP]
+    D --> N[Configure / Doctor]
+    D --> O[List / Completion]
 ```
 
 **Location:** `optics_framework/helper/cli.py`
@@ -284,6 +288,34 @@ optics completion
 ```
 
 **Behavior:** Generates the completion scripts under `~/.optics/`, then asks for confirmation before appending the `source` line to the shell RC file (`.bashrc`, `.zshrc`). On decline — or without an interactive terminal — it prints the line to add manually and leaves RC files untouched.
+
+### 12. Live Command
+
+**Command:** `optics live [folder]`
+
+**Purpose:** Open an interactive terminal session to run keywords against a live target, with recording always on
+
+**Usage:**
+```bash
+optics live                # uses the config.yaml in the current directory
+optics live my_project     # uses that project's config.yaml
+```
+
+**Behavior:** Driver-agnostic and config-driven — the single enabled driver in `config.yaml` is the target. Each successful keyword is buffered; `/save <test_case> <module_name>` appends the recording to `modules/modules.csv`, `test_cases/test_cases.csv`, and `elements/elements.csv`. `Ctrl-N` toggles a natural-language mode where an LLM drives the keywords from a plain-English goal (needs the `llm` extra). See [Live Usage](../usage/live_usage.md).
+
+### 13. MCP Command
+
+**Command:** `optics mcp [--transport stdio|http]`
+
+**Purpose:** Run an MCP server that exposes every keyword as a typed tool and device state as resources, so an AI client can drive a real target
+
+**Usage:**
+```bash
+optics mcp                                  # stdio transport (default; local clients like Claude Desktop)
+optics mcp --transport http --port 8090     # networked
+```
+
+**Behavior:** A thin in-process wrapper over the REST engine — it reuses the keyword machinery, not a reimplementation. `start_session` -> observe (`screenshot`, `optics://session/{id}/source`) -> act (`press_element`, `enter_text`, ...) -> `terminate_session`. Sessions are **not** shared with `optics serve`; each is its own process. Requires the optional `mcp` extra (`pip install "optics-framework[mcp]"`). See [MCP Usage](../usage/mcp_usage.md).
 
 ## Helper Modules
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,8 @@ plugins:
       handlers:
         python:
           paths: [.]
+          options:
+            docstring_style: sphinx
   - minify:
       minify_html: true
 

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -983,7 +983,7 @@ class ActionKeyword:
         If the input is a string that includes angle brackets (e.g., '<enter>'),
         the text between the brackets will be interpreted as a special key name and mapped accordingly.
 
-        :param input: The text or special key identifier to send.
+        :param text_input: The text or special key identifier to send.
         :param event_name: Optional event label for logging.
         """
 
@@ -1155,9 +1155,7 @@ class ActionKeyword:
                                - "mobile:pressKey" (plain script)
                                - '{"script": "mobile:pressKey", "args": {"keycode": 3}}' (JSON with args)
                                - '{"script": "mobile:clear"}' (JSON without args)
-        :type script_or_json: str
         :param event_name: The event triggering the script execution, if any.
-        :type event_name: Optional[str]
         :return: The result of the script execution.
         :rtype: Any
         """

--- a/optics_framework/api/app_management.py
+++ b/optics_framework/api/app_management.py
@@ -62,7 +62,7 @@ class AppManagement:
         """
         Starts another application.
 
-        :param package_name: The package name of the application.
+        :param app_name: The package name of the application.
         :param event_name: The event triggering the app start, if any.
         """
         self.driver.launch_other_app(app_name, event_name)

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -433,17 +433,14 @@ class FlowControl:
         Reads tabular data from a CSV file, JSON file, environment variable, or a 2D list,
         applies optional filtering and column selection, and stores the result in the session's elements.
 
-        Args:
-            input_element: Variable name where the result is stored (e.g. `${data}`). Prefer `${name}` form.
-            file_path: Data source. One of: (1) path to a `.csv` or `.json` file; (2) string
-                ``ENV:VAR_NAME`` to use an environment variable (value parsed as JSON, CSV, or plain string);
-                (3) a 2D list with first row as headers (Python API only).
-            query: Optional semicolon-separated parts: ``select=col1,col2`` and/or filter expressions
-                (pandas-style). Any ``${varname}`` in the query is resolved from `session.elements` before
-                evaluation. Default ``""``.
-
-        Returns:
-            The stored value as a list (or list of lists for multi-row results). Also writes into
+        :param input_element: Variable name where the result is stored (e.g. ``${data}``). Prefer ``${name}`` form.
+        :param file_path: Data source. One of: (1) path to a ``.csv`` or ``.json`` file; (2) string
+            ``ENV:VAR_NAME`` to use an environment variable (value parsed as JSON, CSV, or plain string);
+            (3) a 2D list with first row as headers (Python API only).
+        :param query: Optional semicolon-separated parts: ``select=col1,col2`` and/or filter expressions
+            (pandas-style). Any ``${varname}`` in the query is resolved from `session.elements` before
+            evaluation. Default ``""``.
+        :returns: The stored value as a list (or list of lists for multi-row results). Also writes into
             `session.elements` under the name derived from `input_element`.
         """
         internal_logger.debug(f"[READ_DATA] Called with input_element={input_element}, file_path={file_path}, query={query}")
@@ -924,22 +921,18 @@ class FlowControl:
         """
         Evaluates a date expression based on an input date and stores the result in session.elements.
 
-        Args:
-            param1 (str): The variable name (placeholder) where the evaluated date result will be stored.
-            param2 (str): The input date string (e.g., "04/25/2025" or "2025-04-25"). Format is auto-detected.
-            param3 (str): The date expression to evaluate, such as "+1 day", "-2 days", or "today".
-            param4 (Optional[str]): The output format for the evaluated date (default is "%d %B", e.g., "26 April").
-
-        Returns:
-            str: The resulting evaluated and formatted date string.
-
-        Raises:
-            ValueError: If the session is not present, the input date format cannot be detected,
-                        or the expression format is invalid.
+        :param param1: The variable name (placeholder) where the evaluated date result will be stored.
+        :param param2: The input date string (e.g., ``"04/25/2025"`` or ``"2025-04-25"``). Format is auto-detected.
+        :param param3: The date expression to evaluate, such as ``"+1 day"``, ``"-2 days"``, or ``"today"``.
+        :param param4: The output format for the evaluated date (default is ``"%d %B"``, e.g., ``"26 April"``).
+        :returns: The resulting evaluated and formatted date string.
+        :raises OpticsError: If the session is not present, the input date format cannot be detected,
+            or the expression format is invalid.
 
         Example:
+
             date_evaluate("tomorrow", "04/25/2025", "+1 day")
-            ➔ Stores "26 April" in session.elements["tomorrow"]
+            -> Stores "26 April" in session.elements["tomorrow"]
         """
         self._ensure_session()
         if self.session is None:

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -129,7 +129,7 @@ class Verifier:
         Asserts the presence of elements -- anywhere in the page/DOM, visible or not.
 
         :param elements: Comma-separated string of elements to check (Image templates, OCR templates, or XPaths).
-        :param timeout: The time to wait for the elements in seconds.
+        :param timeout_str: The time to wait for the elements in seconds.
         :param rule: The rule for verification ("any" or "all").
         :param event_name: The name of the event associated with the assertion, if any.
         :return: True if the rule is satisfied, False otherwise.
@@ -337,7 +337,6 @@ class Verifier:
         On Appium sources, element bounds are returned in the screenshot's pixel space.
 
         :param filter_config: Optional list of filter types (e.g., ["buttons", "inputs"]).
-        :type filter_config: Optional[List[str]]
         :return: A list of interactive elements.
         """
         screenshot_np = self._safe_capture_screenshot_np() if self._bounds_need_screenshot() else None

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -338,7 +338,6 @@ class Optics:
         Discover all image templates in the project directory.
 
         :param project_path: The path to the project directory.
-        :type project_path: str
 
         :return: TemplateData containing image name to path mappings.
         :rtype: TemplateData
@@ -397,12 +396,9 @@ class Optics:
         """
         Configure the Optics Framework from a JSON or YAML configuration file.
 
-        Args:
-            config_file_path: Path to the configuration file (JSON or YAML).
-
-        Raises:
-            ValueError: If the file cannot be read or parsed.
-            FileNotFoundError: If the configuration file doesn't exist.
+        :param config_file_path: Path to the configuration file (JSON or YAML).
+        :raises ValueError: If the file cannot be read or parsed.
+        :raises FileNotFoundError: If the configuration file doesn't exist.
         """
         try:
             with open(config_file_path, "r", encoding="utf-8") as file:
@@ -1192,15 +1188,14 @@ class Optics:
         """
         Get interactive elements on the screen.
 
-        Args:
-            filter_config: Optional list of filter types. Valid values:
-                - "all": Show all elements (default when None or empty)
-                - "interactive": Only interactive elements
-                - "buttons": Only button elements
-                - "inputs": Only input/text field elements
-                - "images": Only image elements
-                - "text": Only text elements
-                Can be combined: ["buttons", "inputs"]
+        :param filter_config: Optional list of filter types. Valid values:
+            - "all": Show all elements (default when None or empty)
+            - "interactive": Only interactive elements
+            - "buttons": Only button elements
+            - "inputs": Only input/text field elements
+            - "images": Only image elements
+            - "text": Only text elements
+            Can be combined: ["buttons", "inputs"]
         """
         if not self.verifier:
             raise ValueError(INVALID_SETUP)


### PR DESCRIPTION
## What

### 1. API reference params not rendering
`/api_reference/action_keywords/...#ActionKeyword.swipe` showed the signature line but no parameter table. Root cause: the API classes use Sphinx-style docstrings (`:param x:`), but mkdocstrings defaulted to Google-style, so `:param:` lines rendered as raw description text.

- Set the mkdocstrings Python handler to `docstring_style: sphinx` so `:param:`/`:returns:`/`:raises:` parse into proper tables.
- Fixed the six docstrings the parser then surfaced:
  - `enter_text_using_keyboard`: `:param input:` -> `:param text_input:`
  - `launch_other_app`: `:param package_name:` -> `:param app_name:`
  - `assert_presence`: `:param timeout:` -> `:param timeout_str:`
  - `execute_script`, `get_interactive_elements`, `discover_templates`: dropped redundant `:type:` lines that duplicated the signature annotations.
- Converted the two Google-style docstrings in `flow_control.py` (`read_data`, `date_evaluate`) to Sphinx so they don't regress.

### 2. CLI Layer architecture not updated for the new commands
The `## Overview` list and the Mermaid diagram still named the six original commands and omitted `quickstart`, `doctor`, `configure`, `live`, and `mcp` (the Available Commands section below already had the onboarding ones). Updated both to the full command set, and added Live + MCP sections to Available Commands so the page lists every user-facing subcommand.

## Verification
- `mkdocs build` clean (no griffe warnings; only the pre-existing `mcp_usage.md` Docker-link warning remains, unrelated).
- `pytest tests/units/api/test_{flow_control_all,action_keyword,verifier,app_management}.py` -> 94 passed, 2 pre-existing xfailed.
- pre-commit green on all changed files.

## Commit layout
1. `fix(docs): render API reference params with sphinx docstring style` — mkdocs.yml + 5 API-class docstrings.
2. `docs: bring CLI layer architecture in line with the current commands` — `docs/architecture/cli_layer.md`.