### PR TITLE
fix(appium): activate the app when launch_app runs on a live session

### DIFF
--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -707,7 +707,7 @@ class Appium(DriverInterface):
         app_activity: Optional[str] = None,
         event_name: Optional[str] = None,
     ) -> str:
-        """Launch the app using the Appium driver."""
+        """Launch the app, activating it on the driver if a session is already alive."""
         session_id = self.get_session_id()
         if self.driver is None or not self._is_session_alive():
             session_id = self.start_session(
@@ -715,6 +715,13 @@ class Appium(DriverInterface):
                 app_activity=app_activity,
                 event_name=event_name,
             )
+        elif app_identifier:
+            try:
+                self._require_driver().activate_app(app_identifier)
+            except Exception as exc:
+                raise OpticsError(
+                    Code.E0401, message=f"Failed to launch: {app_identifier}", cause=exc
+                ) from exc
 
         internal_logger.debug(f"Launched application with event: {event_name}")
         return session_id if session_id else None


### PR DESCRIPTION
### Fix: Launch App now launches on a live session

Previously, `launch_app` only worked when no driver existed. Since session creation calls it with empty parameters, subsequent Launch App actions returned the session ID without opening the app.

This caused ** Launch App** silently no-op.

**Fix:** When a session is already active and an app identifier is provided, `launch_app` now activates the app on the live driver using `launch_other_app`. Calls without an identifier retain the existing behavior, so session creation is unaffected.
