### PR TITLE
docs: note the libGL system dependency for OpenCV on Linux

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -18,6 +18,18 @@ optics --version             # confirm the CLI is on your PATH
 !!! warning "Use a standard virtualenv, not Conda"
     `easyocr` and `optics-framework` have conflicting `numpy` requirements (1.x vs 2.x) under Conda. Use a plain `venv`.
 
+### Linux: OpenCV needs a system OpenGL library
+
+Optics depends on `opencv-python`, which links against `libGL`. Minimal Linux images — Docker containers, CI runners, cloud dev environments — usually don't ship it, so `optics --version` fails on import with `ImportError: libGL.so.1: cannot open shared object file`. Install the library from your distro:
+
+```bash
+sudo apt-get install -y libgl1     # Debian/Ubuntu
+sudo dnf install -y mesa-libGL     # Fedora/RHEL
+sudo pacman -S libglvnd            # Arch
+```
+
+Desktop Linux installs normally already have it. macOS and Windows are unaffected.
+
 ---
 
 ## Engine backends (extras)


### PR DESCRIPTION
Closes #490

## What I verified

- `opencv-python` is a **core** dependency (`pyproject.toml:31`), not an extra — so `import cv2` runs on a bare `pip install optics-framework` and `optics --version` fails immediately on a Linux image without a system OpenGL library.
- `grep -rni "libgl\|mesa\|libglvnd"` across the repo returned **zero** hits in docs, README or code. The issue's claim holds: nothing documented it anywhere.
- `docs/prerequisites.md` covers Node/Android SDK/JDK for Appium, the Tesseract binary, and the Playwright browser download under **External tooling** — but that section is scoped to *optional engine extras*. libGL is a core-install concern, so it belongs under **Core install** instead.
- Checked `README.md` for a duplicate gap: its install section already defers all system tooling to the Installation guide (the `[!IMPORTANT]` block links to `/prerequisites/`), so no second copy of the note is warranted. Change stays confined to one file.

## The change

One new `### Linux: OpenCV needs a system OpenGL library` subsection under **Core install**, right after the existing Conda warning — the error string a user would search for, plus the package name per distro:

```bash
sudo apt-get install -y libgl1     # Debian/Ubuntu
sudo dnf install -y mesa-libGL     # Fedora/RHEL
sudo pacman -S libglvnd            # Arch
```

`mkdocs.yml` sets `toc_depth: 3`, so the new heading appears in the page TOC and gets a stable anchor: `prerequisites/#linux-opencv-needs-a-system-opengl-library`.

## Not a duplicate of #503

PR #503 (open, unmerged) adds a **runtime** friendly-error path — the CLI catching the `libGL` ImportError at startup and printing something readable instead of a traceback. This PR is the **docs** half that #490 asks for: the prerequisites page a user reads *before* hitting the crash. No file overlap — #503 touches runtime code, this touches `docs/prerequisites.md` only. The two are complementary; #503's message can point at the anchor above.

## Testing

Pure docs/copy change — a test wouldn't meaningfully protect it, so none added. Verified by rendering `docs/prerequisites.md` through Python-Markdown with the `fenced_code`/`admonition`/`toc`/`tables` extensions and reading the output: heading nests correctly under `## Core install`, the fenced bash block renders, the surrounding admonition and `---` separators are unaffected.

`poetry run pre-commit run --files docs/prerequisites.md` — all applicable hooks pass (trailing-whitespace, end-of-file-fixer, gitleaks; ruff/bandit/check-yaml/check-json skipped, no matching files).
