### PR TITLE
fix: separate sequential wizard prompts with a blank line

### DIFF
--- a/optics_framework/helper/initialize.py
+++ b/optics_framework/helper/initialize.py
@@ -5,7 +5,7 @@ import subprocess # nosec
 import pathlib
 import sys
 
-from optics_framework.helper.onboarding import print_next_steps
+from optics_framework.helper.onboarding import blank_line, print_next_steps
 
 
 # Files/directories that must never be copied out of a sample template.
@@ -65,7 +65,8 @@ def _pick_template() -> str | None:
     Returns the chosen ``folderName`` (or ``""`` for Blank) on a clean pick,
     or ``None`` if the user backs out. Only called when stdin is a TTY."""
     choices = _template_choices()
-    print("\nChoose a starting template:")
+    blank_line()
+    print("Choose a starting template:")
     for idx, (display, _) in enumerate(choices, start=1):
         print(f"  {idx}. {display}")
     while True:
@@ -75,10 +76,12 @@ def _pick_template() -> str | None:
         try:
             idx = int(raw)
         except ValueError:
+            blank_line()
             print("Please enter a number.")
             continue
         if 1 <= idx <= len(choices):
             return choices[idx - 1][1]
+        blank_line()
         print(f"Enter a number between 1 and {len(choices)}.")
 
 

--- a/optics_framework/helper/onboarding.py
+++ b/optics_framework/helper/onboarding.py
@@ -69,6 +69,16 @@ def mark_onboarded() -> None:
         pass
 
 
+def blank_line() -> None:
+    """Separate the next prompt from the previous answer in the scrollback.
+
+    The wizards ask questions back to back and rich renders each one flush
+    against the last typed line. Call this at the start of every prompt —
+    before the question's preamble, when it has one, so the whole block
+    stays together."""
+    _console.print()
+
+
 def welcome(first_run: bool = False) -> None:
     """Print the welcome banner shown by ``optics quickstart``.
 

--- a/optics_framework/helper/project_config.py
+++ b/optics_framework/helper/project_config.py
@@ -19,6 +19,8 @@ import os
 
 from rich.prompt import Confirm, Prompt
 
