### PR TITLE
fix: mention OPTICS_SKIP_PREFLIGHT in preflight failure panels

### DIFF
--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -548,9 +548,23 @@ def _adb_device_count() -> int | None:
 
 
 def _abort_preflight(lines: List[str]) -> NoReturn:
-    """Print a friendly rich block explaining the failure and exit non-zero."""
+    """
+    Print a friendly rich block explaining the failure and exit non-zero.
+
+    Any of these checks can fire against a remote or cloud-hosted target
+    that will never satisfy them locally, so the escape hatch has to be
+    visible wherever the gate stops the run.
+
+    :param lines: Failure-specific message lines for the panel body.
+    """
     console = Console(file=sys.stderr)
-    console.print(Panel("\n".join(lines), title="Cannot start",
+    body = [
+        *lines,
+        "",
+        "Driving a remote/cloud device?",
+        f"Skip this check:  {_PREFLIGHT_SKIP_ENV}=1",
+    ]
+    console.print(Panel("\n".join(body), title="Cannot start",
                         border_style="red"))
     sys.exit(1)
 

--- a/tests/units/helpers/test_execute.py
+++ b/tests/units/helpers/test_execute.py
@@ -333,6 +333,27 @@ class TestPreflightGate:
         probe.assert_not_called()
         adb.assert_not_called()
 
+    @pytest.mark.parametrize("config,probe,adb", [
+        pytest.param(_config_for("appium"), False, None,
+                     id="appium server unreachable"),
+        pytest.param(_config_for("appium",
+                                 capabilities={"platformName": "Android"}),
+                     True, None, id="adb tool missing"),
+        pytest.param(_config_for("appium",
+                                 capabilities={"platformName": "Android"}),
+                     True, 0, id="no android device attached"),
+        pytest.param(_config_for("selenium"), False, None,
+                     id="selenium server unreachable"),
+    ])
+    def test_every_panel_points_at_the_skip_env(self, capsys, config, probe, adb):
+        with patch.object(execute_module, "_probe_tcp", return_value=probe), \
+                patch.object(execute_module, "_adb_device_count", return_value=adb):
+            with pytest.raises(SystemExit):
+                execute_module._preflight_or_exit(config)
+        err = capsys.readouterr().err
+        assert "remote/cloud device" in err
+        assert f"{execute_module._PREFLIGHT_SKIP_ENV}=1" in err
+
     def test_no_enabled_driver_is_left_to_the_existing_gate(self):
         config = Config(driver_sources=[{"selenium": DependencyConfig(enabled=False)}])
         with patch.object(execute_module, "_probe_tcp") as probe:


### PR DESCRIPTION
## The gap

`_preflight_or_exit` (`optics_framework/helper/execute.py`) already supports a blanket escape hatch:

```python
_PREFLIGHT_SKIP_ENV = "OPTICS_SKIP_PREFLIGHT"
...
if os.environ.get(_PREFLIGHT_SKIP_ENV, "").strip().lower() in {"1", "true"}:
    return
```

That early return sits **above** the driver dispatch, so it uniformly gates every check — Appium's and Selenium's alike. But the flag was only documented on `docs/usage/CLI_usage.md` and `docs/architecture/cli_layer.md`. None of the abort panels a user actually sees mentioned it.

Concrete consequence: point a project at a hub-hosted or cloud device and preflight stops the run with *"No Android device/emulator attached (adb reports none)"* — correct locally, but that phone will never appear in local `adb devices`. The panel offers "connect a device or start an emulator" and nothing else. The one flag that would let the run proceed is invisible at the moment it's needed.

## The fix

The hint is appended in `_abort_preflight` — the single sink all panels funnel through — rather than duplicated at four call sites. The env var gates the whole gate uniformly, so identical wording everywhere is correct, and future panels inherit it without the next author having to remember.

All four panels now end with:

```
Driving a remote/cloud device?
Skip this check:  OPTICS_SKIP_PREFLIGHT=1
```

Panels covered (note: **four**, not three — the Selenium one is easy to miss if you only ever hit the Appium path):

1. `_preflight_appium` — "No Appium server reachable at {url}."
2. `_preflight_appium` — "Android run requested, but the adb tool was not found."
3. `_preflight_appium` — "No Android device/emulator attached (adb reports none)."
4. `_preflight_selenium` — "No Selenium/WebDriver server reachable at {url}."

Wording is split across two short lines to match the existing `Label:  action` rhythm of these panels and to stay well clear of Rich's 80-column wrap, so the env var never breaks mid-token.

## Testing

- Added `test_every_panel_points_at_the_skip_env`, parametrized over all four failure paths, asserting both `remote/cloud device` and `OPTICS_SKIP_PREFLIGHT=1` reach stderr.
- Rendered each of the four panels manually to confirm the hint lands in the right place and nothing wraps.
- `pytest tests/units/helpers/` — 456 passed, no regressions. The pre-existing panel-text assertions (`test_appium_unreachable_aborts_with_fix`, `test_selenium_unreachable_aborts_with_fix`, etc.) all still hold since this only appends.
- `pre-commit run --files optics_framework/helper/execute.py tests/units/helpers/test_execute.py` — clean.

Docs already describe the flag, so no doc change was needed; this closes the gap between the docs and the in-context error output.
