### PR TITLE
fix(app_management): pass event_name as keyword to launch_app (#538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ optics.setup(
     elements_sources=[{"appium_find_element": {"enabled": True}}],
 )
 
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 optics.enter_text("username_field", "testuser")
 optics.press_element("submit_button")
 optics.validate_element("welcome_message")

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -205,7 +205,7 @@ enter_text(["username", "user_name", "//input[@name='user']"], "testuser")
 **3. Environment-Specific Values:**
 ```python
 # Different values for different environments
-launch_app([
+launch_app(app_identifier=[
     "com.example.app.dev",      # Development
     "com.example.app.staging",  # Staging
     "com.example.app.prod"      # Production

--- a/docs/architecture/library_layer.md
+++ b/docs/architecture/library_layer.md
@@ -97,7 +97,7 @@ optics.setup(
 )
 
 # Use keywords
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 optics.press_element("submit_button")
 optics.enter_text("username_field", "testuser")
 optics.validate_element("welcome_message")
@@ -175,7 +175,7 @@ optics.scroll(100, 200, 300, 400)
 
 ```python
 # App lifecycle
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 optics.launch_other_app("com.other.app")
 optics.close_and_terminate_app()
 optics.force_terminate_app()
@@ -250,8 +250,8 @@ optics1 = Optics(config=config1)
 optics2 = Optics(config=config2)
 
 # Each instance has its own session
-optics1.launch_app("app1")
-optics2.launch_app("app2")
+optics1.launch_app(app_identifier="app1")
+optics2.launch_app(app_identifier="app2")
 ```
 
 ## Configuration

--- a/docs/usage/library_usage.md
+++ b/docs/usage/library_usage.md
@@ -27,7 +27,7 @@ optics.setup(
 )
 
 # Launch app
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 
 # Interact with elements
 optics.press_element("submit_button")
@@ -134,7 +134,7 @@ optics.setup(config=yaml_config)
 
 ```python
 # Launch app by package name
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 
 # Launch other app
 optics.launch_other_app("com.other.app")
@@ -152,7 +152,7 @@ print(f"Session ID: {session_id}")
 
 ```python
 # Launch app
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 
 # Perform test operations
 optics.press_element("button")
@@ -377,7 +377,7 @@ optics = Optics()
 optics.setup(config=config)
 
 # Use session
-optics.launch_app("com.example.app")
+optics.launch_app(app_identifier="com.example.app")
 optics.press_element("button")
 
 # Cleanup session
@@ -403,7 +403,7 @@ def optics_session(config):
 # Usage
 config = {...}
 with optics_session(config) as optics:
-    optics.launch_app("com.example.app")
+    optics.launch_app(app_identifier="com.example.app")
     optics.press_element("button")
     # Session automatically cleaned up on exit
 ```
@@ -418,8 +418,8 @@ optics1 = Optics(config=config1)
 optics2 = Optics(config=config2)
 
 # Each instance has its own session
-optics1.launch_app("app1")
-optics2.launch_app("app2")
+optics1.launch_app(app_identifier="app1")
+optics2.launch_app(app_identifier="app2")
 
 # Cleanup both
 optics1.quit()
@@ -486,7 +486,7 @@ def test_login_flow():
         optics.setup(config=config)
 
         # Launch app
-        optics.launch_app("com.example.app")
+        optics.launch_app(app_identifier="com.example.app")
 
         # Add elements
         optics.add_element("username", "//input[@id='username']")

--- a/optics_framework/api/action_keyword.py
+++ b/optics_framework/api/action_keyword.py
@@ -520,10 +520,10 @@ class ActionKeyword:
                 internal_logger.info(
                     f"Pressing at coordinates ({x + int(offset_x)}, {y + int(offset_y)}) with offset ({offset_x}, {offset_y})")
                 self.driver.press_coordinates(
-                    x + int(offset_x), y + int(offset_y), event_name)
+                    x + int(offset_x), y + int(offset_y), event_name=event_name)
             else:
                 internal_logger.info(f"Pressing element '{element}'")
