### PR TITLE
fix/yaml steps with a literal first param

### DIFF
--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -123,17 +123,31 @@ class DataReader(ABC):
         pass
 
     @abstractmethod
-    def read_modules(self, file_path: str) -> dict:
+    def read_modules(
+        self, file_path: str, module_names: Optional[Set[str]] = None
+    ) -> dict:
         """
         Read a file containing module information and return a dictionary mapping
         module names to lists of tuples (module_step, params).
 
         :param file_path: Path to the file.
         :type file_path: str
+        :param module_names: Every module name in the project, for a reader that has to tell a
+            module reference from a keyword. A suite is split across files, so a name defined
+            in one file may be referenced from another.
         :return: A dictionary where keys are module names and values are lists of (module_step, params) tuples.
         :rtype: dict
         """
         pass
+
+    def read_module_names(self, file_path: str) -> Set[str]:
+        """The module names a file defines, so a caller can gather the project-wide set before
+        any step is parsed. The names are the dictionary's keys, which no step parsing affects.
+
+        :param file_path: Path to the file.
+        :return: The module names defined in that file.
+        """
+        return set(self.read_modules(file_path))
 
     @abstractmethod
     def read_elements(self, file_path: Optional[str]) -> dict:
@@ -187,13 +201,17 @@ class CSVDataReader(DataReader):
             test_cases[test_case].append(test_step)
         return test_cases
 
-    def read_modules(self, file_path: str) -> dict:
+    def read_modules(
+        self, file_path: str, module_names: Optional[Set[str]] = None
+    ) -> dict:
         """
         Read a CSV file containing module information and return a dictionary mapping
         module names to lists of tuples (module_step, params).
 
         :param file_path: Path to the modules CSV file.
         :type file_path: str
+        :param module_names: Unused — a CSV keeps each param in its own column, so the keyword
+            name never has to be told from a module reference.
         :return: A dictionary where keys are module names and values are lists of (module_step, params) tuples.
         :rtype: dict
         """
@@ -218,6 +236,15 @@ class CSVDataReader(DataReader):
                 modules[module_name] = []
             modules[module_name].append((keyword, params))
         return modules
+
+    def read_module_names(self, file_path: str) -> Set[str]:
+        """Read only the module_name column, so the project-wide names pass neither parses
+        steps nor repeats the malformed-row warnings the parse pass emits."""
+        return {
+            row["module_name"].strip()
+            for row in self.read_file(file_path)
+            if row.get("module_name") and str(row["module_name"]).strip()
+        }
 
     def read_elements(self, file_path: Optional[str]) -> dict:
         """
@@ -365,21 +392,27 @@ class YAMLDataReader(DataReader):
                 module_steps.append((keyword, params))
         return module_steps
 
-    def read_modules(self, file_path: str) -> Dict[str, List[Tuple[str, List[str]]]]:
+    def read_modules(
+        self, file_path: str, module_names: Optional[Set[str]] = None
+    ) -> Dict[str, List[Tuple[str, List[str]]]]:
         """
         Read a YAML file containing module information and return a dictionary mapping
         module names to lists of tuples (module_step, params).
 
         :param file_path: Path to the YAML file.
         :type file_path: str
+        :param module_names: Every module name in the project. Without it only this file's own
+            names are known, and a step referencing a keyword-shaped module defined in another
+            file — ``Sleep Well`` — would be read as the keyword ``Sleep``.
         :return: A dictionary where keys are module names and values are lists of (module_step, params) tuples.
         :rtype: dict
         """
         data = self.read_file(file_path)
         modules = {}
         modules_data = data.get("Modules", [])
-        # Collected before any step is parsed: a step may reference a module defined below it.
-        module_names = {
+        # This file's own names as well, gathered before any step is parsed: a step may
+        # reference a module defined below it.
+        known_modules = set(module_names or ()) | {
             str(name).strip()
             for module in modules_data
             for name in module
@@ -394,9 +427,20 @@ class YAMLDataReader(DataReader):
                         f"Warning: Module '{name}' is empty or invalid"
                     )
                     continue
-                modules[name] = self._process_module_steps(steps, module_names)
+                modules[name] = self._process_module_steps(steps, known_modules)
 
         return modules
+
+    def read_module_names(self, file_path: str) -> Set[str]:
+        """Read only the module keys, so the project-wide names pass does not parse, and
+        warn about, every step that the parse pass reads again."""
+        data = self.read_file(file_path)
+        return {
+            str(name).strip()
+            for module in data.get("Modules", [])
+            for name in module
+            if str(name).strip()
+        }
 
     def read_elements(self, file_path: Optional[str]) -> dict:
         """