+from optics_framework.helper.onboarding import blank_line
+
 # Every platform maps to exactly ONE action driver; that driver owns the
 # matching ``<driver>_*`` elements sources.
 _DRIVER_BY_PLATFORM = {
@@ -53,6 +55,16 @@ def _enabled(enabled: bool) -> str:
     return "true" if enabled else "false"
 
 
+def _ask(question: str, **kwargs) -> str:
+    blank_line()
+    return Prompt.ask(question, **kwargs)
+
+
+def _confirm(question: str, **kwargs) -> bool:
+    blank_line()
+    return Confirm.ask(question, **kwargs)
+
+
 def prompt_project_config(domain: str | None = None) -> dict:
     """Ask the beginner about their target, one platform at a time.
 
@@ -69,50 +81,50 @@ def prompt_project_config(domain: str | None = None) -> dict:
         choices, default = ["web-playwright", "web-selenium"], "web-playwright"
     else:
         choices, default = list(_DRIVER_BY_PLATFORM), "android"
-    platform = Prompt.ask(
+    platform = _ask(
         "What are you automating?",
         choices=choices,
         default=default,
     )
     answers: dict = {"platform": platform}
     if platform == "android":
-        answers["device_name"] = Prompt.ask(
+        answers["device_name"] = _ask(
             "Device or emulator name (see `adb devices`)",
             default="emulator-5554")
-        answers["platform_name"] = Prompt.ask(
+        answers["platform_name"] = _ask(
             "Platform name", default="Android")
-        answers["app_package"] = Prompt.ask(
+        answers["app_package"] = _ask(
             "App package id (e.g. com.example.app)", default="com.example.app")
-        answers["app_activity"] = Prompt.ask(
+        answers["app_activity"] = _ask(
             "App main activity (e.g. com.example.app.MainActivity)",
             default="com.example.app.MainActivity")
-        answers["appium_url"] = Prompt.ask(
+        answers["appium_url"] = _ask(
             "Appium server URL", default="http://127.0.0.1:4723")
     elif platform == "ios":
         # iOS launches apps by bundle identifier — appPackage/appActivity are
         # Android-only capabilities and would be ignored (or rejected) by
         # XCUITest.
-        answers["device_name"] = Prompt.ask(
+        answers["device_name"] = _ask(
             "Device or simulator name", default="iPhone 15")
-        answers["platform_name"] = Prompt.ask(
+        answers["platform_name"] = _ask(
             "Platform name", default="iOS")
-        answers["bundle_id"] = Prompt.ask(
+        answers["bundle_id"] = _ask(
             "Bundle identifier (e.g. com.example.app)", default="com.example.app")
-        answers["appium_url"] = Prompt.ask(
+        answers["appium_url"] = _ask(
             "Appium server URL", default="http://127.0.0.1:4723")
     elif platform == "web-selenium":
-        answers["selenium_url"] = Prompt.ask(
+        answers["selenium_url"] = _ask(
             "Selenium/WebDriver server URL", default="http://127.0.0.1:4444/wd/hub")
     else:  # web-playwright
-        answers["browser"] = Prompt.ask(
+        answers["browser"] = _ask(
             "Which browser?", choices=["chromium", "firefox", "webkit"],
             default="chromium")
-        answers["headless"] = Confirm.ask(
+        answers["headless"] = _confirm(
             "Run headless (no browser window)?", default=False)
-    answers["ocr"] = Confirm.ask(
+    answers["ocr"] = _confirm(
         "Also find elements by on-screen text (EasyOCR)? Useful when there "
         "are no stable locators.", default=False)
-    answers["log_level"] = Prompt.ask(
+    answers["log_level"] = _ask(
         "Log level", choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO")
     return answers

--- a/optics_framework/helper/quickstart.py
+++ b/optics_framework/helper/quickstart.py
@@ -39,16 +39,20 @@ def run_quickstart() -> None:
     template = _choose_template()
     while template is not None and _TEMPLATE_DOMAINS.get(template, domain) != domain:
         target_domain = _TEMPLATE_DOMAINS[template]
+        onboarding.blank_line()
         if Confirm.ask(
             f"The '{template}' sample targets {target_domain}, but you chose "
             f"{domain}. Use it anyway?", default=False):
             break
         template = _choose_template()
+    onboarding.blank_line()
     name = Prompt.ask(
         "Project name", default=_DEFAULT_NAME).strip() or _DEFAULT_NAME
+    onboarding.blank_line()
     base_path = Prompt.ask("Where should the project live?", default=os.getcwd())
     project_path = os.path.join(base_path, name)
     while os.path.exists(project_path):
+        onboarding.blank_line()
         # Every re-prompt offers a free name as its default, so hitting Enter
         # always advances towards an available path instead of re-submitting
         # the colliding one.
@@ -87,6 +91,7 @@ def _suggest_free_name(base_path: str, name: str) -> str:
 
 
 def _ask_domain() -> str:
+    onboarding.blank_line()
     return Prompt.ask(
         "What do you want to automate?", choices=["mobile", "web"],
         default="mobile")
@@ -105,6 +110,7 @@ def _offer_engine_install(domain: str) -> None:
     if invalid or not requests:  # defensive: the domain is a fixed bundle token
         return
     names = ", ".join(sorted({req.engine.name for req in requests}))
+    onboarding.blank_line()
     if not Confirm.ask(f"Install {names} now?", default=True):
         _console.print(f"No problem — install later with:  "
                        f"optics setup --install {domain}")
@@ -125,6 +131,7 @@ def _choose_template() -> str | None:
     """Offer every packaged sample plus a blank start. Returns None for blank."""
     templates = initialize.available_templates()
     options = ["blank", *templates]
+    onboarding.blank_line()
     _console.print("Pick a starting point:")
     for number, option in enumerate(options, start=1):
         label = ("An empty project (recommended)" if option == "blank"
@@ -149,6 +156,7 @@ def _build_config(project_path: str, template: str | None, domain: str) -> None:
     config and must not lose it to a silent regeneration."""
     config_path = os.path.join(project_path, "config.yaml")
     if template is not None and os.path.isfile(config_path):
+        onboarding.blank_line()
         if not Confirm.ask(
             f"'{template}' ships its own working config.yaml. Overwrite it "
             "with your own answers?", default=False):


### PR DESCRIPTION
Closes #495

## Problem

`optics quickstart`, `optics init` and `optics configure` ask their questions back to back. Rich prints each question flush against the line the user just typed, so a scrollback transcript has no boundary between where one answer ends and the next question begins. The densest run is `project_config.prompt_project_config` — up to seven questions with nothing separating them.

Verified against the current code by driving `optics quickstart` end to end in a real pty (so answers echo the way they do for a user). Before, the config Q&A rendered as an unbroken wall:

```
What are you automating? [android/ios] (android): android
Device or emulator name (see `adb devices`) (emulator-5554): emu-1
Platform name (Android): Android
App package id (e.g. com.example.app) (com.example.app): com.acme.app
```

## Fix

Every prompt emits a blank line first. The rule is stated once, in a new `onboarding.blank_line()`, and applied in two shapes because the prompts have two shapes:

- **`quickstart.py`** calls it explicitly at the head of each prompt. Several of its questions carry a preamble — the "Pick a starting point:" menu, the "already exists. Choose a different name." warning — that has to stay in the same visual block as the question it belongs to, so the separator goes *before* the preamble rather than between the preamble and the question. Six call sites: domain, engine install, template menu, project name, project location, name-collision re-prompt, template-config overwrite.
- **`project_config.py`** asks only bare questions, so `_ask` / `_confirm` wrappers enforce the spacing at all 15 call sites instead of repeating the call. They still delegate through the module-level `Prompt` / `Confirm` names, so existing test patch targets and the recorded question text are unchanged.
- **`initialize.py`** `_pick_template` uses plain `print`/`input`, so its "Choose a starting template:" header and two retry messages each call `onboarding.blank_line()` before the print — the separator belongs before the message, which is the re-prompt's preamble.

`cli.py`'s `input("Project name: ")` is the first prompt of the `optics init` flow with nothing printed before it, so it is left alone; the picker question that follows it picks up its own separator. `config_manager.configure`'s overwrite confirm is likewise its flow's first prompt, and the config Q&A after it goes through `prompt_project_config`, so it inherits the same separators (when no `config.yaml` exists yet, the confirm is skipped and the first blank line simply leads the output).

After:

```
What are you automating? [android/ios] (android): android

Device or emulator name (see `adb devices`) (emulator-5554): emu-1

Platform name (Android): Android

App package id (e.g. com.example.app) (com.example.app): com.acme.app
```

## Testing

No new automated test. This is a terminal-spacing change; a unit test could only assert that `blank_line()` was called, which pins the implementation rather than the visual result the issue is about.

Verified by hand instead:
- `optics quickstart` driven through a pty (answers echoed, real TTY behaviour) — every question in the wizard and in the config Q&A is now preceded by a blank line, and the template menu / collision warning stay attached to their question.
- `initialize._pick_template` driven with bad input to hit both retry branches.
- `poetry run pre-commit run --files <the four changed files>` — clean.
- `pytest tests/units/helpers` — all green, no test changes needed.

## Relationship to #501

#501 (open) rewrites the name-collision retry loop in `quickstart.run_quickstart` — it adds `_DEFAULT_NAME`, a `_suggest_free_name()` helper, and makes the re-prompt offer a free name as its default so pressing Enter always advances. This PR does not change any of that logic: inside that loop it adds a single `onboarding.blank_line()` line at the top of the `while` body, above the "already exists" message. Same file and same loop, so a textual conflict on rebase is possible, but the resolution is to keep both — #501's default-suggestion behaviour and this PR's leading blank line are independent and compose cleanly.
