### PR TITLE
docs: document llm_models and ai_self_heal in configuration reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,8 @@ Configuration is **project-specific**: the one file that matters is `config.yaml
 | **Element Sources** | `appium_find_element`, `playwright_screenshot`, etc. | See Element Sources tab |
 | **Text Detection** | `easyocr`, `pytesseract`, `google_vision` | See Text Detection tab |
 | **Image Detection** | `templatematch`, `remote_oir` | See Image Detection tab |
+| **LLM Models** | `gemini` | See LLM Models tab |
+| **AI Self-Healing** | `ai_self_heal` | `false` (opt-in) |
 
 ## Configuration Structure
 
@@ -181,6 +183,7 @@ All configurations are defined in YAML format. The main configuration file (`con
 - **Element sources** - Element detection methods
 - **Text detection engines** - OCR capabilities
 - **Image detection engines** - Template matching
+- **LLM models** - Optional LLM backend for AI self-healing and `optics live`'s natural-language mode
 
 ---
 
@@ -325,6 +328,30 @@ All configurations are defined in YAML format. The main configuration file (`con
     ```yaml
     event_attributes_json: "./config/event_attributes.json"
     ```
+
+=== "AI Self-Healing"
+
+    ### `ai_self_heal`
+
+    **Type:** `bool` | **Default:** `false`
+
+    Last-resort recovery for element location. When every locator strategy (XPath, text,
+    OCR, image) fails for a self-healing-capable keyword (e.g. `Press Element`, `Enter Text`),
+    a bounded LLM-driven loop reads the screen and attempts to recover before the keyword
+    fails outright.
+
+    Opt-in and inert unless an entry under `llm_models` is also enabled — a missing or
+    misconfigured LLM degrades this to a no-op rather than a failure:
+
+    ```yaml
+    ai_self_heal: true
+
+    llm_models:
+      - gemini:
+          enabled: true
+    ```
+
+    See [LLM Models](#llm-models) below for backend configuration.
 
 ---
 
@@ -774,6 +801,48 @@ Image detection engines provide template matching capabilities for locating UI e
           url: "https://your-oir-service.com/api/match"
           capabilities: {}
     ```
+
+---
+
+## LLM Models
+
+LLM backends power two opt-in features: the [`ai_self_heal`](#ai_self_heal) recovery path
+above, and `optics live`'s natural-language mode (`Ctrl-N`). Both stay inert until an entry
+below is enabled — the backend SDK is only imported when its engine is enabled, so leaving
+this section out has no cost for projects that don't use either feature.
+
+=== "Gemini"
+
+    **Purpose:** Google Gemini via the `google-genai` SDK, supporting both the Gemini
+    Developer API and Vertex AI. Requires the optional `llm` extra:
+    `pip install 'optics-framework[llm]'`.
+
+    ```yaml
+    llm_models:
+      - gemini:
+          enabled: true
+          capabilities:
+            model: gemini-3.8-flash    # optional; framework default is gemini-2.5-flash
+            temperature: 0.0           # optional; this is the default
+            # use_vertexai: true       # optional; else uses GOOGLE_GENAI_USE_VERTEXAI
+            # project: your-project    # optional Vertex override; else GOOGLE_CLOUD_PROJECT
+            # location: us-east4       # optional Vertex override; else GOOGLE_CLOUD_LOCATION
+    ```
+
+    With no `capabilities` set, the SDK auto-detects everything from environment variables:
+
+    | Variable | Purpose |
+    |----------|---------|
+    | `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Gemini Developer API key |
+    | `GOOGLE_GENAI_USE_VERTEXAI` | Switch to Vertex AI |
+    | `GOOGLE_CLOUD_PROJECT` | Vertex AI project |
+    | `GOOGLE_CLOUD_LOCATION` | Vertex AI location |
+    | `GOOGLE_APPLICATION_CREDENTIALS` | Vertex AI service account credentials |
+
+    !!! warning "Don't hardcode credentials"
+        `capabilities.api_key` / `capabilities.gemini_api_key` are also accepted but log a
+        warning when used — prefer the environment variables above so keys never end up in
+        a committed `config.yaml`.
 
 ---
 


### PR DESCRIPTION
## Summary
- `Config.llm_models` and `Config.ai_self_heal` ([config_handler.py:29](https://github.com/mozarkai/optics-framework/blob/main/optics_framework/common/config_handler.py#L29), [:42](https://github.com/mozarkai/optics-framework/blob/main/optics_framework/common/config_handler.py#L42)) are real, live project `config.yaml` fields — `llm_models` follows the exact same `DependencyConfig` shape (`enabled`/`url`/`capabilities`) as `driver_sources`/`text_detection`/`image_detection`, all of which already have dedicated sections in `docs/configuration.md`. They were simply never added to that page, so the only end-user-facing config docs for the AI self-heal feature were scattered one-liners in `docs/introduction.md` and `docs/usage/live_usage.md`.
- Adds an **AI Self-Healing** tab under Core Settings documenting `ai_self_heal` (type, default, opt-in relationship to `llm_models`), and a new **LLM Models** section documenting the `gemini` backend's capabilities (`model`, `temperature`, `use_vertexai`, `project`, `location`) and the environment variables the SDK auto-detects when no capabilities are set — sourced from `engines/llm_models/gemini.py`.
- Wires both into the existing Quick Reference table and Configuration Structure summary at the top of the page.

## Test plan
- [x] `poetry run mkdocs build --strict` — only pre-existing unrelated warning (`usage/mcp_usage.md` broken relative link), confirmed present on `main` before this change too.
- [x] Verified rendered anchors resolve: `h2#llm-models`, `h3#ai_self_heal`.
- [x] `poetry run pre-commit run --files docs/configuration.md` — all hooks pass.