### PR TITLE
fix(runner): stop variable-bearing yaml steps dispatching to a shorter keyword

### DIFF
--- a/optics_framework/common/runner/data_reader.py
+++ b/optics_framework/common/runner/data_reader.py
@@ -35,6 +35,10 @@ def _tokens(step: str) -> List[str]:
     """Whitespace-split, except that a quoted run holds together and a value written entirely
     in quotes is unwrapped — which is the only way a param can contain a space.
 
+    Unwrapped whatever the value holds, not only when it holds a space: an editor writing
+    every param as `name="value"` would otherwise hand the keyword the quotes as well, and
+    `index="2"` would arrive as the string `"2"`.
+
     An unbalanced quote falls back to `.split()`: the pattern would drop the quote and split
     anyway, so `text=it's fine` keeps reading as it always has."""
     if _unbalanced_quote(step):
@@ -60,31 +64,138 @@ def _keyword_slug(name: str) -> str:
 # The SDK/Robot facade (optics.py) exposes two keyword names the runtime map does not:
 # an alias of press_element and the session teardown. They still belong in the catalogue,
 # so a suite using one reports the unknown keyword instead of dispatching the words after
-# it to the shorter runtime keyword that shares their prefix.
-_FACADE_KEYWORD_SLUGS = frozenset({"press_element_with_index", "quit"})
+# it to the shorter runtime keyword that shares their prefix. Their arity is written out
+# because reflection only walks the api classes.
+_FACADE_KEYWORD_SLUGS = {"press_element_with_index": 3, "quit": 0}
 
 
-@lru_cache(maxsize=1)
-def _keyword_names() -> frozenset:
+def _arity(method) -> Optional[int]:
+    """How many params a keyword takes, or nothing when it takes any number. Unreadable
+    signatures answer "any number" so a keyword is never rejected for the wrong reason."""
+    try:
+        parameters = list(inspect.signature(method).parameters.values())
+    except (TypeError, ValueError):
+        return None
+
+    count = 0
+    for parameter in parameters:
+        if parameter.name == "self":
+            continue
+        if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            return None
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            count += 1
+    return count
+
+
+def _catalogue_classes(package) -> List[type]:
+    """Every public class the package's modules define (not merely re-export)."""
     import importlib
     import pkgutil
 
-    import optics_framework.api
-
-    names = set()
-    package = optics_framework.api
+    classes = []
     for _, module_name, _ in pkgutil.iter_modules(package.__path__):
         module = importlib.import_module(f"{package.__name__}.{module_name}")
         for class_name, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ != module.__name__ or class_name.startswith("_"):