--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -3,7 +3,8 @@ import yaml
 import re
 import inspect
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Dict, Union, List, Tuple, cast
+from functools import lru_cache
+from typing import Callable, Optional, Dict, Set, Union, List, Tuple, cast
 from optics_framework.common.logging_config import internal_logger
 from optics_framework.common.models import (
     ApiData,
@@ -11,6 +12,40 @@ from optics_framework.common.models import (
     ExpectedResultDefinition,
 )
 from optics_framework.common.utils import unescape_csv_value
+
+
+def _keyword_slug(name: str) -> str:
+    return "_".join(name.replace("_", " ").split()).lower()
+
+
+# The SDK/Robot facade (optics.py) exposes two keyword names the runtime map does not:
+# an alias of press_element and the session teardown. They still belong in the catalogue,
+# so a suite using one reports the unknown keyword instead of dispatching the words after
+# it to the shorter runtime keyword that shares their prefix.
+_FACADE_KEYWORD_SLUGS = frozenset({"press_element_with_index", "quit"})
+
+
+@lru_cache(maxsize=1)
+def _keyword_names() -> frozenset:
+    import importlib
+    import pkgutil
+
+    import optics_framework.api
+
+    names = set()
+    package = optics_framework.api
+    for _, module_name, _ in pkgutil.iter_modules(package.__path__):
+        module = importlib.import_module(f"{package.__name__}.{module_name}")
+        for class_name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__ or class_name.startswith("_"):
+                continue
+            names.update(
+                attr
+                for attr in dir(cls)
+                if not attr.startswith("_") and callable(getattr(cls, attr))
+            )
+    names.update(_FACADE_KEYWORD_SLUGS)
+    return frozenset(names)
 
 
 class DataReader(ABC):
@@ -276,38 +311,56 @@ class YAMLDataReader(DataReader):
                 test_cases[name] = [step.strip() for step in steps if step.strip()]
         return test_cases
 
-    def _parse_module_step(self, step: str) -> Tuple[str, List[str]]:
+    def _parse_module_step(
+        self, step: str, module_names: Optional[Set[str]] = None
+    ) -> Tuple[str, List[str]]:
         """
         Parse a module step to extract the keyword and parameters.
 
         :param step: The module step string.
+        :param module_names: Names defined in the same file, which win over the catalogue — a
+            module may be called ``Sleep Well`` without its first word being read as a keyword.
         :return: Tuple of (keyword, list of parameters).
         """
         step = step.strip()
         if not step:
             return "", []
 
-        param_pattern = re.compile(r"\${[^{}]+}")
-        params = param_pattern.findall(step)
-        if not params:
+        if module_names and step in module_names:
             return step, []
 
-        param_start = step.index(params[0])
-        keyword = step[:param_start].strip()
-        param_str = step[param_start:].strip()
-        param_parts = param_str.split()
-        return keyword, [p.strip() for p in param_parts if p.strip()]
+        words = step.split()
+        catalogue = _keyword_names()
+        # longest first, so "Enter Text hi" is not read as "Enter"
+        for count in range(len(words), 0, -1):
+            name = " ".join(words[:count])
+            if _keyword_slug(name) in catalogue:
+                return name, words[count:]
 
-    def _process_module_steps(self, steps: List[str]) -> List[Tuple[str, List[str]]]:
+        param_pattern = re.compile(r"\${[^{}]+}")
+        params = param_pattern.findall(step)
+        if params:
+            param_start = step.index(params[0])
+            keyword = step[:param_start].strip()
+            param_str = step[param_start:].strip()
+            param_parts = param_str.split()
+            return keyword, [p.strip() for p in param_parts if p.strip()]
+
+        return step, []
+
+    def _process_module_steps(
+        self, steps: List[str], module_names: Optional[Set[str]] = None
+    ) -> List[Tuple[str, List[str]]]:
         """
         Process a list of module steps into a list of (keyword, params) tuples.
 
         :param steps: List of step strings.
+        :param module_names: Names defined in the same file, passed through to the step parser.
         :return: List of (keyword, params) tuples.
         """
         module_steps = []
         for step in steps:
-            keyword, params = self._parse_module_step(step)
+            keyword, params = self._parse_module_step(step, module_names)
             if keyword:
                 module_steps.append((keyword, params))
         return module_steps
@@ -325,6 +378,13 @@ class YAMLDataReader(DataReader):
         data = self.read_file(file_path)
         modules = {}
         modules_data = data.get("Modules", [])
+        # Collected before any step is parsed: a step may reference a module defined below it.
+        module_names = {
+            str(name).strip()
+            for module in modules_data
+            for name in module
+            if str(name).strip()
+        }
 
         for module in modules_data:
             for name, steps in module.items():
@@ -334,7 +394,7 @@ class YAMLDataReader(DataReader):
                         f"Warning: Module '{name}' is empty or invalid"
                     )
                     continue
