### PR TITLE
docs(live): set expectations for slow remote-hub actions

### DIFF
--- a/docs/usage/live_usage.md
+++ b/docs/usage/live_usage.md
@@ -70,6 +70,17 @@ sleep 5
 - A failing keyword is shown as `✗` with a short error (and error code) and is **not**
   recorded; the prompt returns ready for the next command. The UI never crashes.
 
+### Expect a wait on remote targets
+
+While a keyword is in flight its history entry reads `⋯ running…` — there is **no
+elapsed-time counter**; the timing appears only once the action resolves to `✓` or `✗`.
+
+Against a **remote** Appium/Selenium hub every keyword is a full network round trip,
+so `/screenshot` and other real-device actions routinely take **10–20 seconds**. A
+long `running…` is the network, not a hang. Input is blocked while an action runs
+(a second Enter answers `Busy — wait for the current action to finish.`), so just let
+the entry resolve. Local emulators and browsers respond far faster.
+
 ## Autocomplete & hints
 
 - **Keyword completion** — start typing the first token and press Tab.


### PR DESCRIPTION
Closes #500 — item 2 of the three papercuts bundled there.

## What this PR is now

**Docs-only.** It carries one section added to `docs/usage/live_usage.md` — *"Expect a wait on remote targets"* — which sets expectations for `live` sessions driving a remote Appium/Selenium hub: no elapsed-time counter while a keyword is in flight (`running…`), 10–20s round trips for real-device actions, and the fact that input is blocked mid-action.

## Why the rest of the original PR was dropped

The original #500 scope had three items. Re-verified against current `main`:

| # | Item | Status |
|---|------|--------|
| 1 | Screenshot filename `prepress_element.jpg` | **Already fixed** — merged via #525 (`fix(action_keyword): use underscore separator in pre-action screenshot name`). The call site now passes `f"pre_{func_name}"`. |
| 2 | No progress indication on slow remote actions | **This PR** — docs-only note (built no spinner/elapsed-time UI, per scope). |
| 3 | Deprecated `optics config` unflagged in `--help` | **Already fixed** — `config` is marked deprecated since c65768d; verified in rendered `optics --help`. |

The earlier code changes in this branch (the call-site fix, its regression test, and a test fixture filename) all landed in main via #525 and were removed from this branch — `pre-commit` and the docs build (`GitBook`) are the only gates that matter for a docs-only change.