### PR TITLE
fix: skip local adb device check for remote Appium servers

### DIFF
--- a/docs/architecture/cli_layer.md
+++ b/docs/architecture/cli_layer.md
@@ -126,7 +126,7 @@ sequenceDiagram
     CLI-->>User: Results displayed (+ failure details when steps failed)
 ```
 
-The preflight aborts with a non-zero exit and fix instructions when the enabled driver's backend is unreachable (Appium server / Android device, Selenium remote URL). `OPTICS_SKIP_PREFLIGHT=1` bypasses it.
+The preflight aborts with a non-zero exit and fix instructions when the enabled driver's backend is unreachable (Appium server, Selenium remote URL). The Android device check only runs when the Appium server URL is local — a remote server/hub is left to manage its own devices. `OPTICS_SKIP_PREFLIGHT=1` bypasses the whole check.
 
 ### 3. Dry Run Command
 

--- a/docs/usage/CLI_usage.md
+++ b/docs/usage/CLI_usage.md
@@ -71,7 +71,7 @@ optics execute <folder_path> [--runner <runner_name>] [--use-printer | --no-use-
 - `--use-printer` (default): Enable live result printer.
 - `--no-use-printer`: Disable live result printer.
 
-**Preflight check:** before running anything, `optics execute` verifies the enabled driver's backend is actually reachable — the Appium server (plus at least one attached Android device via `adb`) for Appium projects, or the remote WebDriver URL for Selenium projects. If something is missing it stops with the exact fix (e.g. "Start one in another terminal: `appium`") and a non-zero exit code instead of running tests that cannot reach a target. Set `OPTICS_SKIP_PREFLIGHT=1` to bypass this check.
+**Preflight check:** before running anything, `optics execute` verifies the enabled driver's backend is actually reachable — the Appium server for Appium projects, or the remote WebDriver URL for Selenium projects. For an Android Appium project whose server URL is on this machine (e.g. `127.0.0.1`/`localhost`), it additionally requires at least one attached device via `adb`; a remote Appium server or device hub is assumed to manage its own devices, so that extra check is skipped. If something is missing it stops with the exact fix (e.g. "Start one in another terminal: `appium`") and a non-zero exit code instead of running tests that cannot reach a target. Set `OPTICS_SKIP_PREFLIGHT=1` to bypass this check entirely.
 
 **Failure details:** when any step fails, a *Failure details* panel is printed below the summary with each failing step and its reason; unknown steps include a `Did you mean '…'?` suggestion when a close keyword match exists.
 

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -1,3 +1,4 @@
+import ipaddress
 import os
 import shutil
 import socket
@@ -514,6 +515,22 @@ def _probe_tcp(url: str | None, default_port: int,
         return False
 
 
+def _is_local_host(url: str | None) -> bool:
+    """Best-effort loopback check, so a remote Appium hub's own devices aren't checked via local adb."""
+    try:
+        host = urlparse(url).hostname
+    except ValueError:
+        return False
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def _adb_device_count() -> int | None:
     """
     Count attached Android devices/emulators via ``adb devices``.
@@ -565,9 +582,10 @@ def _preflight_or_exit(config: Config | None, folder_path: str = "<folder>") -> 
 
     - playwright: self-contained, skipped silently.
     - selenium: probes the configured WebDriver URL (~2s).
-    - appium: probes the configured Appium server URL (~2s); when capabilities
-      say Android, additionally requires adb on PATH and one attached device.
-      iOS projects get the server probe only.
+    - appium: probes the configured Appium server URL (~2s); for a local
+      Android server, additionally requires adb on PATH and one attached
+      device. iOS projects and remote Appium servers/hubs get the server
+      probe only.
 
     On failure prints exactly what is wrong and how to fix it, then exits 1
     without executing tests (dry_run never invokes this gate). Callers pass
@@ -601,7 +619,7 @@ def _preflight_or_exit(config: Config | None, folder_path: str = "<folder>") -> 
 
 
 def _preflight_appium(details: DependencyConfig, folder_path: str) -> None:
-    """Probe the Appium server and, for Android, adb + an attached device."""
+    """Probe the Appium server and, for Android on a local server, adb + an attached device."""
     url = details.url or _APPIUM_DEFAULT_URL
     if not _probe_tcp(url, default_port=4723):
         _abort_preflight([
@@ -611,7 +629,7 @@ def _preflight_appium(details: DependencyConfig, folder_path: str) -> None:
             f"Then re-run:  optics execute {folder_path}",
         ])
     platform = str(details.capabilities.get("platformName", "")).lower()
-    if platform != "android":
+    if platform != "android" or not _is_local_host(url):
         return
     device_count = _adb_device_count()
     if device_count is None:


### PR DESCRIPTION
## Summary
- The `optics execute` preflight had a mismatch which checked for local adb + at least 1 device even when remote appium hub URL was being used. 
- Added `_is_local_host` to detect whether the Appium URL resolves to this machine (loopback), and only run the local `adb` device check in that case.