-                modules[name] = self._process_module_steps(steps)
+                modules[name] = self._process_module_steps(steps, module_names)
 
         return modules
 

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -726,9 +726,15 @@ class BaseRunner:
 
     def _load_modules(self, module_files):
         self.modules_data: ModuleData = ModuleData()
+        # Every module name first, across every file: a YAML step referencing a module is told
+        # from a keyword call by name, and the module it names may be defined in another file.
+        module_names = set()
         for file_path in module_files:
             reader = self.csv_reader if file_path.endswith(".csv") else self.yaml_reader
-            modules = reader.read_modules(file_path)
+            module_names |= reader.read_module_names(file_path)
+        for file_path in module_files:
+            reader = self.csv_reader if file_path.endswith(".csv") else self.yaml_reader
+            modules = reader.read_modules(file_path, module_names)
             for name, definition in modules.items():
                 if self.modules_data.get_module_definition(name):
                     internal_logger.warning(

--- a/tests/units/common/test_data_reader.py
+++ b/tests/units/common/test_data_reader.py
@@ -139,10 +139,59 @@ class TestYAMLDataReader:
             ("Enter Text ${f} hello", ("Enter Text", ["${f}", "hello"])),
             ("Sleep", ("Sleep", [])),
             ("", ("", [])),
+            # The catalogue ends the keyword name, so a first param that is a plain value is
+            # no longer swallowed into it.
+            ("Swipe 1000 300 up", ("Swipe", ["1000", "300", "up"])),
+            ("Sleep 5", ("Sleep", ["5"])),
+            ("Swipe By Percentage 50 50 20", ("Swipe By Percentage", ["50", "50", "20"])),
+            # The longest run wins, or "Enter Text hi" would parse as "Enter".
+            ("Enter Text hi", ("Enter Text", ["hi"])),
+            # A facade alias the runtime map lacks is a catalogue name too, or the line
+            # is dispatched to "Press Element" with "With Index ..." as its params.
+            ("Press Element With Index ${el} 2", ("Press Element With Index", ["${el}", "2"])),
+            # Slug form is a keyword too, whatever the params look like.
+            ("press_element ${btn}", ("press_element", ["${btn}"])),
+            ("enter_text ${f} hello", ("enter_text", ["${f}", "hello"])),
+            ("swipe_by_percentage 50 50 20", ("swipe_by_percentage", ["50", "50", "20"])),
+            ("swipe 1000 300 up", ("swipe", ["1000", "300", "up"])),
+            # A name the catalogue does not know still reports the name alone, so the runner's
+            # "did you mean" hint has something to work with.
+            ("Press Elemnt ${btn}", ("Press Elemnt", ["${btn}"])),
+            # Failing both, the line is returned whole — how a step referencing another module
+            # has always reached the runner.
+            ("Login Flow", ("Login Flow", [])),
         ],
     )
     def test_parse_module_step(self, step, expected):
         assert self.reader._parse_module_step(step) == expected