-                continue
-            names.update(
-                attr
-                for attr in dir(cls)
-                if not attr.startswith("_") and callable(getattr(cls, attr))
-            )
-    names.update(_FACADE_KEYWORD_SLUGS)
-    return frozenset(names)
+            if cls.__module__ == module.__name__ and not class_name.startswith("_"):
+                classes.append(cls)
+    return classes
+
+
+def _class_keyword_entries(cls) -> Dict[str, Optional[int]]:
+    """Every public callable a class exposes, against the number of params it takes."""
+    entries: Dict[str, Optional[int]] = {}
+    for attr in dir(cls):
+        if attr.startswith("_"):
+            continue
+        method = getattr(cls, attr)
+        if callable(method):
+            entries[attr] = _arity(method)
+    return entries
+
+
+@lru_cache(maxsize=1)
+def _keyword_catalogue() -> Dict[str, Optional[int]]:
+    """Every keyword slug the runtime registers, against the number of params it takes."""
+    import optics_framework.api
+
+    catalogue: Dict[str, Optional[int]] = {}
+    for cls in _catalogue_classes(optics_framework.api):
+        catalogue.update(_class_keyword_entries(cls))
+    catalogue.update(_FACADE_KEYWORD_SLUGS)
+    return catalogue
+
+
+def _keyword_names() -> frozenset:
+    return frozenset(_keyword_catalogue())
+
+
+def _matched_module_name(step: str, module_names: Set[str]) -> Optional[str]:
+    if step in module_names:
+        return step
+    step_slug = _keyword_slug(step)
+    for name in sorted(module_names, key=str):
+        name = str(name)
+        if "${" not in name and _keyword_slug(name) == step_slug:
+            return name
+    return None
+
+
+def _split_at_variable(step: str) -> Optional[Tuple[str, List[str]]]:
+    """The legacy split, for a step the catalogue cannot claim: the keyword is everything
+    before the first token holding a `${...}`.
+
+    Split on the token and not on the `${` itself, or `Press Element text=Login
+    timeout=${t}` is cut through the middle and `text=Login timeout=` is read as part of
+    the keyword name. Params are left exactly as `_tokens` returned them, so a quoted
+    value keeps the spaces it was quoted for."""
+    words = _tokens(step)
+    for index, word in enumerate(words):
+        if "${" in word:
+            return " ".join(words[:index]), words[index:]
+    return None
+
+
+# A word that could be part of a keyword's name: letters, and nothing else. A param that
+# is a number, a `${...}`, a `name=value`, a quoted value or a locator is none of these.
+_NAME_WORD = re.compile(r"^[A-Za-z][A-Za-z_]*$")
+
+
+def _mistyped(name: str, params: List[str]) -> bool:
+    """Whether a catalogue match is really the front half of a misspelt longer keyword.
+
+    `Swipe By Percent ${x} ${y}` matches `swipe`, leaving `By` and `Percent` as params —
+    which the runner would then dispatch, silently doing the wrong thing instead of
+    reporting an unknown keyword. Two exact signals, no fuzzy matching, and both need the
+    next param to be a bare word: the word continues a name the catalogue knows
+    (`swipe by` -> `swipe by percentage`), or the match cannot hold this many params
+    (`Scroll To Element foo` gives `scroll` three, and it takes two).
+
+    A keyword whose first param really is a bare word is unaffected: nothing extends
+    `press element login`, and `press element` takes ten params."""
+    if not params or not _NAME_WORD.match(params[0]):
+        return False
+
+    catalogue = _keyword_catalogue()
+    extended = _keyword_slug(f"{name} {params[0]}") + "_"
+    if any(slug.startswith(extended) for slug in catalogue):
+        return True
+
+    limit = catalogue.get(_keyword_slug(name))
+    return limit is not None and len(params) > limit
+
+
+def _catalogue_match(step: str) -> Optional[Tuple[str, List[str]]]:
+    words = _tokens(step)
+    catalogue = _keyword_names()
+    for count in range(len(words), 0, -1):
+        name = " ".join(words[:count])
+        if _keyword_slug(name) in catalogue:
+            return name, words[count:]
+    return None
 
 
 class DataReader(ABC):
@@ -384,32 +495,27 @@ class YAMLDataReader(DataReader):
         Parse a module step to extract the keyword and parameters.
 
         :param step: The module step string.
