### PR TITLE
fix: reword post-install message so it stops implying a running server

### DIFF
--- a/optics_framework/helper/setup.py
+++ b/optics_framework/helper/setup.py
@@ -471,7 +471,8 @@ def install_extras(requests: List[InstallRequest], *, stream: bool = True) -> tu
             # pulls the required OS libraries.
             run([sys.executable, "-m", "playwright", "install", "--with-deps", "chromium"])
 
-        return True, "Engines installed successfully!"
+        return True, ("Engine packages installed. Services like the Appium "
+                      "server still need to be started separately.")
     except subprocess.CalledProcessError as e:
         # capture_output / _run_streaming route the command's diagnostics to
         # e.stderr/e.stdout rather than losing them, so fold them into the

--- a/tests/units/helpers/test_quickstart.py
+++ b/tests/units/helpers/test_quickstart.py
@@ -91,7 +91,7 @@ class Harness:
 
     def __init__(self, ask_values, confirm_values, *,
                  answers=None,
-                 install_result=(True, "Engines installed successfully!")):
+                 install_result=(True, "Engine packages installed.")):
         self.out = io.StringIO()
         self.prompts = Scripted(ask_values)
         self.confirms = Scripted(confirm_values)
@@ -263,9 +263,9 @@ class TestEngineInstall:
     def test_success_message_shown(self, tmp_path):
         with Harness(["mobile", "1", "demo", str(tmp_path)], [True],
                      install_result=(True,
-                                     "Engines installed successfully!")) as h:
+                                     "Engine packages installed.")) as h:
             h.run()
-        assert "installed successfully" in h.out.getvalue().lower()
+        assert "Engine packages installed" in h.out.getvalue()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/units/helpers/test_setup.py
+++ b/tests/units/helpers/test_setup.py
@@ -223,7 +223,7 @@ class TestInstallExtras:
                 patch(f"{MODULE}.subprocess.run"):
             ok, message = install_extras(_reqs("Appium"), stream=False)
         assert ok is True
-        assert "installed successfully" in message.lower()
+        assert "Engine packages installed" in message
 
     def test_installs_version_pinned_spec(self):
         engines = _reqs("Appium")
@@ -333,7 +333,10 @@ class TestStreamedInstall:
         assert "Collecting appium-python-client" in captured.out
         assert "Downloading appium..." in captured.out
         assert ok is True
-        assert message == "Engines installed successfully!"
+        # The message must not imply the Appium server itself is now running —
+        # only its Python client was installed (issue #494).
+        assert message == ("Engine packages installed. Services like the Appium "
+                           "server still need to be started separately.")
 
     def test_filters_requirement_already_satisfied_noise(self, capsys):
         proc = _popen_result([
@@ -449,7 +452,7 @@ class TestEngineInstallerApp:
         app = EngineInstallerApp()
         with patch(
             f"{MODULE}.install_extras",
-            return_value=(True, "Engines installed successfully!"),
+            return_value=(True, "Engine packages installed."),
         ) as inst:
             async with app.run_test() as pilot:
                 app.selected_engines = {"Appium": ALL_ENGINES["Appium"]}
@@ -457,7 +460,7 @@ class TestEngineInstallerApp:
                 await app.workers.wait_for_complete()
                 await pilot.pause()
                 status = app.query_one("#status", Static)
-                assert "installed successfully" in str(status.render()).lower()
+                assert "Engine packages installed" in str(status.render())
         inst.assert_called_once()
 
     async def test_failure_result_shown_and_install_reenabled(self):
@@ -482,7 +485,7 @@ class TestEngineInstallerApp:
 
         def slow_install(requests, stream=False):
             release.wait(timeout=10)
-            return True, "Engines installed successfully!"
+            return True, "Engine packages installed."
 
         app = EngineInstallerApp()
         with patch(f"{MODULE}.install_extras", side_effect=slow_install) as inst:
@@ -497,7 +500,7 @@ class TestEngineInstallerApp:
                 await app.workers.wait_for_complete()
                 await pilot.pause()
                 status = str(app.query_one("#status", Static).render())
-                assert "installed successfully" in status.lower()
+                assert "Engine packages installed" in status
         assert inst.call_args.kwargs == {"stream": False}
 
 


### PR DESCRIPTION
Closes #494

## Problem

`install_extras` (`optics_framework/helper/setup.py`) returned `"Engines installed successfully!"` after a successful pip install. For the mobile path that install is just `appium-python-client` — the Appium server is a separate Node process that is neither started nor checked here. During `optics quickstart` the next screen (auto-run `doctor`) immediately said `appium server: not reachable`, directly contradicting the "success" message a newcomer had just read.

## Change

One string, now:

> Engine packages installed. Services like the Appium server still need to be started separately.

`install_extras` is generic across every engine extra (Appium, Selenium, Playwright, OCR, LLM), so the wording stays generic and claims only what actually happened — packages installed — while naming the service users are most likely to trip over. It stays a single line, which matters because the setup TUI shows `message.splitlines()[0]` in its notification.

All three consumers pick the new text up unchanged: `optics setup --install` (`cli.py`), the setup TUI status line (`setup.py:_on_install_finished`), and `optics quickstart` (`quickstart.py:_offer_engine_install`).

## Tests

Updated the assertions in `tests/units/helpers/test_setup.py` and `tests/units/helpers/test_quickstart.py` that pinned the old wording (one exact-equality check plus several substring checks and mocked return values). The exact-equality check now carries a short note on why the wording matters, so a future reword doesn't silently reintroduce the overstatement.

`pytest tests/units/helpers/test_setup.py tests/units/helpers/test_quickstart.py` — 88 passed. `pre-commit` clean on the three changed files.