### PR TITLE
docs: note that /device only sees locally-attached devices

### DIFF
--- a/docs/usage/live_usage.md
+++ b/docs/usage/live_usage.md
@@ -85,11 +85,19 @@ sleep 5
 | Command          | Description |
 |------------------|-------------|
 | `/save <test_case> <module_name>` | Save the recorded actions as `<module_name>` in `modules/modules.csv` and add a `(<test_case>, <module_name>)` row to `test_cases/test_cases.csv`. Elements are merged into your project's existing elements CSV when one is tracked anywhere (the templates keep it at `test_data/elements.csv`) — only names not already present are appended, so no second `elements/elements.csv` appears; with no elements file, a header-only `elements/elements.csv` stub is created. All three files use fixed names and are **appended** to when they already exist, so you can build a suite one module at a time. A successful save **clears the recording buffer**, so the next actions become the next module. If `<module_name>` or `<test_case>` already exists, the save is refused with a prompt — re-run the identical `/save` to append, or pick a different name. Session screenshots/artifacts are also snapshotted to `execution_output/<module_name>/`. |
-| `/device [id]`   | **Appium sessions only.** List all connected **Android** (`adb`) and **iOS** (`idevice_id`) devices, each labelled by platform; with no argument, pick one to switch the active device's `udid`. The chosen device must match the session's configured platform. For Selenium/Playwright it reports that switching doesn't apply (the target is the configured browser). |
+| `/device [id]`   | **Appium sessions only.** List the **Android** (`adb`) and **iOS** (`idevice_id`) devices attached to *this* machine, each labelled by platform; with no argument, pick one to switch the active device's `udid`. The chosen device must match the session's configured platform. For Selenium/Playwright it reports that switching doesn't apply (the target is the configured browser). See the note below for remote Appium hubs. |
 | `/elements`      | Open a read-only popup of named elements and their locators (Esc closes). |
 | `/screenshot`    | Capture the current device screen to a file and note the path in the history. |
 | `/help`          | Show the command reference (Esc closes). |
 | `/quit`, `/exit` | End the session, run the normal driver teardown/cleanup, and exit. Typing `quit` or `exit` without the slash does the same, so leaving is never a guessing game. An unknown `/command` prints the available commands instead of failing silently. |
+
+> **`/device` and remote Appium hubs.** `/device` shells out to the local `adb devices`
+> and `idevice_id -l`, so it only ever sees devices plugged into the machine running
+> `optics live`. If your session drives a device through a remote Appium hub, that device
+> is attached to the hub's machine, not yours — `/device` will not list it, and reports
+> no devices found even while the session is happily driving one. That's out of scope,
+> not a fault: pick the hub device the way you already do, through the `udid` /
+> `deviceName` capabilities in your `config.yaml`.
 
 ## Keys
 


### PR DESCRIPTION
`/device` in `optics live` shells out to the local `adb devices` and `idevice_id -l`, so it only ever sees devices attached to the machine running the CLI. On a session driven through a **remote Appium hub**, the device is attached to the hub's machine — `/device` reports zero devices while the session is happily driving one, which reads as a bug rather than a scoping limit.

### Change (docs only, `docs/usage/live_usage.md`)

- Scoped the `/device` table row to devices attached to *this* machine, with a pointer to the new note.
- Added a blockquote note after the slash-commands table explaining the hub case and pointing hub users at the `udid` / `deviceName` capabilities in `config.yaml`, which is how the hub device is selected anyway.

### Verification

- Confirmed the technical claim in code before writing it: `LiveController.list_android_devices` / `list_ios_devices` (`optics_framework/helper/live.py`) run `["adb", "devices"]` and `["idevice_id", "-l"]` via `subprocess` — purely local, with no notion of a hub's inventory; `switch_device` only rewrites the `udid`/`deviceName` caps. This matches the "Device coupling caveat" already recorded in `CLAUDE.md`.
- Grepped `docs/` and `README.md` for other `/device` documentation: only `README.md` lists it in a one-line "other commands" pointer to this page (no duplicate gap), and `docs/usage/mcp_usage.md`'s hub mention is a different feature. Fix kept to `live_usage.md`.
- No test added — this is a pure documentation change and a test would not protect the prose. Instead I read the rendered markdown: the note uses the same `>` blockquote style already used further down this file, and the table row still renders as a single cell.
- `poetry run pre-commit run --files docs/usage/live_usage.md` — all applicable hooks pass.

Closes #499
