### PR TITLE
docs(cli): explain what optics completion changes and how to undo it

### DIFF
--- a/optics_framework/helper/cli.py
+++ b/optics_framework/helper/cli.py
@@ -62,7 +62,22 @@ class ListCommand(Command):
 class AutocompletionCommand(Command):
     def register(self, subparsers: argparse._SubParsersAction):
         parser = subparsers.add_parser(
-            "completion", help="Enable shell autocompletion for optics CLI"
+            "completion",
+            help="Enable shell autocompletion for optics CLI",
+            description=(
+                "Enable Tab-completion of optics commands and arguments in bash or zsh.\n"
+                "\n"
+                "Writes the completion scripts to ~/.optics/optics_completion.sh (bash) and\n"
+                "~/.optics/optics_completion.zsh (zsh), then asks before appending a\n"
+                '"# Optics CLI autocompletion" comment and one "source" line to the rc file\n'
+                "for your $SHELL: ~/.bashrc for bash, ~/.zshrc for zsh. Declining the prompt,\n"
+                "or running without an interactive terminal, leaves the rc file untouched and\n"
+                "prints the line to add by hand instead.\n"
+                "\n"
+                "There is no uninstall flag: to undo, delete those two lines from the rc file\n"
+                "and, if you want, remove ~/.optics/optics_completion.*."
+            ),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
         )
         parser.set_defaults(func=self.execute)
 


### PR DESCRIPTION
Closes #491

`optics completion` writes completion scripts and offers to append a `source` line to the user's shell rc file, but `optics completion --help` said nothing about it. This adds a subparser `description` so the help output explains the change before it happens, and how to reverse it.

### What was verified

**Part 1 — `--help` is silent (confirmed, fixed here).** On `fork/main`, `optics completion --help` rendered only:

```
usage: optics completion [-h]

options:
  -h, --help  show this help message and exit
```

`AutocompletionCommand.register` (`optics_framework/helper/cli.py`) passed only `help=`, no `description=`. The behaviour it hides, read off `helper/autocompletion.py`: `write_completion_scripts()` always writes `~/.optics/optics_completion.sh` and `.zsh`; `update_shell_rc()` picks the rc file from `$SHELL` (`~/.bashrc` / `~/.zshrc`), asks for confirmation, and on a decline or a non-TTY stdin prints the manual `source` line instead of touching the file. There is no `--uninstall` flag, so the undo is manual — the description now says all of that.

**Part 2 — README CLI reference (already resolved, not touched).** `README.md:316` already carries `optics completion  Install shell autocompletion` inside the CLI reference block, alongside the other subcommands. `docs/usage/CLI_usage.md` and `docs/architecture/cli_layer.md` already describe the consent-gated rc-file behaviour too. No README change was needed or made.

### Rendered output

```
usage: optics completion [-h]

Enable Tab-completion of optics commands and arguments in bash or zsh.

Writes the completion scripts to ~/.optics/optics_completion.sh (bash) and
~/.optics/optics_completion.zsh (zsh), then asks before appending a
"# Optics CLI autocompletion" comment and one "source" line to the rc file
for your $SHELL: ~/.bashrc for bash, ~/.zshrc for zsh. Declining the prompt,
or running without an interactive terminal, leaves the rc file untouched and
prints the line to add by hand instead.

There is no uninstall flag: to undo, delete those two lines from the rc file
and, if you want, remove ~/.optics/optics_completion.*.

options:
  -h, --help  show this help message and exit
```

`RawDescriptionHelpFormatter` is set on this subparser only, so the line breaks survive; every other subcommand's help is unchanged, as is the one-line `help=` string shown in `optics --help`.

### Testing

- Ran `optics completion --help` against the branch source and confirmed the output above (bare command not executed — it would touch `~/.optics` and prompt about the rc file).
- Ran `optics --help` to confirm the top-level listing is unchanged.
- `pytest tests/units/helpers/test_autocompletion.py` — 11 passed. No test asserts on this command's help text (grepped `tests/` for `completion`, `AutocompletionCommand`, `update_shell_rc`), so nothing needed updating and no new test was added for help copy.
- `pre-commit run --files optics_framework/helper/cli.py` — all hooks pass.

Text-only change to one argparse subparser; no behaviour change.