-                self.driver.press_element(located, int(repeat), event_name)
+                self.driver.press_element(located, int(repeat), event_name=event_name)
 
         self._locate_and_act(
             element, "press_element", act, (repeat, offset_x, offset_y),
@@ -542,7 +542,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "press_by_percentage")
         self.driver.press_percentage_coordinates(
-            float(percent_x), float(percent_y), int(repeat), event_name
+            float(percent_x), float(percent_y), int(repeat), event_name=event_name
         )
 
     def press_by_coordinates(self, coor_x: str, coor_y: str, repeat: str = "1", event_name: Optional[str] = None) -> None:
@@ -557,7 +557,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "press_by_coordinates")
         internal_logger.info(f'Pressing by coordinates: ({coor_x}, {coor_y})')
-        self.driver.press_coordinates(int(coor_x), int(coor_y), event_name)
+        self.driver.press_coordinates(int(coor_x), int(coor_y), event_name=event_name)
 
 
     def detect_and_press(self, element: str, timeout: str = "30", event_name: Optional[str] = None) -> None:
@@ -664,7 +664,7 @@ class ActionKeyword:
         if container is None:
             _raise_option_not_found(element, option, after)
 
-        self._scroll_dropdown_until_found(element, option, container, float(timeout), event_name)
+        self._scroll_dropdown_until_found(element, option, container, float(timeout), event_name=event_name)
 
     def _find_option_element(self, option: str, timeout_str: str = _DROPDOWN_OPTION_CHECK_TIMEOUT) -> bool:
         """
@@ -732,7 +732,7 @@ class ActionKeyword:
         previous_hash = self._safe_pagesource_hash()
         start_time = time.time()
         while time.time() - start_time < timeout:
-            self.driver.swipe(center_x, center_y, "up", swipe_length, event_name)
+            self.driver.swipe(center_x, center_y, "up", swipe_length, event_name=event_name)
             time.sleep(1)
 
             current_hash = self._safe_pagesource_hash()
@@ -761,7 +761,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "swipe")
         internal_logger.info(f'Swiping from ({coor_x}, {coor_y}) to the {direction} with length {swipe_length}')
-        self.driver.swipe(int(coor_x), int(coor_y), direction, int(swipe_length), event_name)
+        self.driver.swipe(int(coor_x), int(coor_y), direction, int(swipe_length), event_name=event_name)
 
     def swipe_by_percentage(self, percent_x: str, percent_y: str, direction: str = 'right', swipe_length: str = "50", event_name: Optional[str] = None) -> None:
         """
@@ -776,7 +776,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "swipe_percentage")
         internal_logger.info(f'Swiping from ({percent_x}, {percent_y}) to the {direction} with length {swipe_length}')
-        self.driver.swipe_percentage(int(percent_x), int(percent_y), direction, int(swipe_length), event_name)
+        self.driver.swipe_percentage(int(percent_x), int(percent_y), direction, int(swipe_length), event_name=event_name)
 
     def swipe_seekbar_to_right_android(self, element: str, event_name: Optional[str] = None) -> None:
         """
@@ -793,7 +793,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "swipe_seekbar_to_right_android")
         internal_logger.info(f'Swiping seekbar element: {element} to the right')
-        self.driver.swipe_element(element, 'right', 50, event_name)
+        self.driver.swipe_element(element, 'right', 50, event_name=event_name)
 
     def swipe_until_element_appears(self, element: str, direction: str, timeout: str, event_name: Optional[str] = None) -> None:
         """
@@ -818,7 +818,7 @@ class ActionKeyword:
             except OpticsError as e:
                 if e.code != Code.E0201:
                     raise
-            self.driver.swipe_percentage(10, 50, direction, 25, event_name)
+            self.driver.swipe_percentage(10, 50, direction, 25, event_name=event_name)
             time.sleep(3)
         if not found:
             raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after swiping {direction} for {timeout}s.")
@@ -843,11 +843,11 @@ class ActionKeyword:
             if isinstance(located, tuple):
                 x, y = located
                 internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
