### PR TITLE
docs(api): fill in missing keyword docstring params

### DIFF
--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -785,6 +785,7 @@ class ActionKeyword:
         .. deprecated:: Deprecated; prefer :meth:`swipe_from_element` / :meth:`swipe`.
 
         :param element: The seekbar element (Image template, OCR template, or XPath).
+        :param event_name: The event triggering the swipe.
         """
         internal_logger.warning(
             "'Swipe Seekbar To Right Android' is deprecated; use 'Swipe From Element' instead."

--- a/optics_framework/api/app_management.py
+++ b/optics_framework/api/app_management.py
@@ -38,6 +38,8 @@ class AppManagement:
         """
         Launches the specified application.
 
+        :param app_identifier: The app identifier (package name for Android, bundle ID for iOS).
+        :param app_activity: The app activity to launch (Android only).
         :param event_name: The event triggering the app launch, if any.
         """
         return self.driver.launch_app(
@@ -91,6 +93,7 @@ class AppManagement:
         """
         Gets the version of the application.
 
+        :param app_package: The app package/bundle ID to check, or the current app if None.
         :return: The version of the application, or None if not available.
         """
         return self.driver.get_app_version(app_package=app_package) if app_package else self.driver.get_app_version()

--- a/optics_framework/api/flow_control.py
+++ b/optics_framework/api/flow_control.py
@@ -130,6 +130,9 @@ class FlowControl:
         Not exposed on the Optics SDK — session.modules is only populated by
         CSV/YAML-driven execution; SDK/Robot Framework users should call keywords
         directly or write a real function/keyword instead.
+
+        :param module_name: The module to execute.
+        :return: Results of each keyword call in the module, in order.
         """
         module_def = self._get_validated_module_def(module_name)
         results = []
@@ -140,7 +143,13 @@ class FlowControl:
 
     @raw_params(1, 3, 5, 7, 9, 11, 13, 15)
     def run_loop(self, target: str, *args: str) -> List[Any]:
-        """Runs a loop over a target module, either by count or with variables."""
+        """Runs a loop over a target module, either by count or with variables.
+
+        :param target: The module name to execute in the loop.
+        :param args: A single count (e.g. ``"5"``), or variable-iterable pairs
+            (e.g. ``"${user}", "a|b|c"``) to iterate one value per run.
+        :return: One result list per iteration.
+        """
         internal_logger.debug(f"[RUN_LOOP] Called with target={target}, args={args}")
         self._ensure_session()
         if self.session is None:
@@ -267,7 +276,13 @@ class FlowControl:
             raise OpticsError(Code.E0403, message=f"Expected a list, JSON string, or pipe-separated string for iterable of variable '{variable}', got {type(iterable).__name__}.")
 
     def condition(self, *args: str) -> Optional[List[Any]]:
-        """Evaluates conditions and executes corresponding targets."""
+        """Evaluates conditions and executes corresponding targets.
+
+        :param args: Condition-target pairs, optionally ending with an else target:
+            ``"cond1", "target1", "cond2", "target2", [else_target]``. A condition is a
+            module name (prefix ``!`` to invert) or an expression.
+        :return: Result of the matched target module, or None if nothing matched.
+        """
         internal_logger.debug(f"[CONDITION] Called with args={args}")
         self._ensure_session()
         if self.session is None:
@@ -801,7 +816,13 @@ class FlowControl:
 
     @raw_params(0)
     def evaluate(self, param1: str, param2: str) -> Any:
-        """Evaluates an expression and stores the result in session.elements."""
+        """Evaluates an expression and stores the result in session.elements.
+
+        :param param1: Variable name to store the result under, e.g. ``${result}``.
+        :param param2: Expression to evaluate; ``${var}`` refs are substituted first,
+            then run through a restricted eval (arithmetic, comparisons, ternary).
+        :return: The evaluated result (also stored as a string in session.elements).
+        """
         self._ensure_session()
         if self.session is None:
             raise OpticsError(Code.E0501, message=NO_SESSION_PRESENT)
@@ -982,7 +1003,10 @@ class FlowControl:
         return result
 
     def invoke_api(self, api_identifier: str) -> None:
-        """Invokes an API call based on a definition from the session's API data."""
+        """Invokes an API call based on a definition from the session's API data.
+
+        :param api_identifier: API to call, in ``collection.api_name`` form.
+        """
         internal_logger.debug(f"[INVOKE_API] Called with api_identifier={api_identifier}")
         self._ensure_session()
         if self.session is None:

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -132,6 +132,7 @@ class Verifier:
         :param timeout_str: The time to wait for the elements in seconds.
         :param rule: The rule for verification ("any" or "all").
         :param event_name: The name of the event associated with the assertion, if any.
+        :param fail: If True, raise on failure; if False, return False instead.
         :return: True if the rule is satisfied, False otherwise.
         """
         return self._assert_common(elements, timeout_str, rule, event_name, fail, method_name="assert_presence")
@@ -146,6 +147,7 @@ class Verifier:
         :param timeout_str: The time to wait for the elements to become visible, in seconds.
         :param rule: The rule for verification ("any" or "all").
         :param event_name: The name of the event associated with the assertion, if any.
+        :param fail: If True, raise on failure; if False, return False instead.
         :return: True if the rule is satisfied, False otherwise.
         """
         return self._assert_common(elements, timeout_str, rule, event_name, fail, method_name="assert_visibility")


### PR DESCRIPTION
<!-- Title line follows Conventional Commits, e.g. fix(runner): advance fallback ladder -->
<!-- Skip any section that doesn't apply — rough drafts welcome. -->

## What

<!-- Concrete changes, one bullet per logical change. -->
Updates docstrings of keywords

## Why

<!-- Motivation. Link issues with Fixes #123 so they close on merge. -->
It is needed because https://github.com/mozarkai/optics-framework-lsp uses the docstrings of keywords to show them on editor hover action

## Non-obvious choices

<!-- Pins, workarounds, rejected alternatives — anything a reviewer would otherwise have to reconstruct. -->

## Validation

<!-- How did you verify the bug/feature beyond CI? e.g. new/updated tests added, manual testing steps tried. -->

## Follow-ups

<!-- Optional: known gaps, follow-up issues created or planned. -->
