### PR TITLE
fix(expose_api): exclude private helper classes from keyword discovery

### DIFF
--- a/optics_framework/common/expose_api.py
+++ b/optics_framework/common/expose_api.py
@@ -372,8 +372,8 @@ def _extract_keywords_from_class(cls) -> List[KeywordInfo]:
 def _extract_keywords_from_module(module) -> List[KeywordInfo]:
     """Extract all keyword infos from a module."""
     keywords = []
-    for _, obj in inspect.getmembers(module):
-        if inspect.isclass(obj) and obj.__module__ == module.__name__:
+    for name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and obj.__module__ == module.__name__ and not name.startswith("_"):
             keywords.extend(_extract_keywords_from_class(obj))
     return keywords
 


### PR DESCRIPTION
## What
- Skip underscore-prefixed classes in `_extract_keywords_from_module` (`expose_api.py`)

## Why
`/v1/keywords` was reflecting every class in each `api/*.py` module, so `action_keyword.py`'s internal `_HealProviders` helper leaked its public `screenshot()`/`pagesource()` methods as bogus top-level keywords.

## Validation
Confirmed `Screenshot`/`Pagesource` no longer appear in `discover_keywords()` output; real `Capture Screenshot`/`Capture Pagesource` keywords unaffected.