### PR TITLE
fix: stop optics live's /help panel from silently truncating

### DIFF
--- a/docs/usage/live_usage.md
+++ b/docs/usage/live_usage.md
@@ -86,9 +86,9 @@ sleep 5
 |------------------|-------------|
 | `/save <test_case> <module_name>` | Save the recorded actions as `<module_name>` in `modules/modules.csv` and add a `(<test_case>, <module_name>)` row to `test_cases/test_cases.csv`. Elements are merged into your project's existing elements CSV when one is tracked anywhere (the templates keep it at `test_data/elements.csv`) — only names not already present are appended, so no second `elements/elements.csv` appears; with no elements file, a header-only `elements/elements.csv` stub is created. All three files use fixed names and are **appended** to when they already exist, so you can build a suite one module at a time. A successful save **clears the recording buffer**, so the next actions become the next module. If `<module_name>` or `<test_case>` already exists, the save is refused with a prompt — re-run the identical `/save` to append, or pick a different name. Session screenshots/artifacts are also snapshotted to `execution_output/<module_name>/`. |
 | `/device [id]`   | **Appium sessions only.** List the **Android** (`adb`) and **iOS** (`idevice_id`) devices attached to *this* machine, each labelled by platform; with no argument, pick one to switch the active device's `udid`. The chosen device must match the session's configured platform. For Selenium/Playwright it reports that switching doesn't apply (the target is the configured browser). See the note below for remote Appium hubs. |
-| `/elements`      | Open a read-only popup of named elements and their locators (Esc closes). |
+| `/elements`      | Open a read-only popup of named elements and their locators (Up/Down scrolls, Esc closes). |
 | `/screenshot`    | Capture the current device screen to a file and note the path in the history. |
-| `/help`          | Show the command reference (Esc closes). |
+| `/help`          | Show the command reference (Up/Down scrolls, Esc closes). |
 | `/quit`, `/exit` | End the session, run the normal driver teardown/cleanup, and exit. Typing `quit` or `exit` without the slash does the same, so leaving is never a guessing game. An unknown `/command` prints the available commands instead of failing silently. |
 
 > **`/device` and remote Appium hubs.** `/device` shells out to the local `adb devices`
@@ -106,6 +106,7 @@ sleep 5
 | `Enter`        | Run the command, or accept the highlighted completion |
 | `Tab` / `S-Tab`| Cycle completions |
 | `${`           | Suggest element names |
+| `Up` / `Down`  | Scroll an open popup (`PgUp`/`PgDn` by page); otherwise recall previous input |
 | `Ctrl-K`       | Toggle the keyword browser |
 | `Ctrl-N`       | Toggle natural-language (AI) mode |
 | `Ctrl-X`       | Abort a running AI run (stops at the next step) |

--- a/optics_framework/helper/live_tui.py
+++ b/optics_framework/helper/live_tui.py
@@ -9,6 +9,8 @@ accumulate in a scrollable history pane above that auto-scrolls to the newest en
 import asyncio
 import functools
 import os
+import textwrap
+from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from prompt_toolkit.application import Application, get_app
@@ -50,6 +52,13 @@ _META = "class:meta"
 # Style class for in-progress / AI-mode indicators, reused across history and overlays.
 _RUNNING = "class:running"
 
