### PR TITLE
feat(runner): let a quoted value hold a space in a yaml step

### DIFF
--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -14,6 +14,45 @@ from optics_framework.common.models import (
 from optics_framework.common.utils import unescape_csv_value
 
 
+# A quoted run is one token. Applied to the whole step, so a locator keeps the quotes inside
+# it (`//button[@id="save"]`) while a value written as one (`text="a b"`) gives them up.
+_TOKEN = re.compile(r'''(?:[^\s"']|"[^"]*"|'[^']*')+''')
+_WRAPPED = re.compile(r'''^(?P<q>["'])(?P<body>.*)(?P=q)$''', re.S)
+
+
+def _unbalanced_quote(step: str) -> bool:
+    """Whether the token pattern would skip a non-whitespace character, which only an
+    unpaired quote makes it do."""
+    gap = 0
+    for match in _TOKEN.finditer(step):
+        if step[gap : match.start()].strip():
+            return True
+        gap = match.end()
+    return bool(step[gap:].strip())
+
+
+def _tokens(step: str) -> List[str]:
+    """Whitespace-split, except that a quoted run holds together and a value written entirely
+    in quotes is unwrapped — which is the only way a param can contain a space.
+
+    An unbalanced quote falls back to `.split()`: the pattern would drop the quote and split
+    anyway, so `text=it's fine` keeps reading as it always has."""
+    if _unbalanced_quote(step):
+        return step.split()
+
+    out = []
+    for token in _TOKEN.findall(step):
+        key, sep, value = token.partition("=")
+        found = _WRAPPED.match(value if sep else token)
+        if not found:
+            out.append(token)
+        elif sep:
+            out.append(f"{key}={found['body']}")
+        else:
+            out.append(found["body"])
+    return out
+
+
 def _keyword_slug(name: str) -> str:
     return "_".join(name.replace("_", " ").split()).lower()
 
@@ -356,7 +395,7 @@ class YAMLDataReader(DataReader):
         if module_names and step in module_names:
             return step, []
 
-        words = step.split()
+        words = _tokens(step)
         catalogue = _keyword_names()
         # longest first, so "Enter Text hi" is not read as "Enter"
         for count in range(len(words), 0, -1):
@@ -369,8 +408,7 @@ class YAMLDataReader(DataReader):
         if params:
             param_start = step.index(params[0])
             keyword = step[:param_start].strip()
-            param_str = step[param_start:].strip()
-            param_parts = param_str.split()
+            param_parts = _tokens(step[param_start:].strip())
             return keyword, [p.strip() for p in param_parts if p.strip()]
 
         return step, []

--- a/tests/units/common/test_data_reader.py
+++ b/tests/units/common/test_data_reader.py
@@ -175,6 +175,50 @@ class TestYAMLDataReader:
     def test_parse_module_step(self, step, expected):
         assert self.reader._parse_module_step(step) == expected
 
+    @pytest.mark.parametrize(
+        "step, expected",
+        [
+            # The only way a param can hold a space: a value written entirely in quotes.
+            ('Enter Text ${f} text="two words"', ("Enter Text", ["${f}", "text=two words"])),
+            ("Enter Text ${f} text='two words'", ("Enter Text", ["${f}", "text=two words"])),
+            ('Enter Text ${f} "two words"', ("Enter Text", ["${f}", "two words"])),
+            # A locator's own quotes are inside the value, so they stay — this is what
+            # `shlex.split` would have eaten.
+            (
+                'Press Element //button[@id="save"] repeat=2',
+                ("Press Element", ['//button[@id="save"]', "repeat=2"]),
+            ),
+            ('Press Element //*[@text="a b"]', ("Press Element", ['//*[@text="a b"]'])),
+            # Unquoted lines split as they always have.
+            ("Enter Text ${f} plain words here", ("Enter Text", ["${f}", "plain", "words", "here"])),
+            # An apostrophe is not an unbalanced quote, so a double-quoted value keeps its
+            # space, and the other quote character inside a value is not special either.
+            (
+                'Enter Text ${f} text="Bob\'s file"',
+                ("Enter Text", ["${f}", "text=Bob's file"]),
+            ),
+            (
+                "Enter Text ${f} text='say \"hi\" now'",
+                ("Enter Text", ["${f}", 'text=say "hi" now']),
+            ),
+            # An unbalanced quote falls back rather than dropping the quote and splitting.
+            ('Enter Text ${f} text="abc', ("Enter Text", ["${f}", 'text="abc'])),
+            ("Enter Text ${f} it's fine", ("Enter Text", ["${f}", "it's", "fine"])),
+        ],
+    )
+    def test_parse_module_step_honours_quoted_params(self, step, expected):
+        assert self.reader._parse_module_step(step) == expected
+
+    def test_read_modules_keeps_a_quoted_space(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "m.yaml",
+            'Modules:\n  - M:\n      - Enter Text ${f} text="two words"\n',
+        )
+        assert self.reader.read_modules(path) == {
+            "M": [("Enter Text", ["${f}", "text=two words"])]
+        }
+
     def test_parse_module_step_prefers_a_module_of_the_same_name(self):
         """A module may be named after a keyword's first word without being that keyword."""
         assert self.reader._parse_module_step("Sleep Well", {"Sleep Well"}) == ("Sleep Well", [])


### PR DESCRIPTION
Rebased onto main after #547 merged, so this PR is now just the two quoted-params commits.

## What

`_tokens()` splits a step on whitespace *outside* quotes and unwraps a value written entirely in quotes. Used by both places `_parse_module_step` splits.

## Why

A param cannot hold a space today: params are whitespace-split after PyYAML has already unquoted the scalar, so neither `- 'Enter Text ${f} text=a b'` nor `text="a b"` survives. It is the last thing the YAML form cannot express that CSV can.

## Non-obvious choices

- Only a fully quoted value is unwrapped: `text="a b"` gives its quotes up, `//button[@id="save"]` keeps them.
- `shlex.split` is wrong here — posix mode returns `//button[@id=save]` and breaks double-quoted locators.
- A step the tokenizer cannot cover, i.e. one with an unbalanced quote, falls back to `.split()`; the pattern alone would drop the quote and split anyway.
- `split_params_by_signature` and `is_keyword_param` need no change: unwrapping happens first.

## Validation

New cases in `test_data_reader.py`: quoted spaces (named and positional), locators keeping inner quotes, apostrophes inside quoted values, unquoted and unbalanced lines unchanged, one round trip through `read_modules`. Suite: 25 failed / 1131 passed, the 25 pre-existing on `main`.

Nothing emits quotes yet — the LSP and the app-studio pane must learn the same rule before either writes one.
