### PR TITLE
docs: document optics init's interactive template picker in --help

### DIFF
--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -281,7 +281,12 @@ class InitCommand(Command):
         )
         parser.add_argument(
             "--template",
-            help="Start from a sample template: " + ", ".join(available_templates()),
+            help=(
+                "Start from a sample template: "
+                + ", ".join(available_templates())
+                + ". Omit to choose one from an interactive picker; with no "
+                "interactive terminal, a blank project is created instead."
+            ),
         )
         parser.add_argument(
             "--git-init",


### PR DESCRIPTION
Closes #498

### Problem

`optics init --help` listed `--template` as a plain optional flag. Omitting it does not scaffold a blank project — it opens an interactive template picker whenever stdin is a TTY (`_resolve_template`, `optics_framework/helper/initialize.py`). Nothing in the CLI help said so, which is surprising when scripting against the contract `--help` implies.

### Scope — documentation only, deliberately

The issue offered two options: change the default to a blank project, or document the current behaviour. **This PR only does the latter.** Changing the default would be a user-facing behaviour change and is explicitly out of scope for this pass. No control flow was touched — the picker still runs exactly as before.

`docs/usage/CLI_usage.md` already documented this behaviour (line 90); the CLI's own `--help` output was the only place it was missing, so this is a one-flag help-string change.

### Change

`InitCommand.register` in `optics_framework/helper/cli.py` — appended to the `--template` help string:

```
--template TEMPLATE  Start from a sample template: calendar, clock, contact,
                     gmail_web, playwright, youtube. Omit to choose one from
                     an interactive picker; with no interactive terminal, a
                     blank project is created instead.
```

The second clause covers the non-TTY path too, since that is the case a script actually hits.

### Testing

- Rendered `optics init --help` before and after; the wrapped output reads correctly (pasted above).
- `pytest tests/units/helpers/test_initialize.py tests/units/helpers/test_quickstart.py` — 54 passed.
- Grepped `tests/` for assertions on the `init` help text or the `--template` string: none exist, so no test needed updating and no new test was added for copy.
- `pre-commit run --files optics_framework/helper/cli.py` — all hooks pass.
