### PR TITLE
fix(action_keyword): use underscore separator in pre-action screenshot name

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -430,7 +430,7 @@ class ActionKeyword:
                 screenshot_np, aoi_x, aoi_y, aoi_width, aoi_height,
                 self.execution_dir, func_name,
             )
-        self._save_screenshot_if_available(screenshot_np, f"pre-{func_name}")
+        self._save_screenshot_if_available(screenshot_np, f"pre_{func_name}")
         results = _locate_element(
             self.strategy_manager, element,
             aoi_x, aoi_y, aoi_width, aoi_height, int(index), is_aoi_used,

--- a/tests/units/helpers/test_live_driver_agnostic.py
+++ b/tests/units/helpers/test_live_driver_agnostic.py
@@ -330,7 +330,7 @@ def _teardown_shell(artifacts_dir: str) -> LiveController:
 class TestArtifactsPersistence:
     def test_teardown_keeps_dir_with_screenshots(self):
         d = tempfile.mkdtemp(prefix="optics_live_shots_")
-        with open(os.path.join(d, "pre-press_element.jpg"), "w") as fh:
+        with open(os.path.join(d, "pre_press_element.jpg"), "w") as fh:
             fh.write("x")
         _teardown_shell(d).teardown()
         # A session that captured screenshots keeps them after /quit.


### PR DESCRIPTION
Closes #521.

Follows the review decision on #522: keep the `[a-zA-Z0-9\s_]` filename semantic in `utils.save_screenshot` and fix the call site instead of widening the allowlist.

## The fix

`action_keyword.py:433` passed `f"pre-{func_name}"`, and `save_screenshot`'s sanitizer silently deletes the hyphen — producing `prepress_element.jpg` for `press_element`. The call site now passes `f"pre_{func_name}"`, so the file lands as `pre_press_element.jpg` and matches the underscore semantic used by every other screenshot name (`press_by_percentage`, `enter_text_keyboard`, `{func_name}_with_aoi`, ...).

## Call-site audit (all of them, not just the known one)

`grep -rn "save_screenshot(" optics_framework/` — every call site checked against main:

- **Only one hyphenated name in the tree**: `action_keyword.py:433` (`f"pre-{func_name}"`). Fixed here.
- All other call sites already pass underscore-only names, byte for byte unchanged: `action_keyword.py` (`{func_name}_with_aoi`, `{func_name}_image_detection_result`, `{func_name}_element_detection_result`, `enter_text_keyboard`, `enter_text_using_keyboard`, `press_keycode`, `execute_script`), `verifier.py` (`capture_screenshot`, `assert_elements_image_detection_result`), `test_runnner.py` (`end_of_run`), `remote_oir.py` (`detected_template`), `remote_ocr.py` (`detected_text`), `pytesseract.py` (`annotated_frame`), `easyocr.py` (`text_location_annotation`), `live.py` (`live_capture`).
- `helper/live.py` `capture_screenshot` predicts the filename with the same regex — its name is already underscore-only, so it is untouched and stays in sync.