### PR TITLE
fix: reject fuzzy/partial text matches in presence assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ CI runs static analysis on every push to `main` via `.github/workflows/mozarkson
 - **Assume Codex reviews every PR — someone is always watching.** Write code and commit messages as if a sharp reviewer will read them line by line. No dead code, no debug leftovers, no "will fix later" hacks slipping through. Explain non-obvious choices in the commit body, keep diffs focused, and make sure the change actually does what the message claims.
 - **Split large pushes into multiple commits.** If you're pushing a big change or a whole feature, don't dump it in one commit. Break it into logical, individually-reviewable commits (e.g. scaffolding → core logic → tests → docs), each green on its own. One giant commit is a review smell.
 - **After pushing or raising a PR, do a gap analysis.** Deep-dive your own implementation *and* the chat history for the feature, then surface the gaps, risks, edge cases, and follow-ups you noticed to the user. Let the user pick which ones matter; for the approved ones, create GitHub issues, and then reference those issue numbers in the PR description so the open threads are tracked against the work.
+- **No unnecessary code comments.** Names and structure should carry the meaning. Only add an inline comment, or edit a docstring, when the *why* is genuinely non-obvious (a hidden constraint, a subtle invariant, a workaround) or a piece of logic is confusing enough to need a pointer — never to restate *what* the code does.
 
 ## Hard rules
 

--- a/optics_framework/common/config_handler.py
+++ b/optics_framework/common/config_handler.py
@@ -41,6 +41,7 @@ class Config(BaseModel):
     halt_duration: float = 0.1
     max_attempts: int = 3
     ai_self_heal: bool = False
+    strict_element_match: bool = False
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -290,10 +290,13 @@ def detect_change(frame1, frame2, threshold=0.95):
     score, _ = ssim(gray1, gray2, full=True)
     return score < threshold
 
-def compare_text(given_text, target_text):
+def compare_text(given_text, target_text, strict: bool = False):
     """
     Compare two text values using exact, partial, and fuzzy matching.
     Returns True if the texts match closely enough, otherwise False.
+
+    strict=True restricts the comparison to an exact match only -- no partial/substring
+    or fuzzy fallback -- for presence/assertion checks where a false positive is unacceptable.
     """
     # Normalize both texts (case insensitive, strip whitespace)
     given_text = given_text.strip().lower()
@@ -309,6 +312,10 @@ def compare_text(given_text, target_text):
         internal_logger.debug(f"Exact match found: '{given_text}' == '{target_text}'")
         internal_logger.debug(f'Exact match found for text: {given_text}')
         return True
+
+    if strict:
+        internal_logger.debug(f"Strict match required; no exact match for '{given_text}' and '{target_text}'.")
+        return False
 
     # 2. Partial Match (substring, return immediately)
     if target_text in given_text:

--- a/optics_framework/engines/drivers/appium_UI_helper.py
+++ b/optics_framework/engines/drivers/appium_UI_helper.py
@@ -514,12 +514,13 @@ class UIHelper:
                     }
         return None
 
-    def get_locator_and_strategy(self, element):
+    def get_locator_and_strategy(self, element, strict: bool = False):
         """
         Determines the best strategy and locator for the given element identifier.
+
+        strict=True stops after exact/suffix matching -- no fuzzy fallback.
         """
         _, time_stamp = self.get_page_source()
-        tree = self.tree
 
         strategies = [
             ("text", "//*[@text]", "text"),
@@ -534,39 +535,49 @@ class UIHelper:
         if exact is not None:
             return exact
 
-        # Second pass: collect fuzzy candidates and pick the best-scoring one
+        if strict:
+            internal_logger.debug(f"Strict matching enabled; no exact match found for '{element}'.")
+            return None
+
+        return self._find_best_fuzzy_candidate(element, strategies, time_stamp)
+
+    @staticmethod
+    def _fuzzy_ratio(value: str, element: str) -> int:
+        try:
+            return fuzz.ratio(value.lower().strip(), element.lower().strip())
+        except Exception:
+            return 0
+
+    def _find_best_fuzzy_candidate(self, element, strategies, time_stamp):
+        """Second pass: collect fuzzy candidates and return the best-scoring one, if any."""
         best_candidate = None
         best_score = 0
         for strategy_name, xpath_query, attrib in strategies:
-            elements = tree.xpath(xpath_query)
-            for elem in elements:
+            for elem in self.tree.xpath(xpath_query):
                 value = elem.attrib.get(attrib, "").strip()
                 if not value:
                     continue
-                try:
-                    score = fuzz.ratio(value.lower().strip(), element.lower().strip())
-                except Exception:
-                    score = 0
+                score = self._fuzzy_ratio(value, element)
                 if score > best_score:
                     best_score = score
                     best_candidate = (strategy_name, value, elem.attrib)
 
-        if best_candidate and best_score >= 80:
-            strategy_name, value, attributes = best_candidate
+        if not best_candidate or best_score < 80:
             internal_logger.debug(
-                f"Fuzzy match selected (score={best_score}) using '{strategy_name}': '{value}'"
+                f"No matching element found in any of the locator strategies for '{element}'."
             )
-            return {
-                "strategy": strategy_name,
-                "locator": value,
-                "attributes": attributes,
-                "timestamp": time_stamp,
-            }
+            return None
 
+        strategy_name, value, attributes = best_candidate
         internal_logger.debug(
-            f"No matching element found in any of the locator strategies for '{element}'."
+            f"Fuzzy match selected (score={best_score}) using '{strategy_name}': '{value}'"
         )
-        return None
+        return {
+            "strategy": strategy_name,
+            "locator": value,
+            "attributes": attributes,
+            "timestamp": time_stamp,
+        }
 
     def get_view_locator(self, strategy, locator):
         """
@@ -652,7 +663,7 @@ class UIHelper:
             return None
 
     def get_locator_and_strategy_using_index(
-        self, element, index, strategy=None
+        self, element, index, strategy=None, strict: bool = False
     ) -> dict:
         """
         Perform a linear search across all strategies (resource-id, text, content-desc, etc.) in the UI tree,
@@ -662,6 +673,7 @@ class UIHelper:
             element (str): The element identifier to search for.
             index (int): zero indexing
             strategy (str): supported attributes in string, 'resource-id', 'text', 'content-desc', 'name', 'value', 'label'
+            strict (bool): if True, only exact/suffix matches are considered -- no partial/fuzzy fallback.
 
         Returns:
             list: A list of dictionaries, each containing the strategy, value, and index of the match.
@@ -729,7 +741,7 @@ class UIHelper:
                 continue
 
             # fallback to fuzzy/partial compare
-            if utils.compare_text(val, element):
+            if not strict and utils.compare_text(val, element):
                 fuzzy_matches.append(
                     {
                         "index": idx,

--- a/optics_framework/engines/elementsources/appium_page_source.py
+++ b/optics_framework/engines/elementsources/appium_page_source.py
@@ -79,12 +79,23 @@ class AppiumPageSource(ElementSourceInterface):
         internal_logger.error(APPIUM_NOT_INITIALISED_MSG)
         raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
 
+    def _strict_element_match(self) -> bool:
+        """Whether project config requests exact-only matching for locate (Config.strict_element_match).
+
+        Presence/assert checks ignore this and are always strict -- see assert_elements.
+        """
+        try:
+            return bool(self.driver.event_sdk.config_handler.config.strict_element_match)
+        except AttributeError:
+            return False
+
     def _locate_by_text(self, driver: WebDriver, element: str, element_type: str, index: Optional[int] = None) -> Any:
         locator = element[len("text="):] if element.lower().startswith("text=") else element
+        strict = self._strict_element_match()
         if index is not None:
-            xpath = self.find_xpath_from_text_index(locator, index)
+            xpath = self.find_xpath_from_text_index(locator, index, strict=strict)
         else:
-            xpath = self.find_xpath_from_text(locator)
+            xpath = self.find_xpath_from_text(locator, strict=strict)
         try:
             execution_logger.debug(f"Finding element by text: {locator} with xpath: {xpath}")
             element_obj = driver.find_element(AppiumBy.XPATH, xpath)
@@ -97,7 +108,7 @@ class AppiumPageSource(ElementSourceInterface):
 
     def _locate_by_xpath(self, driver: WebDriver, element: str, element_type: str) -> Any:
         if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-            xpath, _ = self.driver.ui_helper.find_xpath(element)
+            xpath, _ = self.driver.ui_helper.find_xpath(element, strict=self._strict_element_match())
             try:
                 element_obj = driver.find_element(AppiumBy.XPATH, xpath)
                 return element_obj
@@ -168,7 +179,9 @@ class AppiumPageSource(ElementSourceInterface):
 
     def locate_using_index(self, element, index, strategy=None) -> Optional[Any]:
         if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-            locators = self.driver.ui_helper.get_locator_and_strategy_using_index(element, index, strategy)
+            locators = self.driver.ui_helper.get_locator_and_strategy_using_index(
+                element, index, strategy, strict=self._strict_element_match()
+            )
             if locators:
                 strategy = locators['strategy']
                 locator = locators['locator']
@@ -213,7 +226,7 @@ class AppiumPageSource(ElementSourceInterface):
             self.get_page_source()  # Refresh page source
 
             # Check text-based elements
-            text_found = self.ui_text_search(texts, rule) if texts else (rule == "all")
+            text_found = self.ui_text_search(texts, rule, strict=True) if texts else (rule == "all")
 
             # Check XPath-based elements
             if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None and xpaths:
@@ -238,19 +251,20 @@ class AppiumPageSource(ElementSourceInterface):
         if rule not in ["any", "all"]:
             raise ValueError("Invalid rule. Use 'any' or 'all'.")
 
-    def find_xpath_from_text(self, text):
+    def find_xpath_from_text(self, text, strict: bool = False):
         """
         Find the XPath of an element based on the text content.
 
         Args:
             text (str): The text content to search for in the UI tree.
+            strict (bool): if True, only exact/suffix matches are considered.
 
         Returns:
             str: The XPath of the element containing the
             text content, or None if not found.
         """
         if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-            locators = self.driver.ui_helper.get_locator_and_strategy(text)
+            locators = self.driver.ui_helper.get_locator_and_strategy(text, strict=strict)
             if locators:
                 strategy = locators['strategy']
                 locator = locators['locator']
@@ -261,9 +275,11 @@ class AppiumPageSource(ElementSourceInterface):
             raise RuntimeError(APPIUM_NOT_INITIALISED_MSG)
         raise RuntimeError("Failed to find XPath from text.")
 
-    def find_xpath_from_text_index(self, text, index, strategy=None):
+    def find_xpath_from_text_index(self, text, index, strategy=None, strict: bool = False):
         if self.driver is not None and hasattr(self.driver, "ui_helper") and self.driver.ui_helper is not None:
-            locators = self.driver.ui_helper.get_locator_and_strategy_using_index(text, index, strategy)
+            locators = self.driver.ui_helper.get_locator_and_strategy_using_index(
+                text, index, strategy, strict=strict
+            )
             if locators:
                 strategy = locators['strategy']
                 locator = locators['locator']
@@ -280,34 +296,35 @@ class AppiumPageSource(ElementSourceInterface):
             internal_logger.error("Element tree is not initialized. Cannot perform xpath search.")
             raise RuntimeError("Element tree is not initialized.")
 
-    def _search_text_in_attribute(self, text, attrib):
+    def _search_text_in_attribute(self, text, attrib, strict: bool = False):
         """Searches for text in a specific attribute across all elements."""
         matching_elements = self.tree.xpath(f"//*[@{attrib}]")
 
         for elem in matching_elements:
             attrib_value = elem.attrib.get(attrib, '').strip()
-            if attrib_value and utils.compare_text(attrib_value, text):
+            if attrib_value and utils.compare_text(attrib_value, text, strict=strict):
                 internal_logger.debug(f"Match found using {attrib} for '{text}'")
                 return True
         return False
 
-    def _search_single_text(self, text):
+    def _search_single_text(self, text, strict: bool = False):
         """Searches for a single text across all strategies."""
         strategies = ["text", "resource-id", "content-desc", "name", "value", "label"]
         internal_logger.debug(f'Searching for text: {text}')
 
         for attrib in strategies:
-            if self._search_text_in_attribute(text, attrib):
+            if self._search_text_in_attribute(text, attrib, strict):
                 return True
         return False
 
-    def ui_text_search(self, texts, rule='any'):
+    def ui_text_search(self, texts, rule='any', strict: bool = False):
         """
         Checks if any or all given texts exist in the UI tree.
 
         Args:
             texts (list): List of text strings to search for.
             rule (str): Rule for matching ('any' or 'all').
+            strict (bool): if True, only exact matches are considered -- no partial/fuzzy fallback.
 
         Returns:
             bool: True if the condition is met, otherwise False.
@@ -316,7 +333,7 @@ class AppiumPageSource(ElementSourceInterface):
         found_texts = set()
 
         for text in texts:
-            if self._search_single_text(text):
+            if self._search_single_text(text, strict):
                 found_texts.add(text)
                 if rule == 'any':
                     return True

--- a/tests/units/common/test_compare_text.py
+++ b/tests/units/common/test_compare_text.py
@@ -1,0 +1,45 @@
+"""compare_text's strict mode -- regression cover for the fuzzy false-positive that let
+an "element exists" check succeed for a value that only vaguely resembled what was on
+screen (e.g. "Buy 102 devices" matching an actual "Buy 101 devices"), so a Condition's
+ELSE branch could never be reached.
+"""
+import pytest
+
+from optics_framework.common.utils import compare_text
+
+pytestmark = pytest.mark.white_box
+
+
+class TestNonStrictMatching:
+    def test_exact_match(self):
+        assert compare_text("Buy 101 devices", "Buy 101 devices") is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert compare_text("  BUY 101 DEVICES ", "buy 101 devices") is True
+
+    def test_substring_match(self):
+        assert compare_text("Buy 101 devices", "devices") is True
+
+    def test_fuzzy_match_above_threshold(self):
+        assert compare_text("Buy 101 devices", "Buy 102 devices") is True
+
+    def test_no_match_below_threshold(self):
+        assert compare_text("Buy 101 devices", "Ask mom for help") is False
+
+    def test_empty_strings_never_match(self):
+        assert compare_text("", "Buy 101 devices") is False
+        assert compare_text("Buy 101 devices", "") is False
+
+
+class TestStrictMatching:
+    def test_exact_match_still_succeeds(self):
+        assert compare_text("Buy 101 devices", "Buy 101 devices", strict=True) is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert compare_text("  BUY 101 DEVICES ", "buy 101 devices", strict=True) is True
+
+    def test_substring_is_rejected(self):
+        assert compare_text("Buy 101 devices", "devices", strict=True) is False
+
+    def test_near_miss_fuzzy_candidate_is_rejected(self):
+        assert compare_text("Buy 101 devices", "Buy 102 devices", strict=True) is False

--- a/tests/units/common/test_config_handler.py
+++ b/tests/units/common/test_config_handler.py
@@ -142,3 +142,7 @@ def test_config_handler_precomputes_enabled(tmp_path):
     handler = ConfigHandler(config)
     assert handler.get("driver_sources") == ["appium"]
     assert handler.get("elements_sources") == []
+
+
+def test_strict_element_match_defaults_to_false():
+    assert Config().strict_element_match is False

--- a/tests/units/engines/drivers/test_appium_ui_helper_strict_match.py
+++ b/tests/units/engines/drivers/test_appium_ui_helper_strict_match.py
@@ -1,0 +1,73 @@
+"""UIHelper's text-locator strict mode -- the same fuzzy/partial fallback that
+find_xpath already gated behind `strict` for XPath locators, extended to
+get_locator_and_strategy/get_locator_and_strategy_using_index.
+"""
+import pytest
+from lxml import etree
+
+from optics_framework.engines.drivers.appium_UI_helper import UIHelper
+
+pytestmark = pytest.mark.white_box
+
+ANDROID_TREE = (
+    '<hierarchy rotation="0">'
+    '<android.widget.RadioButton text="Buy 101 devices" '
+    'resource-id="com.app:id/buy_101" bounds="[0,0][200,50]"/>'
+    "</hierarchy>"
+)
+
+
+def _helper(page_source: str) -> UIHelper:
+    helper = UIHelper.__new__(UIHelper)
+    helper.driver = None
+    helper.tree = etree.ElementTree(etree.fromstring(page_source.encode("utf-8")))
+    helper.root = helper.tree.getroot()
+    helper.get_page_source = lambda: (page_source, "ts")
+    return helper
+
+
+class TestGetLocatorAndStrategy:
+    def test_fuzzy_candidate_matched_when_not_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        result = helper.get_locator_and_strategy("Buy 102 devices")
+
+        assert result is not None
+        assert result["locator"] == "Buy 101 devices"
+
+    def test_fuzzy_candidate_rejected_when_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        assert helper.get_locator_and_strategy("Buy 102 devices", strict=True) is None
+
+    def test_exact_match_unaffected_by_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        result = helper.get_locator_and_strategy("Buy 101 devices", strict=True)
+
+        assert result is not None
+        assert result["locator"] == "Buy 101 devices"
+
+
+class TestGetLocatorAndStrategyUsingIndex:
+    def test_fuzzy_candidate_matched_when_not_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        result = helper.get_locator_and_strategy_using_index("Buy 102 devices", 0)
+
+        assert result["locator"] == "Buy 101 devices"
+
+    def test_fuzzy_candidate_rejected_when_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        with pytest.raises(IndexError):
+            helper.get_locator_and_strategy_using_index("Buy 102 devices", 0, strict=True)
+
+    def test_exact_match_unaffected_by_strict(self):
+        helper = _helper(ANDROID_TREE)
+
+        result = helper.get_locator_and_strategy_using_index(
+            "Buy 101 devices", 0, strict=True
+        )
+
+        assert result["locator"] == "Buy 101 devices"

--- a/tests/units/engines/elementsources/test_appium_page_source_strict_match.py
+++ b/tests/units/engines/elementsources/test_appium_page_source_strict_match.py
@@ -1,0 +1,82 @@
+"""AppiumPageSource text-presence checks must be exact -- regression cover for a
+Condition's "element exists" probe reporting true for a value that only fuzzy-matched
+what was actually on screen (e.g. "Buy 102 devices" against an on-screen "Buy 101
+devices"), which meant the ELSE branch could never be reached. Mirrors the strict
+treatment find_xpath already gives XPath-type presence checks.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from optics_framework.engines.elementsources.appium_page_source import AppiumPageSource
+
+pytestmark = pytest.mark.white_box
+
+ANDROID_TREE = (
+    '<hierarchy rotation="0">'
+    '<android.widget.RadioButton text="Buy 101 devices" '
+    'resource-id="com.app:id/buy_101" bounds="[0,0][200,50]"/>'
+    "</hierarchy>"
+)
+
+
+def _source(page_source: str = ANDROID_TREE, strict_element_match: bool = False) -> AppiumPageSource:
+    driver = MagicMock()
+    driver.driver.page_source = page_source
+    driver.event_sdk.config_handler.config.strict_element_match = strict_element_match
+    return AppiumPageSource(driver=driver)
+
+
+class TestStrictElementMatchConfig:
+    def test_reads_config_flag(self):
+        assert _source(strict_element_match=True)._strict_element_match() is True
+        assert _source(strict_element_match=False)._strict_element_match() is False
+
+    def test_missing_config_chain_defaults_to_false(self):
+        source = AppiumPageSource(driver=object())
+
+        assert source._strict_element_match() is False
+
+
+class TestAssertElementsTextPresence:
+    def test_present_text_is_found(self):
+        source = _source()
+
+        source.assert_elements(["Buy 101 devices"], timeout=1, rule="any")
+
+    def test_fuzzy_near_miss_is_not_reported_as_present(self):
+        source = _source()
+
+        with pytest.raises(TimeoutError):
+            source.assert_elements(["Buy 102 devices"], timeout=0.05, rule="any")
+
+
+class TestLocateStrictWiring:
+    def test_locate_by_xpath_passes_config_strict_flag(self):
+        source = _source(strict_element_match=True)
+        source.driver.ui_helper.find_xpath.return_value = ("//x", "ts")
+
+        source._locate_by_xpath(source.driver, "xpath=//x", "XPath")
+
+        source.driver.ui_helper.find_xpath.assert_called_once_with("xpath=//x", strict=True)
+
+    def test_locate_by_text_passes_config_strict_flag(self):
+        source = _source(strict_element_match=True)
+        source.driver.ui_helper.get_locator_and_strategy.return_value = None
+
+        with pytest.raises(RuntimeError):
+            source._locate_by_text(source.driver, "Buy 101 devices", "Text")
+
+        source.driver.ui_helper.get_locator_and_strategy.assert_called_once_with(
+            "Buy 101 devices", strict=True
+        )
+
+    def test_locate_by_text_with_index_passes_config_strict_flag(self):
+        source = _source(strict_element_match=True)
+        source.driver.ui_helper.get_locator_and_strategy_using_index.return_value = None
+
+        source._locate_by_text(source.driver, "Buy 101 devices", "Text", index=0)
+
+        source.driver.ui_helper.get_locator_and_strategy_using_index.assert_called_once_with(
+            "Buy 101 devices", 0, None, strict=True
+        )


### PR DESCRIPTION
## Summary

- `AppiumPageSource.assert_elements` already resolved **XPath** locators strictly (d844c98); **text** locators had no equivalent guard. A presence/"element exists" check could report `true` for text that only vaguely resembled what was actually on screen -- `compare_text`'s `fuzz.ratio` fallback scores `"Buy 102 devices"` at 93 against an on-screen `"Buy 101 devices"`. In App Studio, a Condition block probing for the former silently succeeded, so its ELSE branch could never run.
- `compare_text` gains a `strict` param that skips the partial/fuzzy stages (exact match only).
- `UIHelper.get_locator_and_strategy` / `get_locator_and_strategy_using_index` gain the same `strict` param, mirroring `find_xpath`'s existing strict mode for XPath locators.
- `AppiumPageSource.assert_elements` now always resolves text strictly -- this alone fixes the reported bug, unconditionally.
- New `Config.strict_element_match` (default `False`) threads the same flag through `AppiumPageSource`'s *locate* paths (`_locate_by_xpath`, `_locate_by_text`), so a project can opt in to exact-only matching for tap/self-heal locates too. Locate stays fuzzy-tolerant by default, per d844c98's original intent (self-healing resilience).

## Test plan

- [x] `poetry run pytest tests/` -- full suite green (2 pre-existing unrelated xfails)
- [x] `poetry run ruff check` / `poetry run pre-commit run --files <changed>` -- clean
- [x] New unit tests cover: `compare_text` strict vs fuzzy (incl. the exact "Buy 102/101 devices" regression), `UIHelper` strict-mode locator resolution, `AppiumPageSource` presence-assertion strictness and locate-path config wiring, `Config.strict_element_match` default