### PR TITLE
fix: bound command output embedded in app version errors

### DIFF
--- a/optics_framework/engines/drivers/appium.py
+++ b/optics_framework/engines/drivers/appium.py
@@ -29,6 +29,20 @@ from optics_framework.engines.drivers.appium_platforms import (
 )
 from optics_framework.common.error import OpticsError, Code
 
+_MAX_ERROR_OUTPUT_LINES = 20
+
+
+def _summarize_command_output(output: str, max_lines: int = _MAX_ERROR_OUTPUT_LINES) -> str:
+    """Cap command output embedded in error messages so one failure can't flood the log."""
+    lines = [line for line in (output or "").splitlines() if line.strip()]
+    if not lines:
+        return "<no output>"
+    if len(lines) <= max_lines:
+        return "\n".join(lines)
+    half = max_lines // 2
+    omitted = len(lines) - max_lines
+    return "\n".join([*lines[:half], f"… ({omitted} lines omitted)", *lines[-half:]])
+
 
 class Appium(DriverInterface):
     DEPENDENCY_TYPE = "driver_sources"
@@ -630,17 +644,25 @@ class Appium(DriverInterface):
                     return appver
 
         except Exception as e:
+            output = getattr(e, "output", "") or output
             internal_logger.info(f"Error executing adb command {dumpsys_cmd}: {e}")
             raise OpticsError(
                 Code.E0401,
-                message=f"Error executing adb command {dumpsys_cmd}: {e}. Received output = {output}.",
+                message=(
+                    f"Error executing adb command {dumpsys_cmd}: {e}. "
+                    f"Output:\n{_summarize_command_output(output)}"
+                ),
                 details=str(e),
                 cause=e
             ) from e
 
         raise OpticsError(
             Code.E0401,
-            message=f"Could not find versionName for package: {app_package}. Received output = {output}"
+            message=(
+                f"Could not find versionName for package: {app_package} in "
+                f"'{' '.join(dumpsys_cmd)}' output.\n"
+                f"Output:\n{_summarize_command_output(output)}"
+            )
         )
 
     def _get_ios_app_version(self, bundle_id_override: Optional[str] = None) -> str:
@@ -675,7 +697,10 @@ class Appium(DriverInterface):
         except Exception as e:
             raise OpticsError(
                 Code.E0401,
-                message=f"ideviceinstaller command failed: {e}. Output: {output}",
+                message=(
+                    f"ideviceinstaller command failed: {e}. "
+                    f"Output:\n{_summarize_command_output(output)}"
+                ),
                 details=str(e),
                 cause=e,
             ) from e
@@ -693,7 +718,10 @@ class Appium(DriverInterface):
 
         raise OpticsError(
             Code.E0401,
-            message=f"Could not find bundle '{bundle_id}' in ideviceinstaller output. Output: {output}",
+            message=(
+                f"Could not find bundle '{bundle_id}' in ideviceinstaller output.\n"
+                f"Output:\n{_summarize_command_output(output)}"
+            ),
         )
 
     def initialise_setup(self) -> None:


### PR DESCRIPTION
## What

- Add `_summarize_command_output()` in `engines/drivers/appium.py`: caps embedded command output at 20 non-blank lines (head + tail + `… (N lines omitted)` marker), or `<no output>` when empty.
- Apply it to all four `E0401` messages that previously embedded raw command output: Android `pm dump` version-not-found, adb command failure, iOS `ideviceinstaller` command failure, and iOS bundle-not-found.

## Why

A missing `versionName` on a real device produced an `E0401` whose message carried the complete output of `adb shell pm dump <package>`. 







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65923254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the previous testing concern fully addressed and no new findings.

<details><summary>Summary</summary>

Bounds command output embedded in Appium application-version errors and adds focused regression coverage.
- Summarizes non-blank output using retained head and tail sections with an omission marker.
- Uses `<no output>` for empty command output.
- Applies bounded diagnostics to Android and iOS command-failure and version-not-found paths.
- Tests summarization boundaries and all affected E0401 paths.
</details>

<sub>Reviews (4) · Last reviewed commit: ["test(appium): cover command-output trunc..."](https://github.com/mozarkai/optics-framework/commit/ce946da1134207d3ffd4391ccdc8ab646a3f07e8)</sub>

<!-- /greptile_comment -->