### PR TITLE
fix: floor per-strategy assertion budget instead of rounding to zero

### DIFF
--- a/optics_framework/common/strategies.py
+++ b/optics_framework/common/strategies.py
@@ -16,6 +16,8 @@ from optics_framework.common.error import OpticsError, Code
 # Constants
 TEXT_DETECTION_NOT_AVAILABLE_MSG = "Text detection is not available."
 
+MIN_STRATEGY_TIMEOUT_S = 0.5
+
 
 class LocateValueWithFrame(NamedTuple):
     """Result from vision strategies: coordinates (or value) plus optional annotated image."""
@@ -698,21 +700,15 @@ class StrategyManager:
 
     def _alloc_time_for_strategy(
         self, deadline: float, idx: int, applicable_strategies: List[Any]
-    ) -> Optional[Tuple[int, float, int]]:
+    ) -> Optional[Tuple[float, float, int]]:
         """Compute seconds to allocate for this strategy. Returns (alloc, remaining_total, remaining_strategies) or None to break."""
         remaining_total = max(0.0, deadline - time.time())
         remaining_strategies = len(applicable_strategies) - idx
         if remaining_total <= 0:
             internal_logger.debug("No remaining time left to try further strategies.")
             return None
-        alloc = int(math.ceil(remaining_total / remaining_strategies))
-        alloc = min(alloc, int(math.floor(remaining_total)))
-        if alloc <= 0:
-            if idx == len(applicable_strategies) - 1:
-                return (0, remaining_total, remaining_strategies)
-            internal_logger.debug("Insufficient time to allocate to next strategies.")
-            return None
-        return (alloc, remaining_total, remaining_strategies)
+        alloc = min(math.ceil(remaining_total / remaining_strategies), remaining_total)
+        return (max(alloc, MIN_STRATEGY_TIMEOUT_S), remaining_total, remaining_strategies)
 
     def assert_presence(self, elements: list, element_type: str, timeout: int = 30, rule: str = 'any'):
         """Assert elements are present -- possibly off-screen, anywhere in the page/DOM."""
@@ -786,7 +782,7 @@ class StrategyManager:
             return LocatorStrategy._is_method_implemented(strategy.element_source, "assert_elements_visible")
         return True
 