+# Popup body bounds; the terminal is the real bound, these only cap it.
+_POPUP_MAX_ROWS = 30
+_POPUP_MAX_COLS = 72
+_POPUP_MIN_COLS = 40
+# Rows/columns the surrounding Frame's border takes off the popup body.
+_FRAME_BORDER = 2
+
 _HELP_TEXT = """\
 Optics Live — command reference
 
@@ -84,6 +93,7 @@ Keys
   Enter          Run the command / accept the highlighted completion
   Tab / S-Tab    Cycle completions
   ${             Suggest element names
+  Up / Down      Scroll an open popup (PgUp/PgDn by page)
   Ctrl-K         Toggle the keyword browser (Up/Down to move, Enter to pick)
   Ctrl-N         Toggle natural-language (AI) mode
   Ctrl-X         Abort a running AI run (stops at the next step)
@@ -112,6 +122,50 @@ _STYLE = Style.from_dict(
         "frame.border": "#5588cc",
     }
 )
+
+
+def _wrap_to_width(text: str, width: int) -> List[str]:
+    """Split ``text`` into the display rows it occupies, over-long lines re-wrapped
+    under their own indent so row counts match what the terminal actually draws."""
+    rows: List[str] = []
+    for line in text.split("\n"):
+        if len(line) <= width:
+            rows.append(line)
+            continue
+        indent = " " * (len(line) - len(line.lstrip()))
+        wrapper = textwrap.TextWrapper(
+            width=width,
+            initial_indent=indent,
+            subsequent_indent=indent,
+            break_long_words=True,
+            break_on_hyphens=False,
+        )
+        wrapped = wrapper.wrap(line.strip())
+        if wrapped:
+            rows.extend(wrapped)
+        else:
+            rows.extend(line[i : i + width] for i in range(0, len(line), width))
+    return rows
+
+
+def _clamp(value: int, maximum: int) -> int:
+    """Clamp ``value`` to ``[0, maximum]`` — scroll offsets never go negative."""
+    return max(0, min(value, maximum))
+
+
+@dataclass(frozen=True)
+class _PopupLayout:
+    """The wrapped popup text plus the viewport arithmetic that scrolls it.
+
+    ``visible`` is the number of content rows shown per page — the whole text
+    when it fits, otherwise one row is reserved so the scroll indicator stays
+    visible. ``max_scroll`` is the furthest the scroll offset can go (0 when
+    nothing is cut off).
+    """
+
+    lines: List[str]
+    visible: int
+    max_scroll: int
 
 
 class LiveCompleter(Completer):
@@ -191,10 +245,11 @@ class LiveTUI:
         self.overlay_on_select: Optional[Callable[[str], None]] = None
         self.overlay_active = False
 
-        # Popup = static read-only text (help / elements).
+        # Popup = static read-only text (help / elements), scrolled by row offset.
         self.popup_title = ""
         self.popup_text = ""
         self.popup_active = False
+        self.popup_scroll = 0
 
         self.input_buffer = Buffer(
             completer=LiveCompleter(controller, is_nl_mode=lambda: self._nl_mode),
@@ -324,8 +379,45 @@ class LiveTUI:
     def open_popup(self, title: str, text: str) -> None:
         self.popup_title = title
         self.popup_text = text
+        self.popup_scroll = 0
         self.popup_active = True
         self.overlay_active = False
+
+    # -- Popup (scrollable static text) -------------------------------------------
+
+    def _popup_viewport(self) -> Tuple[int, int]:
+        """Rows/columns of popup body the current terminal can actually show."""
+        size = get_app().output.get_size()
+        rows = max(2, min(_POPUP_MAX_ROWS, size.rows - _FRAME_BORDER))
+        cols = max(1, min(_POPUP_MAX_COLS, size.columns - _FRAME_BORDER))
+        return rows, cols
+
+    def _popup_layout(self) -> _PopupLayout:
+        """Wrap the popup text and compute the scrolling viewport over it."""
+        rows, cols = self._popup_viewport()
+        lines = _wrap_to_width(self.popup_text, cols)
+        scrollable = len(lines) > rows
+        visible = rows - 1 if scrollable else len(lines)
+        max_scroll = len(lines) - visible if scrollable else 0
+        return _PopupLayout(lines, visible, max_scroll)
+
+    def _render_popup(self) -> StyleAndTextTuples:
+        layout = self._popup_layout()
+        if not layout.max_scroll:
+            return [("", "\n".join(layout.lines))]
+        top = _clamp(self.popup_scroll, layout.max_scroll)
+        shown = layout.lines[top:top + layout.visible]
+        return [
+            ("", "\n".join(shown) + "\n"),
+            (_META, f" ↑/↓ PgUp/PgDn scroll · {top + 1}-{top + len(shown)}/{len(layout.lines)} "),
+        ]
+
+    def _scroll_popup(self, delta: int, *, page: bool = False) -> None:
+        layout = self._popup_layout()
+        if not layout.max_scroll:
+            return
+        step = delta * layout.visible if page else delta
+        self.popup_scroll = _clamp(self.popup_scroll + step, layout.max_scroll)
 
     # -- Layout / application -----------------------------------------------------
 
@@ -390,9 +482,9 @@ class LiveTUI:
             content=ConditionalContainer(
                 content=Frame(
                     body=Window(
-                        content=FormattedTextControl(text=lambda: self.popup_text),
-                        width=Dimension(min=40, preferred=72),
-                        height=Dimension(min=1, max=30),
+                        content=FormattedTextControl(text=self._render_popup),
+                        width=Dimension(min=_POPUP_MIN_COLS, preferred=_POPUP_MAX_COLS),
+                        height=Dimension(min=1, max=_POPUP_MAX_ROWS),
                         wrap_lines=True,
                     ),
                     title=lambda: self.popup_title,
@@ -473,6 +565,7 @@ class LiveTUI:
         kb = KeyBindings()
         blocking = Condition(lambda: self.overlay_active or self.popup_active)
         overlay_on = Condition(lambda: self.overlay_active)
+        popup_on = Condition(lambda: self.popup_active)
         not_blocking = ~blocking
 
         @kb.add("enter", filter=~blocking)
@@ -506,6 +599,22 @@ class LiveTUI:
         @kb.add("down", filter=overlay_on)
         def _(event):
             self._move_overlay(1)
+
+        @kb.add("up", filter=popup_on)
+        def _(event):
+            self._scroll_popup(-1)
+
+        @kb.add("down", filter=popup_on)
+        def _(event):
+            self._scroll_popup(1)
+
+        @kb.add("pageup", filter=popup_on)
+        def _(event):
+            self._scroll_popup(-1, page=True)
+
+        @kb.add("pagedown", filter=popup_on)
+        def _(event):
+            self._scroll_popup(1, page=True)
 
         @kb.add("up", filter=not_blocking & ~overlay_on)
         def _(event):

--- a/tests/units/helpers/test_live_keywords.py
+++ b/tests/units/helpers/test_live_keywords.py
@@ -6,8 +6,8 @@ unknown-keyword message (with closest-match suggestion), the friendly
 signature hint for ValueError/TypeError failures, and the graceful
 empty-input guard — all against a bare controller shell (no device/session),
 like the other live unit tests. The TUI-side command routing (bare quit/exit
-aliases and the unknown-/command hint) is tested here too against a stubbed
-prompt_toolkit app.
+aliases and the unknown-/command hint) and the scrollable /help popup are
+tested here too against a stubbed prompt_toolkit app.
 """
 from types import SimpleNamespace
 