-        :param module_names: Names defined in the same file, which win over the catalogue — a
-            module may be called ``Sleep Well`` without its first word being read as a keyword.
+        :param module_names: Module names that win over the keyword catalogue.
         :return: Tuple of (keyword, list of parameters).
         """
         step = step.strip()
         if not step:
             return "", []
 
-        if module_names and step in module_names:
-            return step, []
+        if module_names:
+            matched = _matched_module_name(step, module_names)
+            if matched is not None:
+                return matched, []
 
-        words = _tokens(step)
-        catalogue = _keyword_names()
-        # longest first, so "Enter Text hi" is not read as "Enter"
-        for count in range(len(words), 0, -1):
-            name = " ".join(words[:count])
-            if _keyword_slug(name) in catalogue:
-                return name, words[count:]
+        # The catalogue answers first, or a keyword whose first param is a plain value has
+        # nothing to split on and `Sleep 5` reads as a keyword named `sleep 5`.
+        match = _catalogue_match(step)
+        if match is not None and not _mistyped(*match):
+            return match
 
-        param_pattern = re.compile(r"\${[^{}]+}")
-        params = param_pattern.findall(step)
-        if params:
-            param_start = step.index(params[0])
-            keyword = step[:param_start].strip()
-            param_parts = _tokens(step[param_start:].strip())
-            return keyword, [p.strip() for p in param_parts if p.strip()]
+        split = _split_at_variable(step)
+        if split is not None:
+            return split
 
         return step, []
 
@@ -473,9 +579,13 @@ class YAMLDataReader(DataReader):
         """Read only the module keys, so the project-wide names pass does not parse, and
         warn about, every step that the parse pass reads again."""
         data = self.read_file(file_path)
+        modules_data = data.get("Modules", [])
+        if not isinstance(modules_data, list):
+            return set()
         return {
             str(name).strip()
-            for module in data.get("Modules", [])
+            for module in modules_data
+            if isinstance(module, dict)
             for name in module
             if str(name).strip()
         }

--- a/optics_framework/helper/execute.py
+++ b/optics_framework/helper/execute.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import shutil
 import socket
@@ -32,6 +33,23 @@ from optics_framework.common.models import (
     TemplateData,
     ErrorDefinitions,
 )
+
+
+def _reader_accepts_module_names(reader) -> bool:
+    try:
+        parameters = inspect.signature(reader.read_modules).parameters
+    except (TypeError, ValueError):
+        return False
+    return "module_names" in parameters
+
+
+def _read_module_names(reader, file_path) -> Set[str]:
+    read_names = getattr(reader, "read_module_names", None)
+    if read_names is not None:
+        return read_names(file_path)
+    if _reader_accepts_module_names(reader):
+        return set(reader.read_modules(file_path, None))
+    return set(reader.read_modules(file_path))
 
 
 def discover_templates(project_path: str) -> TemplateData:
@@ -731,10 +749,14 @@ class BaseRunner:
         module_names = set()
         for file_path in module_files:
             reader = self.csv_reader if file_path.endswith(".csv") else self.yaml_reader
-            module_names |= reader.read_module_names(file_path)
+            module_names |= _read_module_names(reader, file_path)
         for file_path in module_files:
             reader = self.csv_reader if file_path.endswith(".csv") else self.yaml_reader
-            modules = reader.read_modules(file_path, module_names)
+            modules = (
+                reader.read_modules(file_path, module_names)
+                if _reader_accepts_module_names(reader)
+                else reader.read_modules(file_path)
+            )
             for name, definition in modules.items():
                 if self.modules_data.get_module_definition(name):
                     internal_logger.warning(


### PR DESCRIPTION
## Problem

#547 resolves a YAML step's keyword from the keyword catalogue before splitting on `${...}`. A misspelled multi-word keyword whose prefix is itself a keyword now dispatches to the shorter keyword, losing the unknown-keyword error and its "did you mean" hint:

| YAML step | before #547 | main today |
|---|---|---|
| `Swipe By Percent ${x} ${y}` | `Swipe By Percent` -> *Did you mean 'Swipe By Percentage'?* | `Swipe` + `["By","Percent",...]` |
| `Enter Text Using Keybord ${f} hi` | `Enter Text Using Keybord` -> suggestion | `Enter Text` + `["Using","Keybord",...]` |
| `Press Element With Indx ${el} 2` | `Press Element With Indx` -> suggestion | `Press Element` + `["With","Indx",...]` |

`optics dry_run` reports PASS for these typos, and the runtime failure becomes a param/type error instead of the hint. #548 also unwraps every fully-quoted value (`text="hello"` -> `text=hello`), changing params that previously survived verbatim.

## Fix

- Variable-bearing steps keep the legacy split. If a step contains `${`, the keyword is the text before the first `${`, exactly as before #547. Catalogue resolution is used only for fully literal steps, which keeps #547's fix (`Swipe 1000 300 up`, `Sleep 5`, slug forms) and #548's quoted-space params (`text="two words"`).
- Quotes are preserved unless they carry a space: a fully quoted value is unwrapped only when its body holds whitespace. `text="hello"`, `key="a=b"` and `"//button"` read as they did on 1.10.3.
- Module references match case/whitespace-insensitively on the whole step and return the canonical project name. Names containing `${` are skipped so they cannot shadow the variable split.
- `read_module_names` ignores malformed `Modules` shapes (scalar, mapping, list of non-mappings) instead of leaking characters.
- Third-party readers keep loading: `_load_modules` uses `read_module_names` when available, falls back to a full read otherwise, and only passes the names argument when the reader declares `module_names`.
- The step parser was split into small helpers to clear SonarQube `python:S3776` (cognitive complexity 16 > 15).

## Compatibility

- CSV parsing is byte-identical.
- For every step containing a complete `${...}` variable, the parse matches the pre-#547 parser except the intentional #548 quoted-space values.
- The only outputs differing from both trees are `Press Element "//button"` and `Sleep "Well"` (quoted no-space param on a now-resolved keyword); neither parsed on 1.10.3.
- Known limitation (unchanged from #547): a fully literal typo whose prefix is a keyword, e.g. `Swipe By Percent 50 50 20`, still binds to `Swipe`; dry-run arity validation could be a follow-up.
- `read_modules` still raises on malformed `Modules` (pre-existing).

## Verification

- `pytest tests/units` -> 1170 passed, 2 xfailed; `ruff check` clean.
- Parsed a 639-case YAML step corpus against the pre-#547 tree, `main`, and this branch: only the intended cases differ (typo names restored, whitespace-carrying quotes unwrapped, module references canonicalised).

Refs #547, #548.
