### PR TITLE
fix: derive default port from URL scheme in Appium/Selenium reachability probes

### DIFF
--- a/optics_framework/helper/doctor.py
+++ b/optics_framework/helper/doctor.py
@@ -32,6 +32,7 @@ _console = Console()
 
 _SOCKET_TIMEOUT_S = 3.0
 _ADB_TIMEOUT_S = 10.0
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 _STATUS_GLYPH = {
     "ok": "[green]✅[/green]",
@@ -388,12 +389,20 @@ def _appium_target(folder: str) -> tuple[str, int] | None:
 
 
 def _split_host_port(url: object) -> tuple[str, int] | None:
+    """(host, port) for a configured server url.
+
+    ``urlparse`` never fills in a scheme's implied port, so a remote hub given
+    as ``https://hub.example.com/wd/hub`` would otherwise be probed on the
+    local Appium port and reported as unreachable."""
     if not isinstance(url, str) or not url.strip():
         return None
     try:
         # "//" (not http://) lets urlparse read a bare host:port as a netloc.
         parsed = urlparse(url if "://" in url else f"//{url}")
-        return parsed.hostname or "127.0.0.1", parsed.port or 4723
+        port = (parsed.port
+                or _SCHEME_DEFAULT_PORTS.get(parsed.scheme)
+                or 4723)
+        return parsed.hostname or "127.0.0.1", port
     except ValueError:
         return None
 

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -480,6 +480,7 @@ _PREFLIGHT_SOCKET_TIMEOUT_S = 2.0
 _PREFLIGHT_ADB_TIMEOUT_S = 5.0
 _APPIUM_DEFAULT_URL = "http://127.0.0.1:4723"
 _SELENIUM_DEFAULT_URL = "http://127.0.0.1:4444/wd/hub"
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
 def _probe_tcp(url: str | None, default_port: int,
@@ -492,8 +493,13 @@ def _probe_tcp(url: str | None, default_port: int,
     Missing or unparseable URLs count as unreachable so callers can report the
     real fix instead of an opaque driver error minutes into the run.
 
+    ``urlparse`` never fills in a scheme's implied port, so a remote hub given
+    as ``https://hub.example.com/wd/hub`` would otherwise be probed on the
+    local-server default and reported as down.
+
     :param url: Server URL from config.yaml (e.g. ``http://127.0.0.1:4723``).
-    :param default_port: Port used when the URL carries none.
+    :param default_port: Port used when the URL carries neither an explicit
+                         port nor a scheme whose port is implied.
     :param timeout: Seconds to wait for the connection.
     :return: True when the TCP connection succeeds.
     """
@@ -502,7 +508,9 @@ def _probe_tcp(url: str | None, default_port: int,
     try:
         parsed = urlparse(url)
         host = parsed.hostname
-        port = parsed.port or default_port
+        port = (parsed.port
+                or _SCHEME_DEFAULT_PORTS.get(parsed.scheme)
+                or default_port)
     except ValueError:
         return False
     if not host:

--- a/tests/units/helpers/test_doctor.py
+++ b/tests/units/helpers/test_doctor.py
@@ -417,6 +417,9 @@ class TestSplitHostPort:
         ("10.0.0.5:4723", ("10.0.0.5", 4723)),  # schemeless host:port
         ("127.0.0.1", ("127.0.0.1", 4723)),     # bare host keeps the default port
         ("localhost:8080/", ("localhost", 8080)),
+        # No explicit port: the scheme's implied port, not the Appium default.
+        ("https://appium-hub.example.com/wd/hub", ("appium-hub.example.com", 443)),
+        ("http://appium-hub.example.com/wd/hub", ("appium-hub.example.com", 80)),
     ])
     def test_parses_host_and_port(self, url, expected):
         assert doctor._split_host_port(url) == expected

--- a/tests/units/helpers/test_execute.py
+++ b/tests/units/helpers/test_execute.py
@@ -179,14 +179,14 @@ class TestProbeTcp:
         finally:
             server.close()
 
-    def test_default_port_used_when_url_has_none(self):
+    def test_default_port_used_when_url_has_no_scheme_or_port(self):
         server = socket.socket()
         server.bind(("127.0.0.1", 0))
         server.listen(1)
         port = server.getsockname()[1]
         try:
             assert execute_module._probe_tcp(
-                "http://127.0.0.1", default_port=port) is True
+                "//127.0.0.1", default_port=port) is True
         finally:
             server.close()
 
@@ -197,6 +197,18 @@ class TestProbeTcp:
     @pytest.mark.parametrize("url", [None, "", "   ", "http://:4723/wd/hub"])
     def test_missing_or_unparseable_url_returns_false(self, url):
         assert execute_module._probe_tcp(url, default_port=4723) is False
+
+    @pytest.mark.parametrize("url, expected_port", [
+        ("https://appium-hub.example.com:8443/wd/hub", 8443),
+        ("http://appium-hub.example.com:4723/wd/hub", 4723),
+        ("https://appium-hub.example.com/wd/hub", 443),
+        ("http://appium-hub.example.com/wd/hub", 80),
+        ("//appium-hub.example.com", 4723),
+    ])
+    def test_port_comes_from_url_then_scheme_then_default(self, url, expected_port):
+        with patch.object(execute_module.socket, "create_connection") as connect:
+            assert execute_module._probe_tcp(url, default_port=4723) is True
+        assert connect.call_args.args[0] == ("appium-hub.example.com", expected_port)
 
 
 def _fake_adb_run(stdout):


### PR DESCRIPTION
## The bug

Point a project at a real, live **remote** Appium hub with no explicit port:

```yaml
driver_sources:
  - appium:
      enabled: true
      url: "https://appium-hub.preprod.mozark.ai/wd/hub"
```

`optics execute` aborts with "No Appium server reachable at …" and tells you to run `appium` locally, and `optics doctor` shows the appium server row as unreachable — against a hub that is up and serving.

## Root cause

`urlparse()` never infers a scheme's implied port; `.port` is populated only when the URL literally contains `:<port>`:

```
>>> p = urlparse("https://appium-hub.preprod.mozark.ai/wd/hub")
>>> p.scheme, p.hostname, p.port
('https', 'appium-hub.preprod.mozark.ai', None)
```

Two independent helpers then fell straight through to a hardcoded local default:

- `optics_framework/helper/execute.py` → `_probe_tcp`: `port = parsed.port or default_port` — `default_port=4723` from `_preflight_appium`, `default_port=4444` from `_preflight_selenium`.
- `optics_framework/helper/doctor.py` → `_split_host_port`: `parsed.port or 4723` — feeding `_appium_target` → `_appium_row`.

So the probe opened a TCP connection to `appium-hub.preprod.mozark.ai:4723` instead of `:443`, got refused, and reported the live server as down.

## The fix

Both helpers now resolve the port as **explicit URL port → the scheme's implied port (`http` 80 / `https` 443) → the caller's hardcoded default**. A URL with an explicit port is untouched; the caller default now applies only when the URL carries no scheme either, which preserves the schemeless `host` / `host:port` forms doctor accepts via its `//` netloc trick.

Files touched:

- `optics_framework/helper/execute.py` — `_probe_tcp` port resolution + new `_SCHEME_DEFAULT_PORTS`. One change covers both call sites (`_preflight_appium`, `_preflight_selenium`), since they share the helper.
- `optics_framework/helper/doctor.py` — `_split_host_port` port resolution + new `_SCHEME_DEFAULT_PORTS`.
- `tests/units/helpers/test_execute.py`, `tests/units/helpers/test_doctor.py` — coverage below.

The two helpers stay independent copies rather than sharing an extracted one: they have different signatures/purposes (bool probe vs `(host, port)` tuple), and `doctor.py` deliberately keeps a slim import graph — importing from `execute.py` would drag the session/execution stack into a diagnostic command for a three-entry dict lookup.

### Blast radius checked

- `_probe_tcp` has exactly two callers, both fixed by the single change.
- `doctor.py` has **no** Selenium reachability probe — `_selenium_row` only checks the pip package and a WebDriver binary on PATH, so there is no second copy of this bug there.
- Grepped `optics_framework/` for every other `urlparse`/`urlsplit` and every `4723`/`4444` literal: the only other URL parse is `flow_control.py:1127`, which reads `query` for HAR logging and derives no port. `engines/drivers/appium.py` and `engines/drivers/selenium.py` hand the URL to the WebDriver client as-is. No other site has this defect.

## Testing

- `tests/units/helpers/test_execute.py::TestProbeTcp` — new parametrized case asserting the socket target for explicit-port (`:8443`, `:4723`), scheme-only `https` → 443, scheme-only `http` → 80, and schemeless `//host` → the caller's 4723.
- `tests/units/helpers/test_doctor.py::TestSplitHostPort` — added `https://…/wd/hub` → 443 and `http://…/wd/hub` → 80; the existing explicit-port and schemeless rows pass unchanged.
- Updated one existing execute test that encoded the old behaviour: it probed `http://127.0.0.1` expecting the caller default; under correct scheme inference that URL is port 80, so it now uses the schemeless `//127.0.0.1` — the case the default actually exists for.
- Sanity-checked end-to-end against a real listener on an ephemeral port: `https://127.0.0.1:<port>` connects (explicit port wins over 443), `https://127.0.0.1` does not (443, nothing listening), `//127.0.0.1` connects on the caller default.
- Full `tests/units` tree green (2 pre-existing xfails, unrelated).
- `pre-commit run --files` on all four changed files: ruff, bandit, whitespace, end-of-file, gitleaks all pass; commitizen check passes on the commit message.