@@ -182,18 +182,24 @@ def test_unknown_keyword_suggests_closest_match():
 
 
 class _FakeApp:
-    def __init__(self):
+    def __init__(self, rows=40, columns=100):
         self.exited = False
+        self.output = SimpleNamespace(
+            get_size=lambda: SimpleNamespace(rows=rows, columns=columns)
+        )
 
     def exit(self):
         self.exited = True
 
+    def invalidate(self):
+        pass
 
-def _tui_with_stubbed_app(monkeypatch):
+
+def _tui_with_stubbed_app(monkeypatch, rows=40, columns=100):
     """A real LiveTUI over a bare controller; get_app/_info stubbed so no tty is needed."""
     controller = SimpleNamespace(saved=True, recorded=[])
     tui = live_tui.LiveTUI(controller)
-    app = _FakeApp()
+    app = _FakeApp(rows=rows, columns=columns)
     messages: list[str] = []
     monkeypatch.setattr(live_tui, "get_app", lambda: app)
     monkeypatch.setattr(tui, "_info", lambda msg, raw="": messages.append(msg))
@@ -219,6 +225,95 @@ def test_unknown_slash_command_hints_available_commands(monkeypatch):
     assert len(messages) == 1
     assert "/help" in messages[0]
     assert "/quit" in messages[0]
+
+
+def _popup_text(tui) -> str:
+    return "".join(text for _style, text in tui._render_popup())
+
+
+def _popup_key_handler(tui, key):
+    """The single key binding that fires for ``key`` while the popup is open."""
+    bindings = [
+        binding
+        for binding in tui.app.key_bindings.get_bindings_for_keys((key,))
+        if binding.filter()
+    ]
+    assert len(bindings) == 1
+    return bindings[0].handler
+
+
+def test_help_popup_reveals_content_below_the_first_page(monkeypatch):
+    """The tail of the reference (/device, /quit, Keys) used to be clipped away."""
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui._submit("/help")
+    first_page = _popup_text(tui)
+    tui._scroll_popup(1, page=True)
+    second_page = _popup_text(tui)
+
+    assert "/device" not in first_page
+    for marker in ("/device", "/quit", "Keys", "Ctrl-C", "Press Esc to close this help."):
+        assert marker in second_page
+
+
+def test_help_popup_shows_a_scroll_indicator(monkeypatch):
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui._submit("/help")
+    layout = tui._popup_layout()
+
+    assert layout.max_scroll > 0
+    assert _popup_text(tui).endswith(
+        f" ↑/↓ PgUp/PgDn scroll · 1-{layout.visible}/{len(layout.lines)} "
+    )
+
+
+def test_help_popup_scroll_clamps_at_both_ends(monkeypatch):
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui._submit("/help")
+    layout = tui._popup_layout()
+    for _ in range(layout.max_scroll + 10):
+        tui._scroll_popup(1)
+    assert tui.popup_scroll == layout.max_scroll
+    assert "Press Esc to close this help." in _popup_text(tui)
+
+    for _ in range(layout.max_scroll + 10):
+        tui._scroll_popup(-1)
+    assert tui.popup_scroll == 0
+
+
+def test_help_popup_fits_a_short_terminal_by_scrolling(monkeypatch):
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch, rows=12)
+
+    tui._submit("/help")
+    layout = tui._popup_layout()
+    assert layout.visible == 12 - 2 - 1  # frame border, then a row for the indicator
+    for _ in range(layout.max_scroll):
+        tui._scroll_popup(1)
+
+    assert "Press Esc to close this help." in _popup_text(tui)
+
+
+def test_arrow_keys_scroll_the_popup_instead_of_recalling_history(monkeypatch):
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch)
+    tui._submit("/help")
+
+    _popup_key_handler(tui, "down")(None)
+    assert tui.popup_scroll == 1
+    _popup_key_handler(tui, "pagedown")(None)
+    assert tui.popup_scroll > 1
+    _popup_key_handler(tui, "up")(None)
+    _popup_key_handler(tui, "pageup")(None)
+    assert tui.popup_scroll == 0
+
+
+def test_short_popup_renders_without_a_scroll_indicator(monkeypatch):
+    tui, _app, _messages = _tui_with_stubbed_app(monkeypatch)
+
+    tui.open_popup("Elements", " No named elements found in this project. ")
+
+    assert _popup_text(tui) == " No named elements found in this project. "
 
 
 def test_status_hint_leads_with_help_and_quit():


