### PR TITLE
fix/facade forwards the fail flag

### DIFF
--- a/optics_framework/optics.py
+++ b/optics_framework/optics.py
@@ -1098,8 +1098,12 @@ class Optics:
         timeout: fallback_str = "60",
         rule: fallback_str = "any",
         event_name: Optional[fallback_str] = None,
+        fail: Union[bool, str] = True,
     ) -> bool:
-        """Assert the presence of elements."""
+        """Assert the presence of elements.
+
+        :param fail: If True, raise on failure; if False, return False instead.
+        """
         if not self.verifier:
             raise ValueError(INVALID_SETUP)
         return self.verifier.assert_presence(
@@ -1107,6 +1111,7 @@ class Optics:
             timeout_str=cast(str, timeout),
             rule=cast(str, rule),
             event_name=cast(Optional[str], event_name),
+            fail=fail,
         )
 
     @keyword("Assert Visibility")
@@ -1117,8 +1122,12 @@ class Optics:
         timeout: fallback_str = "60",
         rule: fallback_str = "any",
         event_name: Optional[fallback_str] = None,
+        fail: Union[bool, str] = True,
     ) -> bool:
-        """Assert that elements are actually rendered/visible on screen right now."""
+        """Assert that elements are actually rendered/visible on screen right now.
+
+        :param fail: If True, raise on failure; if False, return False instead.
+        """
         if not self.verifier:
             raise ValueError(INVALID_SETUP)
         return self.verifier.assert_visibility(
@@ -1126,6 +1135,7 @@ class Optics:
             timeout_str=cast(str, timeout),
             rule=cast(str, rule),
             event_name=cast(Optional[str], event_name),
+            fail=fail,
         )
 
     @keyword("Validate Screen")


### PR DESCRIPTION
fail exists on Verifier but not on the Optics facade, so no user of the documented Python API can set it. This forwards it through