### PR TITLE
perf+feat(live): batch Playwright bounds, give the NL agent a compact element list

### DIFF
--- a/optics_framework/common/nl_agent.py
+++ b/optics_framework/common/nl_agent.py
@@ -121,6 +121,9 @@ StepCallback = Callable[[AgentStep], None]
 AbortCallback = Callable[[], bool]
 # Returns a condensed UI hierarchy (stripped page source) or None when unavailable.
 PagesourceProvider = Callable[[], Optional[str]]
+# Takes the step's screenshot PNG bytes (reused for bounds scaling, no extra capture) and
+# returns get_interactive_elements()-shaped dicts, or None when unsupported/unavailable.
+ScreenElementsProvider = Callable[[bytes], Optional[List[dict]]]
 
 
 # Structured-output schema. Only thought/action/reason are required so the model is never
@@ -159,9 +162,9 @@ ACTION_SCHEMA: Dict[str, Any] = {
 
 SYSTEM_PROMPT = """\
 You drive a UI test-automation framework ONE keyword at a time to fulfil a natural-language \
-instruction. Each turn you are shown a screenshot of the current device screen, a condensed \
-UI hierarchy of the on-screen elements (when available), and the list of available keywords; \
-you must reply with exactly ONE next action as JSON.
+instruction. Each turn you are shown a screenshot of the current device screen, a list of \
+on-screen elements (when available), and the list of available keywords; you must reply with \
+exactly ONE next action as JSON.
 
 CRITICAL — VERIFY, DON'T FLAIL:
 - A `PASS` observation means the keyword EXECUTED, NOT that your goal was achieved. ALWAYS \
@@ -193,20 +196,20 @@ TARGETING POLICY (in strict order of preference):
 2. On-screen control -> name it by its VISIBLE TEXT as the `element` parameter \
 (e.g. press_element with params ["Search"]). The framework self-heals element location across \
 XPath -> on-screen text -> OCR -> image, so a plain text label usually resolves. Use the \
-condensed hierarchy for the EXACT text / content-desc / resource id.
+on-screen elements list below for the EXACT text / content-desc / resource id.
 3. Ambiguous text -> prefix the label with `text_only:` to force OCR matching \
 (e.g. "text_only:Search").
 4. Target not visible -> scroll/swipe to reveal it, THEN target it by text.
 5. LAST RESORT only — an icon with no readable text AND no keycode -> read its bounds \
-[x1,y1][x2,y2] from the hierarchy to compute a precise center and use `press_by_percentage` \
+[x1,y1][x2,y2] from the elements list to compute a precise center and use `press_by_percentage` \
 with params [percent_x, percent_y] (each 0-100). You may attempt coordinates at most TWICE \
 for a given target; if that does not work, STOP and use `action: "fail"`.
 
-USING THE UI HIERARCHY:
-- When the condensed hierarchy is provided, use it together with the screenshot: it gives the \
-exact on-screen text, content-desc, resource ids, element bounds [x1,y1][x2,y2], and flags \
-(clickable/scrollable/selected/editable). A target present in the hierarchy should be named by \
-its text — not tapped by coordinate.
+USING THE ON-SCREEN ELEMENTS LIST:
+- When the elements list is provided, use it together with the screenshot: it gives exact \
+on-screen text and element bounds [x1,y1][x2,y2], plus — when available — interactivity flags \
+(clickable/scrollable/editable/...) or additional identifiers (content-desc/resource id). A \
+target present in the list should be named by its text — not tapped by coordinate.
 
 RULES:
 - Emit exactly one action per turn.
@@ -221,6 +224,79 @@ coordinate guessing has already failed).
 
 _MAX_THOUGHT_CHARS = 160
 
+# Interactivity flags worth surfacing from an element's `extra` metadata (Appium's
+# UIAutomator2/XCUITest attribute names; truthy string values only -- see
+# appium_UI_helper._build_extra_metadata, which keeps "enabled" even when false).
+_ELEMENT_FLAG_KEYS = (
+    "clickable", "long-clickable", "scrollable", "checkable", "checked", "selected", "focused",
+)
+# Class/tag suffixes that mean "editable" without an explicit flag attribute (mirrors
+# utils._is_interesting's own editable-field heuristic).
+_EDITABLE_CLASS_SUFFIXES = ("EditText", "TextField", "SecureTextField")
+_EDITABLE_WEB_TAGS = ("input", "textarea", "select")
+
+_SCREEN_ELEMENTS_MAX_CHARS = 12000
+
+
+def _flag_true(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return isinstance(value, str) and value.lower() == "true"
+
+
+def _element_flags(extra: Dict[str, Any]) -> List[str]:
+    """Interactivity flags worth showing the model for one element's ``extra`` metadata."""
+    flags = [key for key in _ELEMENT_FLAG_KEYS if _flag_true(extra.get(key))]
+    cls = str(extra.get("class") or "")
+    tag = str(extra.get("tag") or "").lower()
+    if cls.endswith(_EDITABLE_CLASS_SUFFIXES) or tag in _EDITABLE_WEB_TAGS:
+        flags.append("editable")
+    if extra.get("href"):
+        flags.append("link")
+    return flags
+
+
+def _render_screen_element(index: int, element: Dict[str, Any]) -> Optional[str]:
+    """One compact line for a single ``get_interactive_elements()`` dict, or ``None``
+    when the entry is too malformed to render (missing/non-dict, unusable bounds)."""
+    if not isinstance(element, dict):
+        return None
+    bounds = element.get("bounds")
+    try:
+        bounds_str = f"[{bounds['x1']},{bounds['y1']}][{bounds['x2']},{bounds['y2']}]"
+    except (KeyError, TypeError):
+        return None
+    text = str(element.get("text") or "").strip().replace("\n", " ")
+    if len(text) > 80:
+        text = text[:77] + "..."
+    flags = _element_flags(element.get("extra") or {})
+    flag_str = f" {{{','.join(flags)}}}" if flags else ""
+    return f"  {index}. \"{text}\" {bounds_str}{flag_str}"
+
+
+def _render_screen_elements(
+    elements: List[Dict[str, Any]], max_chars: int = _SCREEN_ELEMENTS_MAX_CHARS
+) -> str:
+    """Compact, numbered rendering of ``get_interactive_elements()``-shaped dicts.
+
+    Replaces the raw condensed page-source dump for sessions with a structured element
+    source. Truncates to ``max_chars`` the same way ``utils.strip_page_source`` bounds
+    prompt size.
+    """
+    if not elements:
+        return "(no interactive elements detected)"
+    lines = [
+        rendered
+        for i, el in enumerate(elements, 1)
+        if (rendered := _render_screen_element(i, el)) is not None
+    ]
+    if not lines:
+        return "(no interactive elements detected)"
+    out = "\n".join(lines)
+    if len(out) > max_chars:
+        out = out[:max_chars] + "\n  … (truncated)"
+    return out
+
 
 class NaturalLanguageAgent:
     """Bounded ReAct loop translating an instruction into keyword executions."""
@@ -234,6 +310,7 @@ class NaturalLanguageAgent:
         *,
         element_names: Optional[Callable[[], List[str]]] = None,
         pagesource_provider: Optional[PagesourceProvider] = None,
+        screen_elements_provider: Optional[ScreenElementsProvider] = None,
         max_steps: int = 15,
         max_consecutive_failures: int = 3,
         max_blind_repeats: int = 3,
@@ -246,6 +323,7 @@ class NaturalLanguageAgent:
         self.keyword_catalog = keyword_catalog
         self.element_names = element_names
         self.pagesource_provider = pagesource_provider
+        self.screen_elements_provider = screen_elements_provider
         self.max_steps = max_steps
         self.max_consecutive_failures = max_consecutive_failures
         self.max_blind_repeats = max_blind_repeats
@@ -289,8 +367,11 @@ class NaturalLanguageAgent:
         except Exception as exc:  # noqa: BLE001 - screenshot failures end the run cleanly
             return AgentResult("failed", state.history, f"Screenshot failed: {exc}", state.successful)
 
-        page_source = self._capture_page_source()
-        prompt = self._build_prompt(instruction, catalog, state.history, page_source)
+        # Reuses `png` for bounds scaling instead of a second device capture; falls back to
+        # the raw hierarchy only when structured elements aren't usable this call.
+        screen_elements = self._capture_screen_elements(png)
+        page_source = None if screen_elements is not None else self._capture_page_source()
+        prompt = self._build_prompt(instruction, catalog, state.history, page_source, screen_elements)
         try:
             raw = self.llm.generate_json(
                 prompt, ACTION_SCHEMA, images=[png], system=SYSTEM_PROMPT, temperature=0.0
@@ -436,12 +517,27 @@ class NaturalLanguageAgent:
             internal_logger.debug("NL agent: page source unavailable: %s", exc)
             return None
 
+    def _capture_screen_elements(self, png: bytes) -> Optional[List[dict]]:
+        """Best-effort structured elements; ``None`` when unavailable/unsupported.
+
+        Distinct from "usable but empty" (``[]``, a screen with genuinely no interactive
+        elements) — only ``None`` triggers the raw-page-source fallback in ``_run_one_step``.
+        """
+        if self.screen_elements_provider is None:
+            return None
+        try:
+            return self.screen_elements_provider(png)
+        except Exception as exc:  # noqa: BLE001
+            internal_logger.debug("NL agent: structured screen elements unavailable: %s", exc)
+            return None
+
     def _build_prompt(
         self,
         instruction: str,
         catalog: List[KeywordSpec],
         history: List[AgentStep],
         page_source: Optional[str] = None,
+        screen_elements: Optional[List[dict]] = None,
     ) -> str:
         lines = [f"INSTRUCTION: {instruction}", "", "AVAILABLE KEYWORDS (name and parameters):"]
         lines.extend(f"  {spec.signature}" for spec in catalog)
@@ -453,7 +549,14 @@ class NaturalLanguageAgent:
                 lines.append("NAMED ELEMENTS (reference as ${name}):")
                 lines.append("  " + ", ".join("${" + n + "}" for n in names))
 
-        if page_source:
+        if screen_elements is not None:
+            lines.append("")
+            lines.append(
+                "CURRENT SCREEN ELEMENTS (numbered; text, bounds [x1,y1][x2,y2], and "
+                "interactivity flags where available):"
+            )
+            lines.append(_render_screen_elements(screen_elements))
+        elif page_source:
             lines.append("")
             lines.append(
                 "CURRENT SCREEN ELEMENTS (condensed UI hierarchy — class, text, "

--- a/optics_framework/engines/elementsources/playwright_page_source.py
+++ b/optics_framework/engines/elementsources/playwright_page_source.py
@@ -137,10 +137,14 @@ class PlaywrightPageSource(ElementSourceInterface):
 
         page = self._require_page()
         elements = self.tree.xpath(".//*")
+        # One page.evaluate() call resolves bounds for every candidate node, instead of a
+        # Playwright locator round-trip per node (count() + bounding_box() each).
+        node_xpaths = [self._build_simple_xpath(node) for node in elements]
+        rects = self._resolve_bounds_batch(page, node_xpaths)
         results = []
 
-        for node in elements:
-            bounds = self._extract_bounds(node, page)
+        for node, rect in zip(elements, rects):
+            bounds = self._rect_to_bounds(rect)
             if not bounds:
                 continue
 
@@ -166,48 +170,64 @@ class PlaywrightPageSource(ElementSourceInterface):
     # Helper methods for get_interactive_elements
     # ---------------------------------------------------------
 
-    def _extract_bounds(self, node: etree.Element, page: Any) -> Optional[Dict[str, int]]:
-        """
-        Extract bounding box coordinates for a web element using Playwright.
+    # In-browser: resolves each xpath via document.evaluate and reports its
+    # getBoundingClientRect(), or null when unmatched / not laid out. The visibility
+    # check approximates Playwright's own "not visible" -> null bounding_box() contract,
+    # since that internal algorithm isn't reachable from plain page.evaluate() JS.
+    _BOUNDS_BATCH_SCRIPT = """
+    (xpaths) => xpaths.map((xp) => {
+        if (!xp) return null;
+        try {
+            const result = document.evaluate(
+                xp, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
+            );
+            const el = result.singleNodeValue;
+            if (!el) return null;
+            const rect = el.getBoundingClientRect();
+            if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+            const style = window.getComputedStyle(el);
+            if (style.visibility === 'hidden' || style.display === 'none') return null;
+            return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        } catch (e) {
+            return null;
+        }
+    });
+    """
 
-        Args:
-            node: The lxml element node
-            page: Playwright page object
-
-        Returns:
-            Dict with x1, y1, x2, y2 or None if cannot get bounds
-        """
+    def _resolve_bounds_batch(
+        self, page: Any, xpaths: List[Optional[str]]
+    ) -> List[Optional[Dict[str, float]]]:
+        """Resolve bounding rects for every candidate xpath in one round trip."""
+        if not xpaths:
+            return []
         try:
-            # Build a selector from the element
-            xpath = self._build_simple_xpath(node)
-            if not xpath:
-                return None
-
-            # Try to locate the element using XPath
-            locator = page.locator(f"xpath={xpath}")
-            count = run_async(locator.count())
-
-            if count == 0:
-                return None
-
-            # Get bounding box from the first matching element
-            bbox = run_async(locator.first.bounding_box())
-
-            if bbox is None:
-                return None
-
-            x1 = int(bbox["x"])
-            y1 = int(bbox["y"])
-            x2 = int(bbox["x"] + bbox["width"])
-            y2 = int(bbox["y"] + bbox["height"])
-
-            return {"x1": x1, "y1": y1, "x2": x2, "y2": y2}
-
+            rects = run_async(page.evaluate(self._BOUNDS_BATCH_SCRIPT, xpaths))
+            if rects is None or len(rects) != len(xpaths):
+                return [None] * len(xpaths)
+            return rects
         except Exception as e:
+            # The batch call itself failed (e.g. page mid-navigation). Falling back to one
+            # evaluate() per node here would reintroduce the exact per-node round-trip cost
+            # this batching exists to avoid, so degrade to "no bounds this pass" instead,
+            # same as a single node failing used to.
             internal_logger.debug(
-                f"[PlaywrightPageSource] Could not extract bounds for element: {e}"
+                f"[PlaywrightPageSource] Batched bounds lookup failed: {e}"
             )
+            return [None] * len(xpaths)
+
+    @staticmethod
+    def _rect_to_bounds(rect: Optional[Dict[str, float]]) -> Optional[Dict[str, int]]:
+        """Convert a ``{x,y,width,height}`` rect (or ``None``) into ``{x1,y1,x2,y2}``."""
+        if not rect:
             return None
+        try:
+            x1 = int(rect["x"])
+            y1 = int(rect["y"])
+            x2 = int(rect["x"] + rect["width"])
+            y2 = int(rect["y"] + rect["height"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        return {"x1": x1, "y1": y1, "x2": x2, "y2": y2}
 
     def _escape_xpath_value(self, val: str) -> str:
         """

--- a/optics_framework/helper/live.py
+++ b/optics_framework/helper/live.py
@@ -28,6 +28,8 @@ from datetime import datetime
 from itertools import product
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
+import cv2
+import numpy as np
 import yaml
 
 from optics_framework.common import utils
@@ -1286,6 +1288,34 @@ class LiveController:
         xml_source = result[0]
         return utils.strip_page_source(xml_source) or None
 
+    def screen_elements(self, png: bytes) -> Optional[List[dict]]:
+        """Structured interactive elements for the current screen (bounds-guaranteed).
+
+        Best-effort: returns ``None`` when the active element source doesn't implement
+        structured extraction (``StrategyManager.get_interactive_elements`` raises E0202),
+        so the NL agent falls back to the raw page-source text path (``page_source``).
+        Bounds are scaled using ``png`` -- the screenshot already captured for the LLM this
+        step, decoded locally -- rather than a second device screenshot; only decoded for
+        Appium sources, since the scaling is a no-op everywhere else.
+        """
+        if self._action_keyword is None:  # pragma: no cover - defensive
+            return None
+        try:
+            elements = self._action_keyword.strategy_manager.get_interactive_elements(None)
+        except OpticsError as exc:
+            internal_logger.debug("Structured screen elements unavailable: %s", exc)
+            return None
+        element_source = self._action_keyword.element_source
+        active_source = getattr(element_source, "active_instance", None) or element_source
+        screenshot_np = None
+        if getattr(active_source, "REQUIRED_DRIVER_TYPE", None) == "appium":
+            try:
+                screenshot_np = cv2.imdecode(np.frombuffer(png, dtype=np.uint8), cv2.IMREAD_COLOR)
+            except Exception as exc:  # noqa: BLE001
+                internal_logger.debug("Screenshot decode for bounds scaling failed: %s", exc)
+        utils.scale_interactive_element_bounds(elements, element_source, screenshot_np)
+        return elements
+
     def _nl_execute(self, raw: str) -> ExecResult:
         """Agent executor: run one keyword WITHOUT recording, mapped to an ExecResult."""
         result = self._execute_line(raw, record=False)
@@ -1313,6 +1343,7 @@ class LiveController:
             keyword_catalog=self._nl_catalog,
             element_names=self.element_names,
             pagesource_provider=self.page_source,
+            screen_elements_provider=self.screen_elements,
             curate_on_done=True,
         )
         return self._nl_agent

--- a/tests/units/common/test_llm_wiring.py
+++ b/tests/units/common/test_llm_wiring.py
@@ -6,7 +6,10 @@ returning no LLM when none is enabled, and the commit-on-done recording semantic
 NLStep adapter.
 """
 import types
+from unittest.mock import MagicMock
 
+import cv2
+import numpy as np
 import pytest
 
 from optics_framework.common.config_handler import Config, DependencyConfig
@@ -16,6 +19,7 @@ from optics_framework.helper.live import LiveController, NLStep
 from optics_framework.helper.live import NLRunStatus
 from optics_framework.common.optics_builder import OpticsBuilder
 from optics_framework.common.error import OpticsError, Code
+from optics_framework.common import utils
 
 pytestmark = pytest.mark.white_box
 
@@ -59,13 +63,22 @@ def _bare_controller():
 
 
 class _FakeStrategyManager:
-    def __init__(self, result):
+    def __init__(self, result=None, elements_result=None):
         self._result = result
+        self._elements_result = elements_result
+        # screen_elements() decodes the PNG bytes it's given instead of capturing a second
+        # screenshot -- kept as a spy so tests can assert it's never called.
+        self.capture_screenshot = MagicMock(name="capture_screenshot")
 
     def capture_pagesource(self):
         if isinstance(self._result, Exception):
             raise self._result
         return self._result
+
+    def get_interactive_elements(self, filter_config=None):
+        if isinstance(self._elements_result, Exception):
+            raise self._elements_result
+        return self._elements_result
 
 
 def _ps_controller(strategy_result):
@@ -74,6 +87,21 @@ def _ps_controller(strategy_result):
         strategy_manager=_FakeStrategyManager(strategy_result)
     )
     return ctrl
+
+
+def _elements_controller(elements_result, driver_type="appium"):
+    ctrl = LiveController.__new__(LiveController)
+    ctrl._action_keyword = types.SimpleNamespace(
+        strategy_manager=_FakeStrategyManager(elements_result=elements_result),
+        element_source=types.SimpleNamespace(REQUIRED_DRIVER_TYPE=driver_type),
+    )
+    return ctrl
+
+
+def _png_bytes(width=4, height=4):
+    ok, buf = cv2.imencode(".png", np.zeros((height, width, 3), dtype=np.uint8))
+    assert ok
+    return buf.tobytes()
 
 
 _PS_XML = (
@@ -99,6 +127,62 @@ class TestControllerPageSource:
         ctrl = LiveController.__new__(LiveController)
         ctrl._action_keyword = None
         assert ctrl.page_source() is None
+
+
+class TestControllerScreenElements:
+    def test_returns_elements_and_scales_bounds_for_appium(self, monkeypatch):
+        elements = [{"text": "Search", "bounds": {"x1": 0, "y1": 0, "x2": 10, "y2": 10}}]
+        ctrl = _elements_controller(elements, driver_type="appium")
+
+        calls = []
+        monkeypatch.setattr(
+            utils, "scale_interactive_element_bounds",
+            lambda els, src, ss: calls.append((els, src, ss)),
+        )
+
+        out = ctrl.screen_elements(_png_bytes())
+
+        assert out == elements
+        assert len(calls) == 1
+        assert calls[0][0] == elements
+        assert isinstance(calls[0][2], np.ndarray)  # decoded from the passed PNG bytes
+        # No second device screenshot -- bounds come from decoding what was already
+        # captured for the LLM, not a fresh capture_screenshot() round trip.
+        ctrl._action_keyword.strategy_manager.capture_screenshot.assert_not_called()
+
+    def test_skips_decode_for_non_appium_source(self, monkeypatch):
+        elements = [{"text": "Row", "bounds": {"x1": 0, "y1": 0, "x2": 5, "y2": 5}}]
+        ctrl = _elements_controller(elements, driver_type="playwright")
+
+        calls = []
+        monkeypatch.setattr(
+            utils, "scale_interactive_element_bounds",
+            lambda els, src, ss: calls.append(ss),
+        )
+
+        out = ctrl.screen_elements(_png_bytes())
+
+        assert out == elements
+        assert calls == [None]  # scale called, but with no frame to scale against
+        ctrl._action_keyword.strategy_manager.capture_screenshot.assert_not_called()
+
+    def test_returns_none_when_get_interactive_elements_unavailable(self):
+        ctrl = _elements_controller(OpticsError(Code.E0202, message="No interactive elements"))
+        assert ctrl.screen_elements(_png_bytes()) is None
+
+    def test_returns_none_when_no_action_keyword(self):
+        ctrl = LiveController.__new__(LiveController)
+        ctrl._action_keyword = None
+        assert ctrl.screen_elements(_png_bytes()) is None
+
+    def test_undecodable_png_bytes_still_returns_elements(self, monkeypatch):
+        # Bounds scaling is best-effort: bytes that fail to decode into a frame must not
+        # sink the structured elements the NL agent otherwise has available this step.
+        elements = [{"text": "Search", "bounds": {"x1": 0, "y1": 0, "x2": 10, "y2": 10}}]
+        ctrl = _elements_controller(elements, driver_type="appium")
+        monkeypatch.setattr(utils, "scale_interactive_element_bounds", lambda *a, **k: None)
+
+        assert ctrl.screen_elements(b"not a real png") == elements
 
 
 class FakeAgent:

--- a/tests/units/common/test_nl_agent.py
+++ b/tests/units/common/test_nl_agent.py
@@ -17,6 +17,7 @@ from optics_framework.common.nl_agent import (
     ACTION_SCHEMA,
     CURATION_SCHEMA,
     SYSTEM_PROMPT,
+    _render_screen_elements,
 )
 from optics_framework.common.error import OpticsError, Code
 
@@ -325,7 +326,7 @@ class TestPageSourceInPrompt:
         agent.run("click search")
         assert "CURRENT SCREEN ELEMENTS" in llm.prompt
         assert "search_edit_text" in llm.prompt
-        assert "condensed UI hierarchy" in llm.system
+        assert "on-screen elements" in llm.system
 
     def test_no_provider_means_no_section(self):
         llm = _CapturingLLM()
@@ -343,6 +344,122 @@ class TestPageSourceInPrompt:
         result = agent.run("go")
         assert result.status == "done"  # run still completes
         assert "CURRENT SCREEN ELEMENTS" not in llm.prompt
+
+
+class TestScreenElementsInPrompt:
+    """Precedence between the structured (get_interactive_elements) and raw
+    (strip_page_source) providers: structured wins whenever it's usable; the raw text
+    path is the fallback for sessions/calls where it isn't -- never both at once."""
+
+    def _elements(self, png):
+        self.received_png = png
+        return [
+            {"text": "Search", "bounds": {"x1": 10, "y1": 20, "x2": 110, "y2": 60},
+             "xpath": "//button[1]", "extra": {"clickable": "true"}},
+        ]
+
+    def test_structured_elements_preferred_over_page_source(self):
+        llm = _CapturingLLM()
+        agent = NaturalLanguageAgent(
+            llm, _shots, _ok_executor([]), _catalog,
+            pagesource_provider=lambda: "RAW HIERARCHY TEXT",
+            screen_elements_provider=self._elements,
+        )
+        agent.run("tap search")
+        assert "Search" in llm.prompt
+        assert "[10,20][110,60]" in llm.prompt
+        assert "clickable" in llm.prompt
+        assert "RAW HIERARCHY TEXT" not in llm.prompt
+        # The already-captured screenshot is threaded through, not re-captured.
+        assert self.received_png == _shots()
+
+    def test_falls_back_to_page_source_when_structured_unavailable(self):
+        llm = _CapturingLLM()
+        agent = NaturalLanguageAgent(
+            llm, _shots, _ok_executor([]), _catalog,
+            pagesource_provider=lambda: "RAW HIERARCHY TEXT",
+            screen_elements_provider=lambda png: None,
+        )
+        agent.run("go")
+        assert "RAW HIERARCHY TEXT" in llm.prompt
+
+    def test_no_screen_elements_provider_falls_back_to_page_source(self):
+        llm = _CapturingLLM()
+        agent = NaturalLanguageAgent(
+            llm, _shots, _ok_executor([]), _catalog,
+            pagesource_provider=lambda: "RAW HIERARCHY TEXT",
+        )
+        agent.run("go")
+        assert "RAW HIERARCHY TEXT" in llm.prompt
+
+    def test_screen_elements_provider_raising_falls_back(self):
+        def boom(png):
+            raise RuntimeError("no structured source configured")
+
+        llm = _CapturingLLM()
+        agent = NaturalLanguageAgent(
+            llm, _shots, _ok_executor([]), _catalog,
+            pagesource_provider=lambda: "RAW HIERARCHY TEXT",
+            screen_elements_provider=boom,
+        )
+        result = agent.run("go")
+        assert result.status == "done"  # run still completes
+        assert "RAW HIERARCHY TEXT" in llm.prompt
+
+    def test_empty_structured_list_is_rendered_not_treated_as_unavailable(self):
+        # [] means "the provider works, the screen just has nothing" -- distinct from
+        # None ("provider unusable"), so it must NOT trigger the page_source fallback.
+        llm = _CapturingLLM()
+        agent = NaturalLanguageAgent(
+            llm, _shots, _ok_executor([]), _catalog,
+            pagesource_provider=lambda: "RAW HIERARCHY TEXT",
+            screen_elements_provider=lambda png: [],
+        )
+        agent.run("go")
+        assert "RAW HIERARCHY TEXT" not in llm.prompt
+        assert "no interactive elements" in llm.prompt.lower()
+
+
+class TestRenderScreenElements:
+    def test_renders_text_bounds_and_flags(self):
+        elements = [
+            {"text": "Search", "bounds": {"x1": 10, "y1": 20, "x2": 110, "y2": 60},
+             "xpath": "//button[1]", "extra": {"clickable": "true", "class": "android.widget.Button"}},
+            {"text": "Username", "bounds": {"x1": 5, "y1": 100, "x2": 200, "y2": 140},
+             "xpath": "//android.widget.EditText[1]",
+             "extra": {"class": "android.widget.EditText"}},
+        ]
+        out = _render_screen_elements(elements)
+        assert "1." in out and "Search" in out and "[10,20][110,60]" in out
+        assert "clickable" in out
+        assert "2." in out and "Username" in out
+        assert "editable" in out  # EditText class inferred as editable, no explicit flag
+
+    def test_empty_list_renders_placeholder(self):
+        assert "no interactive elements" in _render_screen_elements([]).lower()
+
+    def test_ignores_malformed_entries_without_raising(self):
+        out = _render_screen_elements([{"not": "a valid element"}, None, "garbage"])
+        assert "no interactive elements" in out.lower()
+
+    def test_truncates_to_max_chars(self):
+        elements = [
+            {"text": f"Item {i}", "bounds": {"x1": i, "y1": i, "x2": i + 10, "y2": i + 10},
+             "extra": {}}
+            for i in range(500)
+        ]
+        out = _render_screen_elements(elements, max_chars=200)
+        assert len(out) <= 220
+        assert "truncated" in out
+
+    def test_false_flags_are_not_shown(self):
+        elements = [
+            {"text": "Row", "bounds": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+             "extra": {"clickable": "false", "scrollable": "true"}},
+        ]
+        out = _render_screen_elements(elements)
+        assert "scrollable" in out
+        assert "clickable" not in out
 
 
 class TestGeminiMissingDependency:

--- a/tests/units/engines/elementsources/test_playwright_page_source.py
+++ b/tests/units/engines/elementsources/test_playwright_page_source.py
@@ -1,0 +1,156 @@
+"""Unit tests for PlaywrightPageSource.get_interactive_elements batched bounds extraction.
+
+Bounds used to be resolved one Playwright locator round trip (count() + bounding_box())
+per candidate DOM node -- fine for a mobile page source dump, painfully slow for a web
+page with a few hundred nodes. It now issues exactly one page.evaluate() call that
+resolves every candidate's bounding box in-browser via document.evaluate() +
+getBoundingClientRect(), so the call count stays constant regardless of node count.
+
+These tests assert the call-count fix and pin the output contract (same dict shape,
+same `if not bounds: continue` filtering, same filter_config semantics) that the
+rewrite must not change.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from lxml import etree
+
+from optics_framework.engines.elementsources import playwright_page_source as pw
+
+pytestmark = pytest.mark.white_box
+
+
+def _source(html, monkeypatch):
+    """A PlaywrightPageSource wired to a fake page.
+
+    run_async is patched to a pass-through since the fake page's methods return plain
+    values (via Mock return_value/side_effect) rather than real coroutines.
+    """
+    monkeypatch.setattr(pw, "run_async", lambda coro: coro)
+    page = MagicMock()
+    page.content.return_value = html
+    src = pw.PlaywrightPageSource(driver=MagicMock(page=page))
+    return src, page
+
+
+def _grid_html(n):
+    items = "".join(f'<button id="item-{i}">Item {i}</button>' for i in range(n))
+    return f"<html><body>{items}</body></html>"
+
+
+def _candidate_count(html):
+    """Every node .//* sees, including lxml's implicit <head/> -- ground truth for
+    'every candidate got bounds' assertions, independent of that auto-wrapping."""
+    tree = etree.HTML(html)
+    return len(tree.xpath(".//*")) if tree is not None else 0
+
+
+def _uniform_rects(width=20, height=20):
+    """An evaluate() side_effect giving every candidate xpath the same real rect."""
+    def _side_effect(script, xpaths):
+        return [{"x": i, "y": i, "width": width, "height": height} for i, _ in enumerate(xpaths)]
+    return _side_effect
+
+
+class TestBatchedEvaluateCallCount:
+    @pytest.mark.parametrize("n", [1, 50])
+    def test_evaluate_called_once_regardless_of_node_count(self, n, monkeypatch):
+        html = _grid_html(n)
+        src, page = _source(html, monkeypatch)
+        page.evaluate.side_effect = _uniform_rects()
+
+        elements = src.get_interactive_elements(None)
+
+        assert page.evaluate.call_count == 1
+        # Every candidate node (including lxml's implicit <head/>) got real bounds from
+        # the single evaluate() call, so none were dropped by the batching rewrite.
+        assert len(elements) == _candidate_count(html)
+
+    def test_evaluate_not_called_when_there_are_no_candidate_nodes(self, monkeypatch):
+        src, page = _source("", monkeypatch)
+        page.evaluate.side_effect = _uniform_rects()
+
+        elements = src.get_interactive_elements(None)
+
+        assert elements == []
+        assert page.evaluate.call_count == 0
+
+
+class TestOutputShapeAndFiltering:
+    def test_mixed_present_absent_bounds_matches_prior_semantics(self, monkeypatch):
+        html = (
+            "<html><body>"
+            '<button id="btn-a">Alpha</button>'
+            '<button id="btn-b">Beta</button>'
+            '<button id="btn-c">Gamma</button>'
+            "</body></html>"
+        )
+        src, page = _source(html, monkeypatch)
+
+        def side_effect(script, xpaths):
+            # Bounds for btn-a/btn-c, withheld for btn-b -- exercises the same
+            # `if not bounds: continue` filtering the old per-node code performed.
+            rects = []
+            for xp in xpaths:
+                if xp and "btn-a" in xp:
+                    rects.append({"x": 10, "y": 20, "width": 100, "height": 40})
+                elif xp and "btn-c" in xp:
+                    rects.append({"x": 200, "y": 20, "width": 100, "height": 40})
+                else:
+                    rects.append(None)
+            return rects
+
+        page.evaluate.side_effect = side_effect
+        elements = src.get_interactive_elements(None)
+
+        assert page.evaluate.call_count == 1
+        texts = {el["text"] for el in elements}
+        assert texts == {"Alpha", "Gamma"}
+
+        alpha = next(el for el in elements if el["text"] == "Alpha")
+        assert set(alpha.keys()) == {"text", "bounds", "xpath", "extra"}
+        assert alpha["bounds"] == {"x1": 10, "y1": 20, "x2": 110, "y2": 60}
+        assert alpha["xpath"]
+
+    def test_filter_config_still_applies_after_bounds_check(self, monkeypatch):
+        html = (
+            "<html><body>"
+            '<button id="btn-a">Alpha</button>'
+            '<span id="span-a">Not a button</span>'
+            "</body></html>"
+        )
+        src, page = _source(html, monkeypatch)
+        page.evaluate.side_effect = _uniform_rects()
+
+        elements = src.get_interactive_elements(["buttons"])
+
+        assert [el["text"] for el in elements] == ["Alpha"]
+
+    def test_no_filter_config_returns_all_bounded_elements(self, monkeypatch):
+        html = _grid_html(5)
+        src, page = _source(html, monkeypatch)
+        page.evaluate.side_effect = _uniform_rects()
+
+        elements = src.get_interactive_elements(None)
+
+        assert len(elements) == _candidate_count(html)
+
+
+class TestBatchFailureDegradesGracefully:
+    def test_evaluate_exception_returns_no_elements_without_per_node_fallback(self, monkeypatch):
+        src, page = _source(_grid_html(3), monkeypatch)
+        page.evaluate.side_effect = RuntimeError("page navigated mid-evaluate")
+
+        elements = src.get_interactive_elements(None)
+
+        assert elements == []
+        # A whole-batch failure must not fall back to one evaluate() call per node.
+        assert page.evaluate.call_count == 1
+
+    def test_mismatched_length_response_is_treated_as_all_absent(self, monkeypatch):
+        src, page = _source(_grid_html(3), monkeypatch)
+        page.evaluate.return_value = [{"x": 0, "y": 0, "width": 5, "height": 5}]  # too short
+
+        elements = src.get_interactive_elements(None)
+
+        assert elements == []


### PR DESCRIPTION
Rebased onto current `main` and reworked to build on the compact interactive-element mode that landed since.

**1. `perf(playwright)`** — both `get_interactive_elements` paths resolved each node's bounds through its own Playwright round trip (`count()` + `bounding_box()`). Now one `page.evaluate()` resolves every candidate in-browser. This also covers the compact path added in ca2d109, which is what the `optics://session/{id}/elements` MCP resource serves by default. A whole-batch failure no longer falls back to per-node calls: the full list degrades to no bounds this pass, while compact extraction reports unavailable so the live NL agent keeps its page-source fallback.

**2. `feat(live)`** — the NL agent's prompt showed a 12000-char raw UI-hierarchy dump. It now gets the compact element list (~95% smaller, so a real screen fits instead of truncating), rendered as: label, afforded actions, bounds, resource id. The `act` verbs (tap/long/toggle/input/scroll) come straight from compact mode instead of a flag heuristic, and the prompt tells the model that an element with no actions is read-only text. Vocabulary matches the MCP elements resource. Sources without structured extraction fall back to the existing page-source path unchanged.

Bounds are scaled against the screenshot the agent already captured that step, so there's no second device capture.

**Note on the merge:** the previous revision deleted `_extract_bounds` while `main` had grown a new caller of it in the compact path. That merged with zero conflicts and broke Playwright compact extraction at runtime — the compact tests stubbed the method onto the instance, so they stayed green. They now stub `page.evaluate` instead, and the real path runs.

## Test plan
- [x] `pytest` — 1274 passed, 2 pre-existing xfails, 0 failures
- [x] Verified the new tests catch the regression above (reintroducing the dangling call fails the suite)
- [x] `pre-commit run --files <changed>` — clean

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65923280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because transient Playwright batch failures can suppress the agent’s page-source fallback, and the repository’s test-docstring requirement must also be satisfied.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aoptics_framework%2Fengines%2Felementsources%2Fplaywright_page_source.py%3A239-240%0AIf%20%60page.evaluate%28%29%60%20fails%20or%20returns%20a%20malformed%20batch%2C%20this%20code%20converts%20every%20bound%20to%20%60None%60%2C%20so%20compact%20extraction%20returns%20%60%5B%5D%60.%20The%20agent%20treats%20%60%5B%5D%60%20as%20a%20successfully%20extracted%20empty%20screen%20and%20skips%20the%20still-available%20page-source%20fallback.%20As%20a%20result%2C%20the%20model%20loses%20all%20element%20context%20and%20may%20fail%20the%20live%20instruction%20or%20act%20blindly.%20Preserve%20a%20distinct%20unavailable%2Ferror%20result%20for%20batch%20failures%20while%20retaining%20%60%5B%5D%60%20for%20genuinely%20empty%20pages.%0A%0A%23%23%23%20Issue%202%0Atests%2Funits%2Fengines%2Felementsources%2Ftest_playwright_page_source.py%3A1-14%0AThe%20new%20module%20docstring%20repeats%20implementation%20history%2C%20performance%20rationale%2C%20and%20assertions%20already%20expressed%20by%20the%20test%20names%20and%20code.%20Similar%20redundant%20docstrings%20appear%20on%20%60_source%60%2C%20%60_uniform_rects%60%2C%20and%20%60_page%60%20in%20the%20compact%20test%20module.%20This%20violates%20the%20repository%20directive%20that%20tests%20need%20not%20have%20unnecessary%20docstrings%2C%20so%20the%20redundant%20prose%20must%20be%20removed%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mozarkai%2Foptics-framework&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Batch failures suppress fallback** <a href="https://github.com/mozarkai/optics-framework/pull/523#discussion_r4047010793">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Test docstrings are unnecessary** <a href="https://github.com/mozarkai/optics-framework/pull/523#discussion_r4047010804">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
optics_framework/engines/elementsources/playwright_page_source.py:239-240
If `page.evaluate()` fails or returns a malformed batch, this code converts every bound to `None`, so compact extraction returns `[]`. The agent treats `[]` as a successfully extracted empty screen and skips the still-available page-source fallback. As a result, the model loses all element context and may fail the live instruction or act blindly. Preserve a distinct unavailable/error result for batch failures while retaining `[]` for genuinely empty pages.

### Issue 2
tests/units/engines/elementsources/test_playwright_page_source.py:1-14
The new module docstring repeats implementation history, performance rationale, and assertions already expressed by the test names and code. Similar redundant docstrings appear on `_source`, `_uniform_rects`, and `_page` in the compact test module. This violates the repository directive that tests need not have unnecessary docstrings, so the redundant prose must be removed before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary>Summary</summary>

This PR batches Playwright bounds resolution and supplies the live natural-language agent with compact, screenshot-aligned element context.

- Replaces per-node Playwright locator calls with one browser-side bounds evaluation.
- Adds compact element rendering and page-source fallback for the live agent.
- Adds coverage for batching, rendering, source precedence, and screenshot-bound scaling.
- Batch lookup failures currently use the same empty-list signal as genuinely empty screens, preventing the intended fallback.
</details>

<details><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Capture screenshot] --> B[Request compact elements]
    B --> C{Structured result}
    C -->|Non-empty list| D[Scale and render compact elements]
    C -->|None or exception| E[Capture condensed page source]
    C -->|Empty list| F[Render no elements and skip fallback]
    G[Playwright batch evaluation failure] --> H[All bounds become null]
    H --> F
    D --> I[Build NL-agent prompt]
    E --> I
    F --> I
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(live): show the NL agent a compact ..."](https://github.com/mozarkai/optics-framework/commit/99b1c57e6f0abf39302e0172c242721058b65a84)</sub>

<!-- /greptile_comment -->