### PR DESCRIPTION
## The bug

In `optics live`, `/help` opened a popup that silently cut off part-way through
the slash-command table. `/device`, `/quit` and the entire **Keys** section were
never visible — at any terminal size, with no scrollbar, no "more below" hint and
no key that could reach them.

Verified in `optics_framework/helper/live_tui.py`:

- The popup `Float` hardcoded `height=Dimension(min=1, max=30)`, and unlike the
  keyword browser (`overlay_float`, which has `up`/`down` bindings gated on
  `overlay_active` and a cursor the window scrolls to) the popup had no scroll
  bindings at all — the window always rendered from row 0 and clipped the rest.
- `_HELP_TEXT` is 41 authored lines, which is **51 rendered rows** once wrapped to
  the popup's 72-column preferred width. Row 31 lands on
  `  /device [id]   List/switch connected Android + iOS devices …`, so everything
  from `/device` down was unreachable — matching the report exactly.
- `/elements` shares the same popup, so any project with more than ~14 named
  elements (2 rows each) lost its tail the same way. That is the only other
  instance: `overlay_float`'s `max=18` is fine because its control reports a cursor
  position, which prompt_toolkit scrolls to keep visible.

## The fix

Took resolution **(a), real scrolling** — the file already had the binding pattern
to copy, and dropping the cap alone would still clip on a terminal shorter than the
content:

- `_render_popup()` renders a window over the popup text starting at
  `popup_scroll`, with a footer showing the visible range
  (`↑/↓ PgUp/PgDn scroll · 1-29/51`) whenever the content overflows. Short popups
  render unchanged, with no footer.
- `up`/`down` (a row) and `pageup`/`pagedown` (a page) are bound behind
  `Condition(lambda: self.popup_active)`, mirroring the overlay's `overlay_on`
  bindings. The existing history-recall bindings were already excluded while a
  popup is open, so nothing else changed.
- The viewport is measured from the live terminal size (capped at 30 rows /
  72 columns) instead of assuming 30 rows exist, so a short terminal just shows a
  smaller page rather than hiding its tail; and the text is pre-wrapped to the
  popup width so the row arithmetic matches what prompt_toolkit draws.
- Docs (`docs/usage/live_usage.md`) and the in-app Keys list mention the scroll keys.

## Testing

`tests/units/helpers/test_live_keywords.py` already drives a real `LiveTUI` against
a stubbed prompt_toolkit app; six tests were added there in the same style:

- previously-clipped markers (`/device`, `/quit`, `Keys`, `Ctrl-C`,
  `Press Esc to close this help.`) are absent from page 1 and present after one
  page-scroll;
- the footer reports the visible range;
- scrolling clamps at both ends and the last line is reachable at the bottom;
- on a 12-row terminal the page shrinks to 9 rows and the tail is still reachable;
- the `up`/`down`/`pageup`/`pagedown` bindings resolve (exactly one each) while the
  popup is open and move the offset — this is the regression test for the wiring
  that was missing;
- a short popup renders with no indicator and byte-identical text.

`pytest tests/units` passes (only the pre-existing `#385` XFAILs), and
`pre-commit run --files …` is clean on all three changed files.