-                self.driver.swipe(x, y, direction, int(swipe_length), event_name)
+                self.driver.swipe(x, y, direction, int(swipe_length), event_name=event_name)
             else:
                 internal_logger.debug(f"Swiping from element '{element}'")
                 self.driver.swipe_element(
-                    located, direction, int(swipe_length), event_name)
+                    located, direction, int(swipe_length), event_name=event_name)
 
         self._locate_and_act(
             element, "swipe_from_element", act, (direction, swipe_length),
@@ -864,7 +864,7 @@ class ActionKeyword:
         screenshot_np = self._capture_screenshot_safe()
         self._save_screenshot_if_available(screenshot_np, "scroll")
         internal_logger.info(f"Scrolling {direction} with event {event_name}")
-        self.driver.scroll(direction, 1000, event_name)
+        self.driver.scroll(direction, 1000, event_name=event_name)
 
     def scroll_until_element_appears(self, element: str, direction: str, timeout: str, event_name: Optional[str] = None) -> None:
         """
@@ -892,7 +892,7 @@ class ActionKeyword:
                 # Don't hide configuration/strategy issues; scrolling won't fix these.
                 if "No strategies found" in e.message or "No valid strategies found" in e.message:
                     raise
-            self.driver.scroll(direction, 1000, event_name)
+            self.driver.scroll(direction, 1000, event_name=event_name)
             time.sleep(3)
         if not found:
             raise OpticsError(Code.E0201, message=f"Element '{element}' did not appear after scrolling {direction} for {timeout}s.")
@@ -917,11 +917,11 @@ class ActionKeyword:
             if isinstance(located, tuple):
                 x, y = located
                 internal_logger.debug(f"Swiping from coordinates ({x}, {y})")
-                self.driver.swipe(x, y, direction, int(scroll_length), event_name)
+                self.driver.swipe(x, y, direction, int(scroll_length), event_name=event_name)
             else:
                 internal_logger.debug(f"Swiping from element '{element}'")
                 self.driver.swipe_element(
-                    located, direction, int(scroll_length), event_name)
+                    located, direction, int(scroll_length), event_name=event_name)
 
         self._locate_and_act(
             element, "scroll_from_element", act, (direction, scroll_length),
@@ -952,10 +952,10 @@ class ActionKeyword:
                 x, y = located
                 internal_logger.debug(f"Entering text '{text}' at coordinates ({x}, {y})")
                 self.driver.press_coordinates(x, y, event_name=event_name)
-                self.driver.enter_text(text, event_name)
+                self.driver.enter_text(text, event_name=event_name)
             else:
                 internal_logger.debug(f"Entering text '{text}' into element '{element}'")
-                self.driver.enter_text_element(located, text, event_name)
+                self.driver.enter_text_element(located, text, event_name=event_name)
 
         self._locate_and_act(
             element, "enter_text", act, (text,),
@@ -975,7 +975,7 @@ class ActionKeyword:
         except Exception as e:
             internal_logger.error(f"Error capturing screenshot: {e}")
         internal_logger.info(f'Entering text directly: {text}')
-        self.driver.enter_text(text, event_name)
+        self.driver.enter_text(text, event_name=event_name)
 
     def enter_text_using_keyboard(self, text_input: str, event_name: Optional[str] = None) -> None:
         """
@@ -997,7 +997,7 @@ class ActionKeyword:
         except Exception as e:
             internal_logger.error(f"Error capturing screenshot: {e}")
         internal_logger.info(f'Entering text using keyboard: {text_input}')
-        self.driver.enter_text_using_keyboard(text_input, event_name)
+        self.driver.enter_text_using_keyboard(text_input, event_name=event_name)
 
     def enter_number(self, element: str, number: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
                      aoi_height: str = "100", event_name: Optional[str] = None, index: str = "0") -> None:
@@ -1018,10 +1018,10 @@ class ActionKeyword:
                 x, y = located
                 internal_logger.debug(f"Entering number '{number}' at coordinates ({x}, {y})")
                 self.driver.press_coordinates(x, y, event_name=event_name)
-                self.driver.enter_text(str(number), event_name)
+                self.driver.enter_text(str(number), event_name=event_name)
             else:
                 internal_logger.debug(f"Entering number '{number}' into element '{element}'")
-                self.driver.enter_text_element(located, str(number), event_name)
+                self.driver.enter_text_element(located, str(number), event_name=event_name)
 
         self._locate_and_act(
             element, "enter_number", act, (number,),
@@ -1042,7 +1042,7 @@ class ActionKeyword:
             internal_logger.error(f"Error capturing screenshot: {e}")
 
         internal_logger.info(f"Pressing keycode: {keycode}")
-        self.driver.press_keycode(keycode, event_name)
+        self.driver.press_keycode(keycode, event_name=event_name)
 
 
     def clear_element_text(self, element: str, aoi_x: str = "0", aoi_y: str = "0", aoi_width: str = "100",
@@ -1064,10 +1064,10 @@ class ActionKeyword:
                 internal_logger.debug(f"Clearing text at coordinates ({x}, {y})")
                 self.driver.press_coordinates(
                     x, y, event_name=event_name)
-                self.driver.clear_text(event_name)
+                self.driver.clear_text(event_name=event_name)
             else:
                 internal_logger.debug(f"Clearing text from element '{element}'")
-                self.driver.clear_text_element(located, event_name)
+                self.driver.clear_text_element(located, event_name=event_name)
 
         self._locate_and_act(
             element, "clear_element_text", act,

--- a/optics_framework/api/app_management.py
+++ b/optics_framework/api/app_management.py
@@ -54,7 +54,7 @@ class AppManagement:
 
         :param event_name: The event triggering the session start, if any.
         """
-        self.driver.launch_app(event_name)
+        self.driver.launch_app(event_name=event_name)
 
     def get_driver_session_id(self) -> Optional[str]:
         """Return the current driver session id, if available."""
@@ -67,7 +67,7 @@ class AppManagement:
         :param app_name: The package name of the application.
         :param event_name: The event triggering the app start, if any.
         """
-        self.driver.launch_other_app(app_name, event_name)
+        self.driver.launch_other_app(app_name=app_name, event_name=event_name)
 
     def close_and_terminate_app(self) -> None:
         """
@@ -87,7 +87,7 @@ class AppManagement:
         :param app_name: The name of the application to terminate.
         :param event_name: The event triggering the forced termination, if any.
         """
-        self.driver.force_terminate_app(app_name, event_name)
+        self.driver.force_terminate_app(app_name=app_name, event_name=event_name)
 
     def get_app_version(self, app_package: Optional[str] = None) -> Optional[str]:
         """

--- a/optics_framework/api/verifier.py
+++ b/optics_framework/api/verifier.py
@@ -43,7 +43,7 @@ class Verifier:
         """
         internal_logger.debug(f"Validating element: {element}")
         internal_logger.debug(f"Timeout: {timeout} and Rule: {rule}")
-        self.assert_presence(element, timeout, rule, event_name)
+        self.assert_presence(element, timeout, rule, event_name=event_name)
 
     def is_element(
         self,
@@ -216,7 +216,7 @@ class Verifier:
     def _handle_result(self, result: bool, timestamps: list, event_name: Optional[str], fail: bool, rule: str, method_name: str):
         """Handle the final result, including event capture and error raising."""
         if result:
-            self._capture_success_event(timestamps, event_name)
+            self._capture_success_event(timestamps, event_name=event_name)
         elif fail:
             assertion_label = method_name.replace("assert_", "").capitalize()
             raise AssertionError(f"{assertion_label} assertion failed based on rule: {rule}")
@@ -240,7 +240,7 @@ class Verifier:
         internal_logger.debug(f"Validating screen for elements: {elements}")
         internal_logger.debug(f"Timeout: {timeout} and Rule: {rule}")
         try:
-            self.assert_presence(elements, timeout, rule, event_name, fail=False)
+            self.assert_presence(elements, timeout, rule, event_name=event_name, fail=False)
             return True
         except OpticsError as e:
             internal_logger.info(f"Validate Screen: Elements not found. Error: {e}")

--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -257,7 +257,7 @@ class Appium(DriverInterface):
         all_caps = self.capabilities.copy() if self.capabilities else {}
         self._apply_app_identifier_caps(all_caps, app_package, app_activity)
 
-        attached_sid = self._try_attach_or_clear_session_caps(all_caps, event_name)
+        attached_sid = self._try_attach_or_clear_session_caps(all_caps, event_name=event_name)
         if attached_sid is not None:
             return attached_sid
 
@@ -267,7 +267,7 @@ class Appium(DriverInterface):
         for key, value in final_caps.items():
             options.set_capability(key, value)
 
-        return self._create_new_driver_session(options, event_name)
+        return self._create_new_driver_session(options, event_name=event_name)
 
     def get_session_id(self) -> Optional[str]:
         """Return the current Appium session id, if a session is active."""
@@ -891,7 +891,7 @@ class Appium(DriverInterface):
         else:
             internal_logger.error(f"Unknown swipe direction: {direction}")
             return
-        self.swipe(start_x, start_y, direction, swipe_length, event_name)
+        self.swipe(start_x, start_y, direction, swipe_length, event_name=event_name)
 
     @supported_on(*MOBILE)
     def swipe_element(
@@ -1236,7 +1236,7 @@ class Appium(DriverInterface):
         """
         coor_x, coor_y = int(coor_x), int(coor_y)
         internal_logger.debug(f"Pressing at coordinates: ({coor_x}, {coor_y})")
-        self.tap_at_coordinates(coor_x, coor_y, event_name)
+        self.tap_at_coordinates(coor_x, coor_y, event_name=event_name)
 
     @supported_on(*MOBILE)
     def press_percentage_coordinates(
@@ -1255,7 +1255,7 @@ class Appium(DriverInterface):
             internal_logger.debug(
                 f"Pressing at percentage coordinates: ({percentage_x}%, {percentage_y}%)"
             )
-            self.press_coordinates(x, y, event_name)
+            self.press_coordinates(x, y, event_name=event_name)
 
     @supported_on(*MOBILE)
     def press_xpath_using_coordinates(self, xpath: str, event_name: Optional[str] = None) -> None:
@@ -1274,7 +1274,7 @@ class Appium(DriverInterface):
             (x1, y1), (x2, y2) = bbox
             x_centre = (x1 + x2) // 2
             y_centre = (y1 + y2) // 2
-            self.tap_at_coordinates(x_centre, y_centre, event_name)
+            self.tap_at_coordinates(x_centre, y_centre, event_name=event_name)
         else:
             internal_logger.debug(
                 f"Bounding box not found for element with xpath: {xpath}"

--- a/optics_framework/engines/drivers/playwright.py
+++ b/optics_framework/engines/drivers/playwright.py
@@ -44,7 +44,7 @@ class Playwright(DriverInterface):
     # =====================================================
 
     def launch_app(self, app_identifier=None, app_activity=None, event_name=None):
-        return run_async(self._launch_app_async(app_identifier, event_name))
+        return run_async(self._launch_app_async(app_identifier, event_name=event_name))
 
     async def _launch_app_async(self, app_identifier, event_name):
         try:
@@ -89,7 +89,7 @@ class Playwright(DriverInterface):
             if self._context is None:
                 # If no context exists, initialize browser first
                 internal_logger.info("[Playwright] No existing context, initializing browser")
-                await self._launch_app_async(None, event_name)
+                await self._launch_app_async(None, event_name=event_name)
 
             # Create a new page (tab) in the existing context
             internal_logger.debug("[Playwright] Creating new tab for %s", app_name)
@@ -110,7 +110,7 @@ class Playwright(DriverInterface):
             raise OpticsError(Code.E0102, str(e), cause=e)
 
     def launch_other_app(self, app_name: str, event_name=None):
-        return run_async(self._launch_other_app_async(app_name, event_name))
+        return run_async(self._launch_other_app_async(app_name, event_name=event_name))
 
     async def _navigate_to(self, url: str):
         """
@@ -173,7 +173,7 @@ class Playwright(DriverInterface):
     # =====================================================
 
     def press_element(self, element: str, repeat: int = 1, event_name=None):
-        run_async(self._press_element_async(element, repeat, event_name))
+        run_async(self._press_element_async(element, repeat, event_name=event_name))
 
     async def _press_element_async(self, element, repeat, event_name):
         # Handle both string selectors and Playwright locator objects

--- a/optics_framework/engines/drivers/selenium.py
+++ b/optics_framework/engines/drivers/selenium.py
@@ -246,7 +246,7 @@ class SeleniumDriver(DriverInterface):
             size = self.driver.get_window_size()
             abs_x = int(size['width'] * percentage_x / 100)
             abs_y = int(size['height'] * percentage_y / 100)
-            self.press_coordinates(abs_x, abs_y, event_name)
+            self.press_coordinates(abs_x, abs_y, event_name=event_name)
         except Exception as e:
             internal_logger.error(f"Failed to click using percentage coordinates: {e}")
             raise

--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -793,7 +793,9 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.detect_and_press(
-            cast(str, element), cast(str, timeout), cast(Optional[str], event_name)
+            element=cast(str, element),
+            timeout=cast(str, timeout),
+            event_name=cast(Optional[str], event_name),
         )
 
     @keyword("Swipe")
@@ -810,11 +812,11 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.swipe(
-            cast(str, coor_x),
-            cast(str, coor_y),
-            cast(str, direction),
-            cast(str, swipe_length),
-            cast(Optional[str], event_name),
+            coor_x=cast(str, coor_x),
+            coor_y=cast(str, coor_y),
+            direction=cast(str, direction),
+            swipe_length=cast(str, swipe_length),
+            event_name=cast(Optional[str], event_name),
         )
 
     @keyword("Swipe By Percentage")
@@ -831,11 +833,11 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.swipe_by_percentage(
-            cast(str, percent_x),
-            cast(str, percent_y),
-            cast(str, direction),
-            cast(str, swipe_length),
-            cast(Optional[str], event_name),
+            percent_x=cast(str, percent_x),
+            percent_y=cast(str, percent_y),
+            direction=cast(str, direction),
+            swipe_length=cast(str, swipe_length),
+            event_name=cast(Optional[str], event_name),
         )
 
     @keyword("Swipe Until Element Appears")
@@ -851,10 +853,10 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.swipe_until_element_appears(
-            cast(str, element),
-            cast(str, direction),
-            cast(str, timeout),
-            cast(Optional[str], event_name),
+            element=cast(str, element),
+            direction=cast(str, direction),
+            timeout=cast(str, timeout),
+            event_name=cast(Optional[str], event_name),
         )
 
     @keyword("Swipe From Element")
@@ -870,10 +872,10 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.swipe_from_element(
-            cast(str, element),
-            cast(str, direction),
-            cast(str, swipe_length),
-            cast(Optional[str], event_name),
+            element=cast(str, element),
+            direction=cast(str, direction),
+            swipe_length=cast(str, swipe_length),
+            event_name=cast(Optional[str], event_name),
         )
 
     @keyword("Scroll")
@@ -887,7 +889,7 @@ class Optics:
         if not self.action_keyword:
             raise ValueError(INVALID_SETUP)
         self.action_keyword.scroll(
-            cast(str, direction), cast(Optional[str], event_name)
+            direction=cast(str, direction), event_name=cast(Optional[str], event_name)
         )
 
     @keyword("Scroll Until Element Appears")

--- a/tests/units/api/test_action_keyword.py
+++ b/tests/units/api/test_action_keyword.py
@@ -124,23 +124,23 @@ class TestPressElementWithIndex:
     def test_coordinate_result_presses_coordinates(self, action_keyword, mock_dependencies):
         with self._mock_locate(action_keyword, (100, 150)):
             action_keyword.press_element("button")
-        mock_dependencies['driver'].press_coordinates.assert_called_once_with(100, 150, None)
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(100, 150, event_name=None)
 
     def test_element_result_presses_element_with_repeat(self, action_keyword, mock_dependencies):
         element_handle = MagicMock()
         with self._mock_locate(action_keyword, element_handle):
             action_keyword.press_element("//button", repeat="3")
-        mock_dependencies['driver'].press_element.assert_called_once_with(element_handle, 3, None)
+        mock_dependencies['driver'].press_element.assert_called_once_with(element_handle, 3, event_name=None)
 
     def test_offset_adjusts_coordinates(self, action_keyword, mock_dependencies):
         with self._mock_locate(action_keyword, (100, 150)):
             action_keyword.press_element("button", offset_x="10", offset_y="20")
-        mock_dependencies['driver'].press_coordinates.assert_called_once_with(110, 170, None)
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(110, 170, event_name=None)
 
     def test_event_name_forwarded_to_driver(self, action_keyword, mock_dependencies):
         with self._mock_locate(action_keyword, (120, 180)):
             action_keyword.press_element("button", event_name="test_event")
-        mock_dependencies['driver'].press_coordinates.assert_called_once_with(120, 180, "test_event")
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(120, 180, event_name="test_event")
 
     def test_aoi_params_passed_to_locate(self, action_keyword, mock_dependencies):
         with self._mock_locate(action_keyword, (200, 250)) as mock_locate:
@@ -148,7 +148,7 @@ class TestPressElementWithIndex:
                 "button", index="1", aoi_x="10", aoi_y="20", aoi_width="50", aoi_height="60"
             )
         mock_locate.assert_called_once_with("button", 10.0, 20.0, 50.0, 60.0, index=1)
-        mock_dependencies['driver'].press_coordinates.assert_called_once_with(200, 250, None)
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(200, 250, event_name=None)
 
     def test_no_located_result_raises_element_not_found(self, action_keyword):
         with patch.object(action_keyword.strategy_manager, 'locate', return_value=[]):
@@ -174,7 +174,7 @@ class TestScreenshotFailureFallback:
             with patch.object(action_keyword.strategy_manager, 'locate', return_value=[mock_locate_result]):
                 action_keyword.press_element("button")
 
-        mock_dependencies['driver'].press_coordinates.assert_called_once_with(100, 150, None)
+        mock_dependencies['driver'].press_coordinates.assert_called_once_with(100, 150, event_name=None)
 
     @patch('optics_framework.common.utils.save_screenshot')
     def test_locate_and_act_skips_save_when_screenshot_raises(
@@ -223,7 +223,7 @@ class TestScreenshotFailureFallback:
         ):
             action_keyword.press_by_percentage("50", "50")
 
-        mock_dependencies['driver'].press_percentage_coordinates.assert_called_once_with(50.0, 50.0, 1, None)
+        mock_dependencies['driver'].press_percentage_coordinates.assert_called_once_with(50.0, 50.0, 1, event_name=None)
         mock_save_screenshot.assert_not_called()
 
 
@@ -432,7 +432,7 @@ class TestSwipeUntilElementAppears:
             action_keyword.swipe_until_element_appears("element", "down", "10")
 
         assert call_count == 2
-        action_keyword.driver.swipe_percentage.assert_called_once_with(10, 50, "down", 25, None)
+        action_keyword.driver.swipe_percentage.assert_called_once_with(10, 50, "down", 25, event_name=None)
 
     @patch('optics_framework.api.action_keyword.time.sleep', return_value=None)
     @patch('optics_framework.api.action_keyword.time.time')

--- a/tests/units/api/test_app_management.py
+++ b/tests/units/api/test_app_management.py
@@ -21,25 +21,27 @@ class TestAppManagement:
         assert app_management.initialise_setup() is None
 
     @pytest.mark.parametrize(
-        "method, args, driver_attr, expected_args, expected_kwargs",
+        "method, args, kwargs, driver_attr, expected_args, expected_kwargs",
         [
-            ("launch_app", ("com.x",), "launch_app", (),
+            ("launch_app", (), {"app_identifier": "com.x"}, "launch_app", (),
              {"app_identifier": "com.x", "app_activity": None, "event_name": None}),
-            ("launch_other_app", ("com.y", "ev"), "launch_other_app", ("com.y", "ev"), {}),
-            ("close_and_terminate_app", (), "terminate", (), {}),
-            ("force_terminate_app", ("com.z", "ev"), "force_terminate_app", ("com.z", "ev"), {}),
-            ("start_appium_session", ("ev",), "launch_app", ("ev",), {}),
-            ("get_driver_session_id", (), "get_driver_session_id", (), {}),
+            ("launch_other_app", ("com.y", "ev"), {}, "launch_other_app", (),
+             {"app_name": "com.y", "event_name": "ev"}),
+            ("close_and_terminate_app", (), {}, "terminate", (), {}),
+            ("force_terminate_app", ("com.z", "ev"), {}, "force_terminate_app", (),
+             {"app_name": "com.z", "event_name": "ev"}),
+            ("start_appium_session", (), {"event_name": "ev"}, "launch_app", (), {"event_name": "ev"}),
+            ("get_driver_session_id", (), {}, "get_driver_session_id", (), {}),
         ],
     )
-    def test_delegates_to_driver(self, app_management, mock_driver, method, args,
+    def test_delegates_to_driver(self, app_management, mock_driver, method, args, kwargs,
                                  driver_attr, expected_args, expected_kwargs):
-        getattr(app_management, method)(*args)
+        getattr(app_management, method)(*args, **kwargs)
         getattr(mock_driver, driver_attr).assert_called_once_with(*expected_args, **expected_kwargs)
 
     def test_launch_app_returns_driver_result(self, app_management, mock_driver):
         mock_driver.launch_app.return_value = "session-123"
-        assert app_management.launch_app("com.x") == "session-123"
+        assert app_management.launch_app(app_identifier="com.x") == "session-123"
 
     def test_get_app_version_without_package(self, app_management, mock_driver):
         mock_driver.get_app_version.return_value = "1.2.3"

--- a/tests/units/common/test_ai_self_heal.py
+++ b/tests/units/common/test_ai_self_heal.py
@@ -525,7 +525,7 @@ class TestActionKeywordWiring:
         ak.strategy_manager.locate = MagicMock(return_value=iter([mock_result]))
 
         assert ak._ai_self_heal("Login", "press_element", (), shot) is True
-        ak.driver.scroll.assert_called_once_with("down", 1000, None)
+        ak.driver.scroll.assert_called_once_with("down", 1000, event_name=None)
         # Healed keyword is recorded as a breadcrumb (may appear more than once —
         # the inner press_element records one, and _log_heal_outcome records another).
         steps = list(ak._recent_steps)


### PR DESCRIPTION
## Summary

AppManagement.start_appium_session was calling the driver's `launch_app` positionally:

`python
self.driver.launch_app(event_name)
`

Since `launch_app`'s signature is `launch_app(self, app_identifier=None, app_activity=None, event_name=None)`, the `event_name` string was being bound to `app_identifier` instead of `event_name`.

## Why it matters

Today this is a silent no-op: `launch_app` only acts when no session exists, where a stray string in `app_identifier` is harmless noise in the capabilities dict.

Once #537 merges, `launch_app` will act on an already-alive session:

`python
elif app_identifier:
    self.launch_other_app(app_identifier, event_name)
`

That forwards the event-name string to `activate_app(...)`, which is not a valid package/bundle id, raising:

`
OpticsError: Failed to launch: <event_name>
`

This would break any suite where **Start Appium Session** runs more than once against a live session (e.g. a second test case in the same `optics execute` batch run, and generated pytest/Robot suites via `optics generate`).

## Fix

`python
def start_appium_session(self, event_name: Optional[str] = None) -> None:
    self.driver.launch_app(event_name=event_name)
`

Updated the parametrized case in `tests/units/api/test_app_management.py` to assert the corrected keyword-argument call shape.

## Testing

`
python -m pytest tests/units/api/test_app_management.py -v
# 11 passed
`

Fixes #538