### PR TITLE
fix: preserve separators in screenshot filename sanitizer

### DIFF
--- a/optics_framework/common/utils.py
+++ b/optics_framework/common/utils.py
@@ -344,7 +344,7 @@ def save_screenshot(img, name, output_dir, time_stamp=None):
     if output_dir is None:
         internal_logger.info(OUTPUT_PATH_NOT_SET_MSG)
         return
-    name = re.sub(r'[^a-zA-Z0-9\s_]', '', name)
+    name = re.sub(r'[^a-zA-Z0-9\s_]', '_', name)
     if time_stamp is None:
         time_stamp = str(datetime.now().astimezone().strftime('%Y-%m-%dT%H-%M-%S-%f'))
     screenshot_file_path = os.path.join(output_dir, f"{time_stamp}-{name}.jpg")

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -1235,7 +1235,7 @@ class LiveController:
         name = "live_capture"
         timestamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H-%M-%S-%f")
         utils.save_screenshot(image, name, output_dir=output_dir, time_stamp=timestamp)
-        sanitized = re.sub(r"[^a-zA-Z0-9\s_]", "", name)
+        sanitized = re.sub(r"[^a-zA-Z0-9\s_]", "_", name)
         return os.path.join(output_dir, f"{timestamp}-{sanitized}.jpg")
 
     def screenshot_png_bytes(self) -> bytes:


### PR DESCRIPTION
Closes #521

## The bug

`utils.save_screenshot` sanitized the caller-supplied name by **deleting** every character outside its allow-list:

```python
name = re.sub(r'[^a-zA-Z0-9\s_]', '', name)   # before
```

Deletion silently merges names that differ only by a separator. Verified before touching anything:

```
'pre-press_element'  -> 'prepress_element'
'prepress_element'   -> 'prepress_element'   # same file, no warning
```

That is exactly how #500 produced `prepress_element.jpg` from a call site that correctly passed `pre-{func_name}`.

`LiveController.capture_screenshot` (`helper/live.py`) independently runs the same regex, purely to predict the filename `save_screenshot` is about to write so it can return the path to `/screenshot`.

## The fix

Both copies get the identical one-character fix — `''` → `'_'` — so disallowed characters are **replaced**, not deleted:

```python
name = re.sub(r'[^a-zA-Z0-9\s_]', '_', name)   # after
```

| | before | after |
|---|---|---|
| `pre-press_element` | `prepress_element` | `pre_press_element` |

Minimal, 2-file, 2-line diff — no new function, no behavior change beyond fixing the delete-vs-replace bug.

**Known tradeoff, left as-is deliberately**: the regex still lives in two places (`utils.py` and `live.py`). An earlier version of this PR extracted a shared `sanitize_screenshot_name()` helper so the two couldn't drift again; that was reverted in favor of keeping this fix as small as possible. If the pattern changes again in the future, both call sites need updating together — `grep -rn "a-zA-Z0-9\\\\s_" optics_framework/` finds both.

## Call-site audit (re-verified, not taken from the issue)

`grep -rn "save_screenshot(" optics_framework/` — every call site was diffed old-vs-new:

- **Unchanged, byte for byte** (all already underscore-only): `action_keyword.py` `press_keycode`, `execute_script`, `enter_text_keyboard`, `enter_text_using_keyboard`, `{func_name}_with_aoi`; `verifier.py` `capture_screenshot`; `test_runnner.py` `end_of_run`; `remote_oir.py` `detected_template`; `remote_ocr.py` `detected_text`; `pytesseract.py` `annotated_frame`; `easyocr.py`; `live.py` `live_capture`.
- **Changed (intentionally, to the correct value)**: `action_keyword.py:433` `f"pre-{func_name}"` → now writes `pre_press_element.jpg` instead of `prepress_element.jpg`.

**Interaction with #520** (open, `docs/500-cli-polish-papercuts`): that PR routes around this by changing the call site to `f"pre_{func_name}"`. Both orders converge on the same filename `pre_press_element.jpg`, and this PR does not touch `action_keyword.py`, so there is no conflict and no merge-order dependency either way.

No test in `tests/` pinned the old deletion behaviour. (`test_live_driver_agnostic.py:333` writes a literal `pre-press_element.jpg` straight to disk as a teardown fixture — it never goes through the sanitizer.)

## Judgment call: consecutive disallowed characters are NOT collapsed

`a..b` becomes `a__b`, not `a_b`. Deliberate:

- Collapsing reintroduces the exact bug class being fixed — it makes the mapping non-injective again (`a..b` and `a_b` would collide).
- A 1:1 character mapping means two distinct inputs of equal length can never produce the same output.
- It matches existing repo precedent: `expose_api.py:673` already does `re.sub(r"[^a-zA-Z0-9_.-]", "_", name)` without collapsing.

## Tests

No automated test added — verified manually instead:

```pycon
>>> import re
>>> s = lambda n: re.sub(r'[^a-zA-Z0-9\s_]', '_', n)
>>> s("pre-press_element"), s("prepress_element")
('pre_press_element', 'prepress_element')
```

The two names the issue was filed over no longer collide.

**Full suite**: `pytest` → 1062 passed, 2 xfailed, 1 failed. The 1 failure is
`TestExtractionCost::test_cost_growth_is_linear_not_quadratic`, a known load-sensitive flake that fails only
under parallel load and passes when run alone (verified) — unrelated to this change (no timing code touched).

`pre-commit run --files <changed>`: ruff, bandit, trailing-whitespace, end-of-file-fixer, gitleaks all pass.