+
+    def test_parse_module_step_prefers_a_module_of_the_same_name(self):
+        """A module may be named after a keyword's first word without being that keyword."""
+        assert self.reader._parse_module_step("Sleep Well", {"Sleep Well"}) == ("Sleep Well", [])
+        assert self.reader._parse_module_step("Sleep Well") == ("Sleep", ["Well"])
+
+    def test_read_modules_keeps_a_literal_first_param(self, tmp_path):
+        """The whole point, through the public reader: the params survive the round trip."""
+        path = _write(
+            tmp_path,
+            "m.yaml",
+            "Modules:\n  - M:\n      - Swipe 1000 300 up\n      - Press Element ${btn}\n",
+        )
+        assert self.reader.read_modules(path) == {
+            "M": [("Swipe", ["1000", "300", "up"]), ("Press Element", ["${btn}"])]
+        }
+
+    def test_read_modules_lets_a_step_reference_a_module_named_like_a_keyword(self, tmp_path):
+        """Module names come from the whole file, so one defined below is still recognised."""
+        path = _write(
+            tmp_path,
+            "m.yaml",
+            "Modules:\n  - Caller:\n      - Sleep Well\n  - Sleep Well:\n      - Sleep 1\n",
+        )
+        assert self.reader.read_modules(path) == {
+            "Caller": [("Sleep Well", [])],
+            "Sleep Well": [("Sleep", ["1"])],
+        }
 
     def test_read_elements_single_and_list_values(self, tmp_path):
         path = _write(

--- a/tests/units/common/test_data_reader.py
+++ b/tests/units/common/test_data_reader.py
@@ -76,6 +76,16 @@ class TestCSVDataReader:
         path = _write(tmp_path, "m.csv", "module_name,module_step,param_1\nM,Launch App,\n,Sleep,1\nM,,2\n")
         assert self.reader.read_modules(path) == {"M": [("Launch App", [])]}
 
+    def test_read_module_names_does_not_parse_steps(self, tmp_path, monkeypatch):
+        """The names pass reads the column only, so read_modules parses and warns once, later."""
+        monkeypatch.setattr(
+            CSVDataReader,
+            "read_modules",
+            lambda self, file_path, module_names=None: pytest.fail("names pass parsed the file"),
+        )
+        path = _write(tmp_path, "m.csv", "module_name,module_step\nM,Launch App\n,Bad,row\n")
+        assert self.reader.read_module_names(path) == {"M"}
+
     def test_read_elements_supports_multiple_ids_for_fallback(self, tmp_path):
         path = _write(
             tmp_path, "e.csv",
@@ -180,6 +190,27 @@ class TestYAMLDataReader:
         assert self.reader.read_modules(path) == {
             "M": [("Swipe", ["1000", "300", "up"]), ("Press Element", ["${btn}"])]
         }
+
+    def test_read_modules_takes_module_names_from_other_files(self, tmp_path):
+        """A suite is split across files, so the name a step references may be defined in
+        another one — without the project-wide set it would read as a keyword call."""
+        caller = _write(tmp_path, "a.yaml", "Modules:\n  - Caller:\n      - Sleep Well\n")
+        defined = _write(tmp_path, "b.yaml", "Modules:\n  - Sleep Well:\n      - Sleep 1\n")
+        names = self.reader.read_module_names(caller) | self.reader.read_module_names(defined)
+        assert names == {"Caller", "Sleep Well"}
+        assert self.reader.read_modules(caller, names) == {"Caller": [("Sleep Well", [])]}
+
+    def test_read_module_names_does_not_parse_steps(self, tmp_path, monkeypatch):
+        """The names pass reads the keys only, so read_modules parses and warns once, later."""
+        monkeypatch.setattr(
+            YAMLDataReader,
+            "read_modules",
+            lambda self, file_path, module_names=None: pytest.fail("names pass parsed the file"),
+        )
+        path = _write(
+            tmp_path, "m.yaml", "Modules:\n  - Empty:\n  - M:\n      - Swipe 1000 300 up\n"
+        )
+        assert self.reader.read_module_names(path) == {"Empty", "M"}
 
     def test_read_modules_lets_a_step_reference_a_module_named_like_a_keyword(self, tmp_path):
         """Module names come from the whole file, so one defined below is still recognised."""


### PR DESCRIPTION
## What

 - _parse_module_step resolves a step's keyword from the keyword catalogue (optics_framework.api) instead of from the first ${...} in the line. Longest matching run of leading words wins, the rest are params, and written or slug form both resolve.
 - read_modules gathers the file's module names up front and passes them in, so they win over the catalogue.

 ## Why

 A keyword whose first param is a plain value has no ${...} to split on, so the whole line became the keyword name and the params were lost — 'Swipe 1000 300 up' → ('Swipe 1000 300 up', []). That is ~15 of the 44 parameterised keywords (Swipe, Sleep, Scroll, …), unusable from a YAML suite. CSV is unaffected; its params sit in their own columns.

## Non-obvious choices

 - The ${...} scan stays as a fallback for names the catalogue does not know, so a misspelt keyword still reports the name alone and _suggest_keyword can offer a hint.
 - Module names beat the catalogue, or a module called Sleep Well loses its first word to Sleep.
 - Catalogue is imported lazily and lru_cached — a reader has no other reason to load the keyword surface.
 - Steps that parse today parse identically: where a ${...} exists, both rules agree.

## Validation

 test_data_reader.py 60 passed, covering literal first params, slug form, longest-run-wins, the unknown-keyword fallback, module precedence, and two through read_modules. Full unit suite 25 failed / 1121 passed — the 25 are pre-existing on main and unrelated.