-    def _try_assert_with_strategy(self, strategy, elements: list, timeout: int, rule: str, method_name: str = "assert_elements"):
+    def _try_assert_with_strategy(self, strategy, elements: list, timeout: float, rule: str, method_name: str = "assert_elements"):
         """Try to assert elements using a specific strategy.
 
         Strategies are required to return (result, timestamp, annotated_frame).

--- a/tests/units/common/test_strategies.py
+++ b/tests/units/common/test_strategies.py
@@ -20,6 +20,7 @@ from optics_framework.common.base_factory import InstanceFallback
 from optics_framework.common.elementsource_interface import ElementSourceInterface
 from optics_framework.common.error import Code, OpticsError
 from optics_framework.common.strategies import (
+    MIN_STRATEGY_TIMEOUT_S,
     LocatorStrategy,
     StrategyManager,
     TextDetectionStrategy,
@@ -564,12 +565,30 @@ class TestAllocTimeForStrategy:
         # deadline already passed
         assert _sm(MagicMock())._alloc_time_for_strategy(999.0, 0, [1, 2]) is None
 
-    def test_last_strategy_gets_remainder_even_if_sub_second(self, monkeypatch):
+    def test_sub_second_remainder_is_floored_not_zeroed(self, monkeypatch):
+        """A sub-second remainder used to floor to 0s, so the strategy checked nothing."""
         monkeypatch.setattr(time, "time", lambda: 1000.0)
-        # 0.4s left, last strategy (idx 1 of 2): alloc rounds to 0 but the last one still runs.
         result = _sm(MagicMock())._alloc_time_for_strategy(1000.4, 1, [1, 2])
         assert result is not None
-        assert result[0] == 0
+        assert result[0] == MIN_STRATEGY_TIMEOUT_S
+
+    def test_tight_timeout_never_allocates_zero_to_any_strategy(self, monkeypatch):
+        """timeout=1 across 3 strategies: every strategy gets a usable budget (#507)."""
+        now = 1000.0
+        monkeypatch.setattr(time, "time", lambda: now)
+        manager = _sm(MagicMock())
+        strategies = [1, 2, 3]
+        deadline = 1001.0
+        for idx in range(len(strategies)):
+            result = manager._alloc_time_for_strategy(deadline, idx, strategies)
+            assert result is not None
+            assert result[0] >= MIN_STRATEGY_TIMEOUT_S
+            now += 0.4
+
+    def test_alloc_never_exceeds_remaining_time_above_the_floor(self, monkeypatch):
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        alloc, remaining, _ = _sm(MagicMock())._alloc_time_for_strategy(1002.5, 1, [1, 2])
+        assert alloc == remaining == 2.5
 
 
 # --- StrategyManager.get_interactive_elements() strategy screening ---


### PR DESCRIPTION
Closes #507

## The bug

`StrategyManager._alloc_time_for_strategy` (`optics_framework/common/strategies.py`) divides the caller's total timeout across the applicable assertion strategies:

```python
alloc = int(math.ceil(remaining_total / remaining_strategies))
alloc = min(alloc, int(math.floor(remaining_total)))   # <-- floor() is the bug
if alloc <= 0:
    if idx == len(applicable_strategies) - 1:
        return (0, remaining_total, remaining_strategies)
    return None
```

`math.floor(remaining_total)` is 0 for *any* sub-second remainder, so `alloc` collapses to 0 as soon as the budget drops below one second. Traced with `timeout=1` and 3 applicable strategies, each returning after ~0.4s:

| idx | remaining | old alloc | outcome |
|-----|-----------|-----------|---------|
| 0 | 1.0s | `min(1, floor(1.0)=1)` = **1** | runs normally |
| 1 | 0.6s | `min(1, floor(0.6)=0)` = **0** | not the last strategy → `return None` → loop `break`s, strategies 2 and 3 never run |
| 2 (if reached as last) | 0.2s | **0** | runs with a 0s budget |

A 0s budget is a no-op, not a fast check. `TextDetectionStrategy.assert_elements` does `end_time = time.time() + timeout` and then `while time.time() < end_time:` — with `timeout=0` the loop body never executes, so it returns `(False, None, None)` without ever pulling a frame or running OCR. The result is `assert_presence` / `assert_visibility` reporting "not found" for an element that was on screen, with nothing in the logs to say the strategy was never actually given a chance.

## The fix

```python
alloc = min(math.ceil(remaining_total / remaining_strategies), remaining_total)
return (max(alloc, MIN_STRATEGY_TIMEOUT_S), remaining_total, remaining_strategies)
```

with `MIN_STRATEGY_TIMEOUT_S = 0.5` as a module-level constant.

Two changes, both minimal:

1. **Clamp against `remaining_total` itself, not `floor(remaining_total)`.** This alone removes most of the zeroing — a 0.6s remainder now allocates 0.6s instead of 0s. The `ceil` on the even division is kept as-is so the existing whole-second allocation behaviour (10s / 3 strategies → 4s each) is unchanged.
2. **Floor at 0.5s.** Covers the residual case where the honest remainder is itself below half a second.

Because `alloc` is now always ≥ 0.5, the `if alloc <= 0:` branch (and its special case for the last strategy) is dead and was removed. The `remaining_total <= 0` guard at the top is untouched, so an exhausted deadline still stops the loop.

### Why floor rather than raise

The issue offered "raise a clear configuration error" as an alternative. `timeout` reaches here from user-authored CSV/YAML (`Assert Presence  ${el}  1`) and from `Verifier`'s internal polling callers, so raising would turn working-if-lucky suites into hard failures on upgrade. A floor is strictly more forgiving and needs no caller changes.

### Why 0.5s, and the deadline overshoot

0.5s is the smallest value that still lets a vision strategy do one real pass, and it is small enough that the overshoot it can cause is negligible.

The overshoot is bounded at roughly 0.5s, not `0.5 × n_strategies`: the loop re-reads the clock each iteration, so the first strategy that actually consumes a floored slice pushes past the deadline, and the next iteration's `remaining_total <= 0` check breaks out. Strategies that return faster than their slice cost nothing extra. A tight-timeout assertion finishing ~0.5s late is a far better outcome than one that silently checks nothing, so I took the trade rather than building a proportional/redistribution scheme the surrounding code doesn't justify.

## Testing

`tests/units/common/test_strategies.py::TestAllocTimeForStrategy`:

- **`test_tight_timeout_never_allocates_zero_to_any_strategy`** (new) — the issue's exact scenario: `timeout=1` across 3 strategies, clock advanced 0.4s per strategy. Asserts all three iterations return a non-`None` allocation ≥ `MIN_STRATEGY_TIMEOUT_S`. Fails on `main` (idx 1 returns `None`).
- **`test_alloc_never_exceeds_remaining_time_above_the_floor`** (new) — guards the other direction: with 2.5s left and one strategy remaining, `alloc == remaining == 2.5`, i.e. the `ceil` can't hand out more time than actually exists.
- **`test_sub_second_remainder_is_floored_not_zeroed`** — the existing `test_last_strategy_gets_remainder_even_if_sub_second`, renamed and updated from `== 0` to `== MIN_STRATEGY_TIMEOUT_S`. That assertion encoded the bug, so changing it is the point of the PR.
- `test_even_division_rounds_up` and `test_no_time_left_returns_none` are unchanged and still pass — the whole-second and exhausted-deadline paths are untouched.

Full suite green (`poetry run pytest`, exit 0, only the two pre-existing `#385` XFAILs). `pre-commit` clean on both changed files.

## Overlap with #506

`#506` (open) also touches `common/strategies.py`, adding `raise_if_session_dead(e)` calls into the broad `except` blocks — including `_try_assert_with_strategy` and `_assert`'s exception handler, both of which sit within ~40 lines of this change. It does **not** touch `_alloc_time_for_strategy`, so the two fixes are independent; if both land, expect at most a trivial context conflict in `_assert` / `_try_assert_with_strategy`, no semantic overlap.

One interaction worth noting for whichever merges second: this PR widens the set of strategies that actually get run under a tight timeout, so #506's dead-session detection will now fire from strategies that previously exited early with a 0s budget. That's the desired direction — a dead session surfaces as `E0106` sooner rather than being masked by a skipped strategy.

## Blast radius

`_alloc_time_for_strategy` has exactly one caller, `StrategyManager._assert` (backing both `assert_presence` and `assert_visibility`); `_try_assert_with_strategy` likewise. `alloc` is now a `float` rather than an `int`, so the return annotation moved to `Tuple[float, float, int]` and `_try_assert_with_strategy`'s `timeout` param to `float`. Every downstream consumer already treats the value as a duration (`time.time() + timeout`, `time.time() - start < timeout`, `capture_screenshot_stream(timeout=...)`) — checked across all `assert_elements` implementations in `engines/elementsources/`; none index, `range()`, or otherwise require an int. The public `assert_presence(timeout: int = 30)` signature is unchanged.
